### PR TITLE
Fixed broken link

### DIFF
--- a/tyk-docs/content/troubleshooting/tyk-gateway/profiling.md
+++ b/tyk-docs/content/troubleshooting/tyk-gateway/profiling.md
@@ -9,7 +9,7 @@ url: "/troubleshooting/tyk-gateway/profiling"
 ---
 
 In some cases, to identify tricky issues like concurrency or memory related, it may be required to get information about the Gateway process runtime, for example, memory or CPU usage details.
-The Tyk Gateway is built using Go, and inherits its powerful profiling tools, specifically Google's [`pprof`](https://github.com/google/pprof/blob/master/doc/pprof.md).
+The Tyk Gateway is built using Go, and inherits its powerful profiling tools, specifically Google's [`pprof`](https://github.com/google/pprof/).
 
 The Tyk Gateway can generate various profiles in the `pprof` supported format, which you can analyse by yourself, using the `go tool pprof` command, or you can send the profiles to our support team for analysis.
 


### PR DESCRIPTION
Link to the specific markdown file doesn't work anymore, so have linked to the project page directly. This will show the readme anyway, so should be enough to get started.