### PR TITLE
Hide nav container instead of the anchor tags

### DIFF
--- a/tyk-docs/static/js/docs-navigation.js
+++ b/tyk-docs/static/js/docs-navigation.js
@@ -62,8 +62,7 @@ var doNav = function() {
 
 
 	if((location.pathname.match(troubleshootingURL)) ||  (location.pathname.match(faqURL)) ) {
-		$('#previousArticle').hide();
-		$('#nextArticle').hide();
+		$('.docs-navigation').hide();
 	}
 };
 


### PR DESCRIPTION
We were hiding the actual links instead of the nav, resulting in an odd UI