### PR TITLE
Added `proxy_close_connections` to optimised settings

### DIFF
--- a/tyk-docs/content/deploy-tyk-premise-production/deploy-tyk-premise-production.mmark
+++ b/tyk-docs/content/deploy-tyk-premise-production/deploy-tyk-premise-production.mmark
@@ -152,6 +152,7 @@ Most of the changed below should be already in your `tyk.conf` by default:
 
 ```{.copyWrapper}
 "close_connections": false,
+"proxy_close_connections": false,
 "enforce_org_quotas": false,
 "enforce_org_data_detail_logging": false,
 "experimental_process_org_off_thread": true,


### PR DESCRIPTION
Discovered this setting based on something Leon wrote:

> Inside tyk.conf try setting `close_connections` value to `false`. 
> Option itself toggle keep-alive connection support, which basically means if new connection will be established for every request or connections is going to be re-used.
> 
> Before 2.6 this option was controlling both User -> Tyk and Tyk -> Upstream keep-alive behavior.
> 
> Starting from 2.6, this option was split into 2 parts: `close_connections` now controls only Us behavior, and new `proxy_close_connections` controls Tyk -> Upstream channel.