### PR TITLE
Fix typo in URL rewrite example

### DIFF
--- a/tyk-docs/content/transform-traffic/url-rewriting.md
+++ b/tyk-docs/content/transform-traffic/url-rewriting.md
@@ -25,7 +25,7 @@ To rewrite a URL with the API Definition, you must add a new object to the `exte
 "url_rewrites": [{
   "path": "match/me",
   "method": "GET",
-  "match_pattern": "(w+)/(w+)",
+  "match_pattern": "(\w+)/(\w+)",
   "rewrite_to": "my/service?value1=$1&value2=$2"
 }],
 ```


### PR DESCRIPTION
change (w+) to (\w+) so it matches any alphanumeric & underscore char