### PR TITLE
Update capping-analytics-data-storage.md

### DIFF
--- a/tyk-docs/content/analyse/capping-analytics-data-storage.md
+++ b/tyk-docs/content/analyse/capping-analytics-data-storage.md
@@ -50,10 +50,10 @@ Set the data expires to a time in seconds for it to expire. Tyk will calculate t
 
 ```{.copyWrapper}
 "enforce_org_data_age": true, 
-"enforce_org_quota": false
+"enforce_org_quotas": false
 ```
 
-> **Note**: This will only work for v2.2.0.23 or above, if you are running an earlier patch, you will need to `enforce_org_quota` set to `true`.
+> **Note**: This will only work for v2.2.0.23 or above, if you are running an earlier patch, you will need to `enforce_org_quotas` set to `true`.
 
 ## <a name="size-based-cap"></a> Size Based Cap
 


### PR DESCRIPTION
https://github.com/TykTechnologies/tyk/blob/8ecd114a20914729eb2abbdc1c101eee926d7067/cli/lint/schema.go#L260

should be `enforce_org_quotas` and not `enforce_org_quota` without an 's'. Have verified there's no such variable in the code base