### PR TITLE
Added tabs shortcuts

### DIFF
--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/on-ubuntu/gateway.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/on-ubuntu/gateway.md
@@ -24,6 +24,7 @@ We're installing on a `t2.micro` because this is a tutorial, you'll need more RA
 ### Step 1: Set up our APT Repositories
 
 First, add our GPG key which signs our binaries:
+
 ```{.copyWrapper}
 curl https://packagecloud.io/gpg.key | sudo apt-key add -
 ```
@@ -55,9 +56,18 @@ sudo apt-get update
 ### Step 2: Install the Tyk Gateway
 
 We're now ready to install the Tyk Gateway. To install it, run:
+{{% tabs %}}
+{{% tab "Ubuntu" %}}
 ```{.copyWrapper}
 sudo apt-get install -y tyk-gateway
 ```
+{{% /tab %}}
+{{% tab "Docker" %}}
+```{.copyWrapper}
+docker pull ...
+```
+{{% /tab %}}
+{{% /tabs %}}
 
 What we've done here is instructed apt-get to install the Tyk Gateway without prompting, wait for the downloads to complete.
 

--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/on-ubuntu/gateway.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/on-ubuntu/gateway.md
@@ -56,19 +56,10 @@ sudo apt-get update
 ### Step 2: Install the Tyk Gateway
 
 We're now ready to install the Tyk Gateway. To install it, run:
-{{% tabs %}}
-{{% tab "Ubuntu" %}}
+
 ```{.copyWrapper}
 sudo apt-get install -y tyk-gateway
 ```
-{{% /tab %}}
-{{% tab "Docker" %}}
-```{.copyWrapper}
-docker pull ...
-```
-{{% /tab %}}
-{{% /tabs %}}
-
 What we've done here is instructed apt-get to install the Tyk Gateway without prompting, wait for the downloads to complete.
 
 When Tyk is finished installing, it will have installed some init scripts, but it will not be running yet. The next step will be to setup the Gateway - thankfully this can be done with three very simple commands, however it does depend on whether you are configuring Tyk Gateway for use with the Dashboard or without (Community Edition).

--- a/tyk-docs/themes/tykio/layouts/shortcodes/tab.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/tab.html
@@ -1,0 +1,3 @@
+<div class="tab-pane" title="{{ .Get 0 }}">
+  {{ .Inner | safeHTML }}
+</div>

--- a/tyk-docs/themes/tykio/layouts/shortcodes/tabs.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/tabs.html
@@ -1,0 +1,62 @@
+<div class='code-tabs'>
+  <ul class="nav nav-tabs"></ul>
+  <div class="tab-content">{{ .Inner | safeHTML }}</div>
+</div>
+
+
+<style>
+.code-tabs .nav-tabs {
+    margin-bottom: 1em;
+    padding-left: 0;
+}
+
+.code-tabs .nav-tabs li {
+    display: inline;
+    margin-right: 0em;
+    opacity: 0.5;
+    padding: 1em 2em;
+}
+
+.code-tabs .nav-tabs li.active {
+    opacity: 1;
+    border-bottom: 2px solid #00D9BA;
+    font-weight: bold;
+}
+
+.code-tabs .tab-pane {
+    display: none;
+}
+
+.code-tabs .tab-pane.active {
+    display: block;
+}
+</style>
+
+<script>
+setTimeout(function(){
+$('.tab-content').find('.tab-pane').each(function(idx, item) {
+  var navTabs = $(this).closest('.code-tabs').find('.nav-tabs'),
+      title = $(this).attr('title');
+  navTabs.append('<li><a href="#">'+title+'</a></li');
+});
+
+$('.code-tabs ul.nav-tabs').each(function() {
+  $(this).find("li:first").addClass('active');
+})
+
+$('.code-tabs .tab-content').each(function() {
+  $(this).find("div:first").addClass('active');
+});
+
+$('.nav-tabs a').click(function(e){
+  e.preventDefault();
+  var tab = $(this).parent(),
+      tabIndex = tab.index(),
+      tabPanel = $(this).closest('.code-tabs'),
+      tabPane = tabPanel.find('.tab-pane').eq(tabIndex);
+  tabPanel.find('.active').removeClass('active');
+  tab.addClass('active');
+  tabPane.addClass('active');
+});
+}, 0)
+</script>


### PR DESCRIPTION
Example:

{{% tabs %}}
{{% tab "Ubuntu" %}}
```{.copyWrapper}
sudo apt-get install -y tyk-gateway
```
{{% /tab %}}
{{% tab "Docker" %}}
```{.copyWrapper}
docker pull ...
```
{{% /tab %}}
{{% /tabs %}}