### PR TITLE
Fix ToC duplication and bottom Nav links

### DIFF
--- a/tyk-docs/static/js/docs-navigation.js
+++ b/tyk-docs/static/js/docs-navigation.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+var doNav = function() {
 	var currentPage = location.pathname,
 		currentPageGH = currentPage.replace(/\/$/, ""),
 		githubIndexLink = currentPage.replace(/\/docs/, "/"),
@@ -60,4 +60,7 @@ $(document).ready(function() {
 		$('#previousArticle').hide();
 		$('#nextArticle').hide();
 	}
-});
+};
+
+$(document).ready(doNav);
+$(document).on('turbolinks:load', doNav);

--- a/tyk-docs/static/js/docs-table-of-contents.js
+++ b/tyk-docs/static/js/docs-table-of-contents.js
@@ -7,6 +7,8 @@ var updatePageNav = function() {
     if (!ToC[0]) {
         return
     }
+
+    ToC.html('')
 	
 	$(".page-content h2").each(function(i) {
 		i++;	


### PR DESCRIPTION
It broke because of Turbolinks: now page not fully reloaded and all
actions made via AJAX. So containers should be cleaned up before use,
and instead of `load` event we should use `turbolinks:load`