### PR TITLE
Adds a note on init systems, enables gpgcheck on rpm repos

### DIFF
--- a/tyk-docs/content/get-started/with-tyk-on-premise/index.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/index.md
@@ -31,4 +31,33 @@ A full Tyk On-Premises installation has the following requirements:
 *   Redis: The primary key store for the Tyk Gateway, also synchronises data across gateways in a horizontally scaling installation.
 *   MongoDB: The primary configuration store and analytics data store, required by the dashboard and portal, not required by the gateway.
 
+## <a name="init-systems"></a>Init Systems
+
+Tyk packages support [systemd][2], [Upstart][3] (both 0.6.x and 1.x) and SysVinit Linux init systems. During package installation only one is chosen depending on the operating system support, e.g.:
+
+*   CentOS 6, RHEL 6, Amazon Linux ship with Upstart 0.6.x
+*   Ubuntu 14.04, Debian Jessie with Upstart 1.x
+*   CentOS 7, RHEL 7, Ubuntu 16.04, Debian Stretch are running with systemd
+*   Certain older distros may only provide SysVinit but all of them typically provide compatibility with its scripts
+
+Note that any init scripts of your choosing can be used instead of automatically detected ones by copying them from the `install/inits` directory inside the package directory.
+
+This init system variance implies there are different ways to manage the services and collect service logs.
+
+For Upstart, service management can be performed through the `initctl` or a set of `start`, `stop`, `restart` and `status` commands. Upstart 1.x also works with the `service` command.
+
+For systemd, either `systemctl` or `service` commands may be utilised.
+
+The `service` command can usually be used with SysVinit scripts, as well as invoking them directly.
+
+Service logs availability is as follows:
+
+*   Upstart 0.6.x and SysVinit: log files are located in `/var/logs` for every respective service, e.g. `/var/logs/tyk-gateway.stderr` and `/var/logs/tyk-gateway.stdout`
+*   Upstart 1.x: by default everything is stored in `/var/logs/upstart` directory, e.g. `/var/logs/upstart/tyk-gateway.log`
+*   systemd utilises its own logging mechanism called journald, which is usable via the `journalctl` command, e.g. `journalctl -u tyk-gateway`
+
+Please consult with respective init system documentation for more details on how to use and configure it.
+
  [1]: /api-manager-licenses/
+ [2]: https://www.freedesktop.org/wiki/Software/systemd/
+ [3]: http://upstart.ubuntu.com/cookbook/

--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/redhat-rhel-centos/analytics-pump.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/redhat-rhel-centos/analytics-pump.md
@@ -38,20 +38,10 @@ Make sure to replace `el` and `7` in the config below with your Linux distributi
 name=tyk_tyk-pump
 baseurl=https://packagecloud.io/tyk/tyk-pump/el/7/$basearch
 repo_gpgcheck=1
-gpgcheck=0
+gpgcheck=1
 enabled=1
-gpgkey=https://packagecloud.io/tyk/tyk-pump/gpgkey
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
-
-[tyk_tyk-pump-source]
-name=tyk_tyk-pump-source
-baseurl=https://packagecloud.io/tyk/tyk-pump/el/7/SRPMS
-repo_gpgcheck=1
-gpgcheck=0
-enabled=1
-gpgkey=https://packagecloud.io/tyk/tyk-pump/gpgkey
+gpgkey=http://keyserver.tyk.io/tyk.io.rpm.signing.key
+       https://packagecloud.io/tyk/tyk-pump/gpgkey
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300
@@ -84,9 +74,9 @@ sudo service tyk-pump start
 
 That's it, the Pump should now be up and running.
 
-You can verify if Tyk Pump is running and working by tailing the log file:
+You can verify if Tyk Pump is running and working by accessing the logs:
 ```{.copyWrapper}
-sudo tail -f /var/log/tyk-pump.stderr /var/log/tyk-pump.stdout
+sudo journalctl -u tyk-pump
 ```
  [1]: https://packagecloud.io
  [2]: http://aws.amazon.com

--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/redhat-rhel-centos/dashboard.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/redhat-rhel-centos/dashboard.md
@@ -46,20 +46,10 @@ Create a file named `/etc/yum.repos.d/tyk_tyk-dashboard.repo` that contains the 
 name=tyk_tyk-dashboard
 baseurl=https://packagecloud.io/tyk/tyk-dashboard/el/7/$basearch
 repo_gpgcheck=1
-gpgcheck=0
+gpgcheck=1
 enabled=1
-gpgkey=https://packagecloud.io/tyk/tyk-dashboard/gpgkey
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
-
-[tyk_tyk-dashboard-source]
-name=tyk_tyk-dashboard-source
-baseurl=https://packagecloud.io/tyk/tyk-dashboard/el/7/SRPMS
-repo_gpgcheck=1
-gpgcheck=0
-enabled=1
-gpgkey=https://packagecloud.io/tyk/tyk-dashboard/gpgkey
+gpgkey=http://keyserver.tyk.io/tyk.io.rpm.signing.key
+       https://packagecloud.io/tyk/tyk-dashboard/gpgkey
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300

--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/redhat-rhel-centos/gateway.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/redhat-rhel-centos/gateway.md
@@ -38,20 +38,10 @@ Create a file named `/etc/yum.repos.d/tyk_tyk-gateway.repo` that contains the re
 name=tyk_tyk-gateway
 baseurl=https://packagecloud.io/tyk/tyk-gateway/el/7/$basearch
 repo_gpgcheck=1
-gpgcheck=0
+gpgcheck=1
 enabled=1
-gpgkey=https://packagecloud.io/tyk/tyk-gateway/gpgkey
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
-
-[tyk_tyk-gateway-source]
-name=tyk_tyk-gateway-source
-baseurl=https://packagecloud.io/tyk/tyk-gateway/el/7/SRPMS
-repo_gpgcheck=1
-gpgcheck=0
-enabled=1
-gpgkey=https://packagecloud.io/tyk/tyk-gateway/gpgkey
+gpgkey=http://keyserver.tyk.io/tyk.io.rpm.signing.key
+       https://packagecloud.io/tyk/tyk-gateway/gpgkey
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300


### PR DESCRIPTION
This adds a short guide on Linux init systems for the on-prem install. Describes their management differences and which OSes ship which one. Brings back package gpgcheck in the rpm repo files to make sure package signatures are verified by default, removes unused source repos from the repo files.