### PR TITLE
Update Docker Quickstart page

### DIFF
--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-quickstart/index.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-quickstart/index.md
@@ -1,16 +1,18 @@
 ---
 date: 2017-03-22T16:54:02Z
-title: Docker Quickstart
+title: Docker Demo
 menu:
   main:
     parent: "With Docker"
 weight: 0
-url: "/get-started/with-tyk-on-premise/installation/docker/docker-quickstart"
+url: "/get-started/with-tyk-on-premise/installation/docker/docker-demo"
 ---
 
-## Get started with Docker & Tyk API Gateway
+## Get Started with Docker & Tyk API Gateway
 
-Getting started with Tyk and Docker is very quick, we have set up a Docker Compose configuration that will get you up and running with a few commands. 
+> **Warning!** Our Docker Demo setup involves some workarounds, and should be installed for demonstration purposes only, and not used on a production machine.
+
+Getting started with Tyk and Docker is very quick. We have set up a Docker Compose configuration that will get you up and running with a few commands. 
 This tutorial and scripts assume you have already installed the following: 
 
 *   Docker
@@ -18,9 +20,6 @@ This tutorial and scripts assume you have already installed the following:
 *   Python
     *   The json module for Python which should be install by default.
     *   Please remember to add Python to your PATH.
-
-
-> **Warning!** Our Docker Quickstart setup involves some workarounds, and should be installed for demonstration purposes, not on a production machine.
 
 What we will do in this setup guide is build the entire stack (the Gateway and the Dashboard) in one go.
 
@@ -42,17 +41,17 @@ In order for everything to work in a single Docker instance, assuming everything
 2.  Run the Tyk Gateway so it can accept traffic on port 8080, but expose port 80 and map that so 80->8080.
 3.  We override the `tyk.conf` file in the Tyk Gateway container with one that is specifically set up for this tutorial.
 4.  Run the Tyk Dashboard on port 3000 and expose port 3000 (so you can see the Dashboard).
-5.  Override the `tyk_analytics.conf` file with one that is specifically for a Docker setup).
+5.  Override the `tyk_analytics.conf` file with one that is specifically for a Docker setup.
 6.  Run a setup script that will:
     
     *   Create an organisation for you
     *   Create a new user so you can log into the Dashboard
-    *   Add three APIs to the Gateway that proxy to your new organisations' Portal, Portal assets and public API
+    *   Add three APIs to the Gateway that proxy to your new organisation Portal, Portal assets and public API
     *   Create a Portal home page with some dummy content
 
-#### Step 1: Set up hosts entries
+#### Step 1: Set up the Hosts Entries
 
-We are assuming that you are running this on a local Docker installation, the Tyk Portal requires a domain name to bind to in order to work properly, so let's make sure we set that up in `/etc/hosts`:
+We are assuming that you are running this on a local Docker installation. The Tyk Portal requires a domain name to bind to in order to work properly, so let's make sure we set that up in `/etc/hosts`:
 ```{.copyWrapper}
     127.0.0.1    www.tyk-portal-test.com
 ```
@@ -61,9 +60,9 @@ This entry will be used to access our Portal.
 
 > **Note**: OS X (v10.11 or earlier) or Kitematic users (v0.11.0 or earlier) should change this to their Docker Host IP Address. You can find this out by running `docker-machine ip default`.
 
-#### Step 2: Get the quick start compose files
+#### Step 2: Get the Docker Demo Compose Files
 
-Our quick start is a GitHub repository that contains everything you need to start Tyk, let's clone it locally:
+Our Docker Demo is a GitHub repository that contains everything you need to start Tyk, let's clone it locally:
 ```{.copyWrapper}
     git clone https://github.com/TykTechnologies/tyk_quickstart.git
     cd tyk_quickstart
@@ -71,7 +70,7 @@ Our quick start is a GitHub repository that contains everything you need to star
 
 **A quick note for those using an older Docker client (previous to Docker client v1.9.0):** There is another YML file for older clients in the repository, use this by specifying `-f docker-compose-pre-1.9.yml` directly after docker-compose (like `docker-compose -f docker-compose-pre-1.9.yml up -d`).
 
-#### Step 3: Add dashboard license
+#### Step 3: Add Your Tyk Dashboard License
 
 Go grab a Tyk Starter License (completely free), and edit the `tyk_analytics.conf` file in the the `tyk_quickstart` directory.
 
@@ -88,7 +87,7 @@ Add your license to the field marked `license`:
 
 Save the file and start your containers in the step below.
 
-#### Step 4: Bootstrap dashboard and portal
+#### Step 4: Bootstrap the Dashboard and Portal
 
 We've included a setup script that will create an organisation, a user and create the proxy configurations for your Portal:
 ```{.copyWrapper}
@@ -96,10 +95,10 @@ We've included a setup script that will create an organisation, a user and creat
     ./setup.sh
 ```
 
-#### Step 5: Log in
+#### Step 5: Log In
 
 The setup script will provide login details for your Dashboard - go ahead and log in.
 
-> **Note for Portal setup**: In order to create your portal definition and get the whole system bootstrapped , you simply need to visit the *Settings* section under *Portal Management* on the left hand side menu and you shall get a notification confirming that the configuration has been created.
+> **Note for Your Portal setup**: In order to create your portal definition and get the whole system bootstrapped , you need to visit the *Settings* section under *Portal Management* on the left hand side menu and you shall get a notification confirming that the configuration has been created.
 > 
 > If you wish to change your Portal domain, **do not use** the drop-down option in the navigation, instead, change the domain names in the three site entries in the API section. However, if you want clean URLs constructed for your APIs in the Dashboard, setting this value will show the URLs for your APIs as relative to the domain you've set.


### PR DESCRIPTION
Renamed this page to "Docker Demo" to make it clear that this is not for use in a production environment. I've moved the warning to the top of the page.