### PR TITLE
Typo. should be with an "s" enforce_org_quotas

### DIFF
--- a/tyk-docs/content/analyse/capping-analytics-data-storage.md
+++ b/tyk-docs/content/analyse/capping-analytics-data-storage.md
@@ -50,10 +50,10 @@ Set the data expires to a time in seconds for it to expire. Tyk will calculate t
 
 ```{.copyWrapper}
 "enforce_org_data_age": true, 
-"enforce_org_quota": false
+"enforce_org_quotas": false
 ```
 
-> **Note**: This will only work for v2.2.0.23 or above, if you are running an earlier patch, you will need to `enforce_org_quota` set to `true`.
+> **Note**: This will only work for v2.2.0.23 or above, if you are running an earlier patch, you will need to `enforce_org_quotas` set to `true`.
 
 ## <a name="size-based-cap"></a> Size Based Cap
 


### PR DESCRIPTION
No `enforce_org_quota` in the code base just `enforce_org_quotas`