### PR TITLE
OIDC: Setting use_openid to true in example

### DIFF
--- a/tyk-docs/content/security/your-apis/openid-connect.md
+++ b/tyk-docs/content/security/your-apis/openid-connect.md
@@ -50,7 +50,7 @@ To set up an API Definition to use OIDC, add the following block to the definiti
     "openid_options": {
         "providers": [
             {
-                issuer: "accounts.google.com",
+                "issuer": "accounts.google.com",
                 "client_ids": {
                     "MTIzNDU2Nzc4OQ==": "5654566b30c55e3904000003"
                 }

--- a/tyk-docs/content/security/your-apis/openid-connect.md
+++ b/tyk-docs/content/security/your-apis/openid-connect.md
@@ -46,7 +46,7 @@ In order to make OIDC Access tokens meaningful in analytics data, Tyk will also 
 To set up an API Definition to use OIDC, add the following block to the definition, and ensure no other access methods are enabled:
 
 ```{.copyWrapper}
-    "use_openid": false,
+    "use_openid": true,
     "openid_options": {
         "providers": [
             {


### PR DESCRIPTION
Seems weird to me that to enable OIDC the `use_openid` attribute would have to be set to `false`. Hoping for confirmation here from the Tyk team.