### PR TITLE
Add undocumented TYK_DB_SSOCUSTOMPORTALLOGINURL environment variable

### DIFF
--- a/tyk-docs/content/configure/dashboard-env-variables.md
+++ b/tyk-docs/content/configure/dashboard-env-variables.md
@@ -58,6 +58,7 @@ weight: 13
 | sentry_js_code                           | TYK_DB_SENTRYJSCODE                          |
 | show_org_id                              | TYK_DB_SHOWORGID                             |
 | sso_custom_login_url                     | TYK_DB_SSOCUSTOMLOGINURL                     |
+| sso_custom_portal_login_url              | TYK_DB_SSOCUSTOMPORTALLOGINURL               |
 | storage.optimisations_max_active         | TYK_DB_STORAGE_MAXACTIVE                     |
 | storage.optimisations_max_idle           | TYK_DB_STORAGE_MAXIDLE                       |
 | tagging_options.tag_all_apis_by_org      | TYK_DB_TAGGINGOPTIONS_TAGALLAPISBYORG        |


### PR DESCRIPTION
The dashboard environment variable `TYK_DB_SSOCUSTOMPORTALLOGINURL` is undocumented.  However, when I attempted to use it, it worked.  This PR adds the variable to the documentation.