### PR TITLE
Update 3rd-party-identity-providers.md

### DIFF
--- a/tyk-docs/content/integrate/3rd-party-identity-providers/3rd-party-identity-providers.md
+++ b/tyk-docs/content/integrate/3rd-party-identity-providers/3rd-party-identity-providers.md
@@ -54,7 +54,7 @@ An identity handler will perform a predefined set of actions once a provider has
 
 These are actions are all handled by the `tap.providers.TykIdentityHandler` module which wraps the Tyk Gateway, Dashboard and Admin APIs to grant access to a stack.
 
-Handlers are not limited to Tyk, a handler can be added quite easily by implementing the `TAProvider` so long as it implements this pattern and is registered it can handle any of the above actions for its own target.
+Handlers are not limited to Tyk, a handler can be added quite easily by implementing the `tap.IdentityHandler` so long as it implements this pattern and is registered it can handle any of the above actions for its own target.
 
 ### Requirements and dependencies
 


### PR DESCRIPTION
If it's handler, it should be **tap.IdentityHandlerdentityHandler** and not the provider interface