### PR TITLE
Fix sample request bodies

### DIFF
--- a/tyk-docs/content/tyk-dashboard-api/manage-key-requests.md
+++ b/tyk-docs/content/tyk-dashboard-api/manage-key-requests.md
@@ -41,7 +41,7 @@ weight: 8
                 },
                 "for_api": "",
                 "org_id": "53ac07777cbb8c2d53000002",
-                "version: "v2",
+                "version": "v2",
                 "for_plan": "554c789030c55e4ca0101002"
             },
             {
@@ -55,7 +55,7 @@ weight: 8
                 },
                 "for_api": "b605a6f03cc14f8b74665452c263bf19",
                 "org_id": "53ac07777cbb8c2d53000002",
-                "version: ""
+                "version": ""
             },
             ...],
         "Pages": 2
@@ -90,8 +90,8 @@ weight: 8
         "by_user": "554c733a30c55e4b16000002",
         "fields": {},
         "approved": true,
-        "date_created": "2015-05-08T04:49:20.992-04:00"
-        "version: "v2",
+        "date_created": "2015-05-08T04:49:20.992-04:00",
+        "version": "v2",
         "for_plan": "554c789030c55e4ca0101002"
     }
 ```
@@ -152,8 +152,8 @@ By default, all key requests created for new catalogue entries will be version 2
             "custom1": "sdf",
             "custom2": "sdf"
         },
-        "for_plan": "554c789030c55e4ca0101002"
-        "version: "v2"
+        "for_plan": "554c789030c55e4ca0101002",
+        "version": "v2"
     }
 ```
 

--- a/tyk-docs/content/tyk-dashboard-api/token-policies.md
+++ b/tyk-docs/content/tyk-dashboard-api/token-policies.md
@@ -37,7 +37,7 @@ weight: 4
               "allowed_urls": [
                 {
                   "methods": [
-                    "GET",
+                    "GET"
                   ],
                   "url": "/some_resources"
                 },
@@ -46,7 +46,7 @@ weight: 4
                     "POST"
                   ],
                   "url": "/some_resource/(.*)"
-                },
+                }
               ],
               "apiid": "35447b1269df4e846894b7e87312f6d7",
               "apiname": "My API",
@@ -241,7 +241,7 @@ Creating policy definitions is slightly different to the core API, API definitio
       "access_rights": {
         "35447b1469df4e846894b1e87372f6d7": {
           "api_id": "35447b1469df4e846894b1e87372f6d7",
-          "api_name": "My API",,
+          "api_name": "My API",
           "versions": ["Default"],
           "allowed_urls": []
         }

--- a/tyk-docs/content/tyk-rest-api/token-management.md
+++ b/tyk-docs/content/tyk-rest-api/token-management.md
@@ -57,8 +57,8 @@ Adding the `suppress_reset` parameter and setting it to `1`, will cause Tyk to *
         },
         "org_id": "53ac07777cbb8c2d53000002",
         "meta_data": {},
-        "oauth_client_id": ""
-        "oauth_keys"
+        "oauth_client_id": "",
+        "oauth_keys": {},
         "basic_auth_data": {
             "password": "",
             "hash_type": ""
@@ -130,8 +130,8 @@ Adding the `suppress_reset` parameter and setting it to `1`, will cause Tyk to *
         },
         "org_id": "53ac07777cbb8c2d53000002",
         "meta_data": {},
-        "oauth_client_id": ""
-        "oauth_keys"
+        "oauth_client_id": "",
+        "oauth_keys": {},
         "basic_auth_data": {
             "password": "",
             "hash_type": ""


### PR DESCRIPTION
I've noticed that some of the request bodies that we use in our guides contain JSON syntax errors, this PR contains a few fixes.