### PR TITLE
Link to javascript API from Virtual Endpoints

### DIFF
--- a/tyk-docs/content/compose-apis/virtual-endpoints.md
+++ b/tyk-docs/content/compose-apis/virtual-endpoints.md
@@ -7,9 +7,11 @@ menu:
 weight: 0 
 ---
 
+> **NOTE**: Virtual endpoints are not available in the Tyk Cloud Edition.
+
 Virtual endpoints are unique to Tyk. With a virtual endpoint, you can plug short JavaScript functions at the end of a Tyk route and have them run when the endpoint is called.
 
-> **Note**: Virtual endpoints are not available in the Tyk Cloud Edition.
+> **NOTE**: Virtual endpoints and the JSVM middleware share the same API. See [JavaScript API](/docs/customise-tyk/plugins/javascript-middleware/javascript-api/) for more details. 
 
 A sample use case for this might be aggregate functions that bring together related data from multiple services in your stack into a single object.
 
@@ -17,118 +19,117 @@ Alternatively, you could produce a dynamic response object that transforms or co
 
 > **Note**: The JavaScript engine in which these methods run in is a traditional ECMAScript 5 compatible environment and does not offer the more expressive power of something like Node.js. These methods are meant to provide a functional interpreter before complex interactions with your underlying service that cannot be handled by one of the other middleware components.
 
-#### Virtual endpoint functions
+#### Virtual Endpoint Functions
 
 To create one of these methods, create a file and place it in a subdirectory of the Tyk configuration environment (ideally under the `middleware` folder in your Tyk installation). Here is a sample method:
 
 ```{.copyWrapper}
-    function sampleVirtual (request, session, config) {
-        log("Virtual Test running")
+function sampleVirtual (request, session, config) {
+    log("Virtual Test running")
     
-        log("Request Body: ")
-        log(request.Body)
+    log("Request Body: ")
+    log(request.Body)
     
-        log("Session: ")
-        log(session)
+    log("Session: ")
+    log(session)
     
-        log("Config:")
-        log(config)
+    log("Config:")
+    log(config)
     
-        log("param-1:")
-        log(request.Params["param1"])
+    log("param-1:")
+    log(request.Params["param1"])
     
-        var responseObject = {
-            Body: "THIS IS A  VIRTUAL RESPONSE"
-            Headers: {
-                "test": "virtual",
-                "test-2": "virtual"
-            },
-            Code: 200
-        }
-    
-        return TykJsResponse(responseObject, session.meta_data)   
+    var responseObject = {
+        Body: "THIS IS A  VIRTUAL RESPONSE"
+        Headers: {
+            "test": "virtual",
+            "test-2": "virtual"
+        },
+        Code: 200
     }
-    log("Virtual Test initialised")
+    
+    return TykJsResponse(responseObject, session.meta_data)   
+}
+log("Virtual Test initialised")
 ```
 
-The JSVM that this method runs in is the same as the plugins and middleware API, so you have access to the same methods.
 
-### An aggregate JS function
+### An Aggregate JS Function
 
 The most common use case for this functionality, as we see it, is to provide some form of aggregate data to your users, here's a snippet that will do just that using the new batch processing API:
 
 ```{.copyWrapper}
-    function batchTest (request, session, config) {
-        // Set up a response object
-        var response = {
-            Body: ""
-            Headers: {
-                "test": "virtual-header-1",
-                "test-2": "virtual-header-2",
-                "content-type": "application/json"
-            },
-            Code: 200
-        }
-    
-        // Batch request
-        var batch = {
-            "requests": [
-                {
-                    "method": "GET",
-                    "headers": {
-                        "x-tyk-test": "1",
-                        "x-tyk-version": "1.2",
-                        "authorization": "1dbc83b9c431649d7698faa9797e2900f"
-                    },
-                    "body": "",
-                    "relative_url": "http://httpbin.org/get"
-                },
-                {
-                    "method": "GET",
-                    "headers": {},
-                    "body": "",
-                    "relative_url": "http://httpbin.org/user-agent"
-                }
-            ],
-            "suppress_parallel_execution": false
-        }
-    
-        log("[Virtual Test] Making Upstream Batch Request")
-        var newBody = TykBatchRequest(JSON.stringify(batch))
-    
-        // We know that the requests return JSON in their body, lets flatten it
-        var asJS = JSON.parse(newBody)
-        for (var i in asJS) {
-            asJS[i].body = JSON.parse(asJS[i].body)
-        }
-    
-        // We need to send a string object back to Tyk to embed in the response
-        response.Body = JSON.stringify(asJS)
-    
-        return TykJsResponse(response, session.meta_data)
-    
+function batchTest (request, session, config) {
+    // Set up a response object
+    var response = {
+        Body: ""
+        Headers: {
+            "test": "virtual-header-1",
+            "test-2": "virtual-header-2",
+            "content-type": "application/json"
+        },
+        Code: 200
     }
-    log("Batch Test initialised")
+    
+    // Batch request
+    var batch = {
+        "requests": [
+            {
+                "method": "GET",
+                "headers": {
+                    "x-tyk-test": "1",
+                    "x-tyk-version": "1.2",
+                    "authorization": "1dbc83b9c431649d7698faa9797e2900f"
+                },
+                "body": "",
+                "relative_url": "http://httpbin.org/get"
+            },
+            {
+                "method": "GET",
+                "headers": {},
+                "body": "",
+                "relative_url": "http://httpbin.org/user-agent"
+            }
+        ],
+        "suppress_parallel_execution": false
+    }
+    
+    log("[Virtual Test] Making Upstream Batch Request")
+    var newBody = TykBatchRequest(JSON.stringify(batch))
+    
+    // We know that the requests return JSON in their body, lets flatten it
+    var asJS = JSON.parse(newBody)
+    for (var i in asJS) {
+        asJS[i].body = JSON.parse(asJS[i].body)
+    }
+    
+    // We need to send a string object back to Tyk to embed in the response
+    response.Body = JSON.stringify(asJS)
+    
+    return TykJsResponse(response, session.meta_data)
+    
+}
+log("Batch Test initialised")
 ```
 
 The above code is pretty self explanatory, so we won't go into great detail - the batch object here is the same object that is fed into our batch request method `TykBatchRequest` that is exposed as part of certain API definitions.
 
-### Adding virtual endpoints to your API definition
+### Adding Virtual Endpoints to your API Definition
 
 Virtual paths follow the same layout and setup as other elements in the `extended_path` section of the API definition:
 
 ```{.copyWrapper}
-    ...
-    virtual: [
-        {
-          response_function_name: "batchTest",
-          function_source_type: "file",
-          function_source_uri: "middleware/testVirtual.js",
-          path: "get-batch",
-          method: "GET",
-          use_session: true
-        }
-    ]
+...
+virtual: [
+    {
+        response_function_name: "batchTest",
+        function_source_type: "file",
+        function_source_uri: "middleware/testVirtual.js",
+        path: "get-batch",
+        method: "GET",
+        use_session: true
+    }
+]
 ```
 
 The parameters are as follows:
@@ -149,9 +150,9 @@ You can use the `config_data` special field in your API definition to pass custo
 Add the following to the root of your API definition:
 
 ```{.copyWrapper}
-    "config_data": {
-        "foo": "bar"
-    },
+"config_data": {
+    "foo": "bar"
+},
 ```
 
 #### Sample use of `config_data`

--- a/tyk-docs/content/customise-tyk/plugins/javascript-middleware/javascript-api.md
+++ b/tyk-docs/content/customise-tyk/plugins/javascript-middleware/javascript-api.md
@@ -22,7 +22,7 @@ Below is the list of functions currently provided by Tyk.
 *   `TykBatchRequest` this function is similar to `TykMakeHttpRequest` but makes use of the Tyk Batch API. See [Batch Requests](/docs/tyk-rest-api/batch-requests/) for more details.
 *   `TykMakeHttpRequest(JSON.stringify(requestObject))`: This method is used to make an HTTP request, requests are encoded as JSON for deserialisation in the min binary and translation to a system HTTP call. The request object has the following structure:
 
-```{.copyWrapper}
+```{.javascript}
 newRequest = {
     "Method": "POST",
     "Body": JSON.stringify(event),


### PR DESCRIPTION
Add link and make clear that Virtual Endpoints and JavaScript Middleware use the same API.