### PR TITLE
markdown wasn't translated correctly to a list

### DIFF
--- a/tyk-docs/content/log-data/log-data.md
+++ b/tyk-docs/content/log-data/log-data.md
@@ -17,10 +17,12 @@ Log data is usually of the Error level and higher, though you can enable Debug m
 Tyk will try to output structured logs, and so will include context data around request errors where possible.
 
 From v2.4 you can set a logging level via the `tyk.conf` file. The following levels can be set:
+
 * debug
 * info
 * warn
 * error
+
 If unset or left empty, it will default to `info`.
 
 ## <a name="aggregated-logs-with-sentry"></a> Aggregated logs with Sentry


### PR DESCRIPTION
Looks like this:
 The following levels can be set: * debug * info * warn * error If unset or left empty, it will default to info.

Added extra \n