### PR TITLE
Correct redis cluster typo and add "gotcha" values

### DIFF
--- a/tyk-docs/content/tyk-multi-data-centre/setup-master-data-centre.mmark
+++ b/tyk-docs/content/tyk-multi-data-centre/setup-master-data-centre.mmark
@@ -87,7 +87,11 @@ Once installed, modify your `/opt/tyk-sink/tyk_sink.conf` file as follows:
     "type": "redis",
     "host": "localhost",
     "port": 6379,
-    "enabled_cluster": false
+    "username": "",
+    "password": "",
+    "enable_cluster": false,
+    "redis_use_ssl": false,
+    "redis_ssl_insecure_skip_verify": false
   },
   "security": {
     "private_certificate_encoding_secret": "<gateway-secret>"
@@ -99,6 +103,8 @@ Once installed, modify your `/opt/tyk-sink/tyk_sink.conf` file as follows:
   ],
   "analytics": {
     "mongo_url": "mongodb://localhost/tyk_analytics"
+    "mongo_use_ssl": false,
+    "mongo_ssl_insecure_skip_verify": false
   },
   "license": "MDCB_LICENSE_KEY"
 }


### PR DESCRIPTION
Added redis_ prefixed values to example config as they are possible gotchas and while were here basically add all the parts necessary for ssl comms with DBs