### PR TITLE
Add note for 2.8 "bundle" gateway command

### DIFF
--- a/tyk-docs/content/customise-tyk/plugins/rich-plugins/grpc/custom-auth-dot-net.mmark
+++ b/tyk-docs/content/customise-tyk/plugins/rich-plugins/grpc/custom-auth-dot-net.mmark
@@ -19,6 +19,7 @@ For additional information about gRPC, check the official documentation [here](h
 
 * Tyk Gateway: This can be installed using standard package management tools like Yum or APT, or from source code. See [here][1] for more installation options.
 * The Tyk CLI utility, which is bundled with our RPM and DEB packages, and can be installed separately from [https://github.com/TykTechnologies/tyk-cli][2]
+* In Tyk 2.8 the Tyk CLI is part of the gateway binary, you can find more information by running "tyk help bundle".
 * .NET Core for your OS: https://www.microsoft.com/net/core
 * gRPC tools: https://grpc.io/docs/quickstart/csharp.html#generate-grpc-code
 
@@ -283,6 +284,11 @@ To bundle our plugin run the following command in the `tyk-plugin` directory. Ch
 
 ```{.copyWrapper}
 /opt/tyk-gateway/utils/tyk-cli bundle build -y
+```
+
+For Tyk 2.8 use:
+```{.copyWrapper}
+/opt/tyk-gateway/bin/tyk bundle build -y
 ```
 
 

--- a/tyk-docs/content/customise-tyk/plugins/rich-plugins/grpc/custom-auth-nodejs.mmark
+++ b/tyk-docs/content/customise-tyk/plugins/rich-plugins/grpc/custom-auth-nodejs.mmark
@@ -19,6 +19,7 @@ For additional information about gRPC, check the official documentation [here](h
 
 * Tyk Gateway: This can be installed using standard package management tools like Yum or APT, or from source code. See [here][1] for more installation options.
 * The Tyk CLI utility, which is bundled with our RPM and DEB packages, and can be installed separately from [https://github.com/TykTechnologies/tyk-cli][2]
+* In Tyk 2.8 the Tyk CLI is part of the gateway binary, you can find more information by running "tyk help bundle".
 * * NodeJS v6.x.x https://nodejs.org/en/download/ 
 
 
@@ -185,6 +186,10 @@ To bundle our plugin run the following command in the `tyk-plugin` directory. Ch
 /opt/tyk-gateway/utils/tyk-cli bundle build -y
 ```
 
+For Tyk 2.8 use:
+```{.copyWrapper}
+/opt/tyk-gateway/bin/tyk bundle build -y
+```
 
 A plugin bundle is a packaged version of the plugin. It may also contain a cryptographic signature of its contents. The `-y` flag tells the Tyk CLI tool to skip the signing process in order to simplify the flow of this tutorial. 
 

--- a/tyk-docs/content/customise-tyk/plugins/rich-plugins/grpc/request-transformation-java.mmark
+++ b/tyk-docs/content/customise-tyk/plugins/rich-plugins/grpc/request-transformation-java.mmark
@@ -20,6 +20,7 @@ For additional information about gRPC, check the official documentation [here](h
 
 * Tyk Gateway: This can be installed using standard package management tools like Yum or APT, or from source code. See [here][1] for more installation options.
 * The Tyk CLI utility, which is bundled with our RPM and DEB packages, and can be installed separately from [https://github.com/TykTechnologies/tyk-cli][2].
+* In Tyk 2.8 the Tyk CLI is part of the gateway binary, you can find more information by running "tyk help bundle".
 * Gradle Build Tool: https://gradle.org/install/.
 * gRPC tools: https://grpc.io/docs/quickstart/csharp.html#generate-grpc-code
 * Java JDK 7 or higher.
@@ -254,6 +255,10 @@ To bundle our plugin run the following command in the `tyk-plugin` directory. Ch
 /opt/tyk-gateway/utils/tyk-cli bundle build -y
 ```
 
+For Tyk 2.8 use:
+```{.copyWrapper}
+/opt/tyk-gateway/bin/tyk bundle build -y
+```
 
 A plugin bundle is a packaged version of the plugin. It may also contain a cryptographic signature of its contents. The `-y` flag tells the Tyk CLI tool to skip the signing process in order to simplify the flow of this tutorial. 
 

--- a/tyk-docs/content/customise-tyk/plugins/rich-plugins/grpc/write-grpc-plugin.md
+++ b/tyk-docs/content/customise-tyk/plugins/rich-plugins/grpc/write-grpc-plugin.md
@@ -44,6 +44,11 @@ After saving this file as `manifest.json`, build it using [tyk-cli][1]:
 tyk-cli bundle build -output mybundle.zip -key mykey.pem
 ```
 
+For Tyk 2.8 use (the bundle functionaliy is integrated as part of the gateway binary, located in "/opt/tyk-gateway/bin/tyk` by default):
+```{.copyWrapper}
+tyk bundle build -output mybundle.zip -key mykey.pem
+```
+
 ## <a name="server"></a> The gRPC server
 
 A gRPC server must be implemented in the language of your choice, we have prepared different tutorials for some of them:

--- a/tyk-docs/content/customise-tyk/plugins/rich-plugins/plugin-bundles.md
+++ b/tyk-docs/content/customise-tyk/plugins/rich-plugins/plugin-bundles.md
@@ -63,6 +63,12 @@ After installing any of the Tyk Gateway packages, the program will be located in
 
 You may use the full path to call this program, feel free to create a symbolic link or attach its directory to your `PATH`.
 
+If you're using Tyk 2.8, you will find the Tyk CLI functionality integrated as part of the Tyk binary, run this command to get more details:
+
+```
+/opt/tyk-gateway/bin/tyk help bundle
+```
+
 > **Note for Go developers**: If you happen to have a working Go environment setup, you can also fetch the bundler tool using `go get`:
 > 
 > `$ go get github.com/TykTechnologies/tyk-cli`
@@ -73,6 +79,12 @@ This step will assume that you're located in your plugin directory and a valid m
 
 ```{.copyWrapper}
 $ tyk-cli bundle build
+```
+
+For Tyk 2.8 (where `tyk` is the gateway binary located in `/opt/tyk-gateway/bin/tyk`):
+
+```{.copyWrapper}
+$ tyk bundle build
 ```
 
 The resulting file will contain all your specified files and a modified `manifest.json` with the right checksum and signature (if required), in ZIP format.

--- a/tyk-docs/content/customise-tyk/plugins/rich-plugins/python/custom-auth-python-tutorial.md
+++ b/tyk-docs/content/customise-tyk/plugins/rich-plugins/python/custom-auth-python-tutorial.md
@@ -20,6 +20,7 @@ The code used in this tutorial is also available in [this GitHub repository][1].
 ### Dependencies
 
 * The Tyk CLI utility, which is bundled with our RPM and DEB packages, and can be installed separately from [https://github.com/TykTechnologies/tyk-cli][3]
+* In Tyk 2.8 the Tyk CLI is part of the gateway binary, you can find more information by running "tyk help bundle".
 * Python 3.4
 
 ## <a name="create-plugin"></a>Create the Plugin
@@ -83,6 +84,10 @@ You can modify the `manifest.json` to add as many files as you want. Files that 
 To bundle our plugin we run the following command in the working directory. Check your `tyk-cli` install path first:
 
 `/opt/tyk-gateway/utils/tyk-cli bundle build -y`
+
+For Tyk 2.8 use:
+
+`/opt/tyk-gateway/bin/tyk bundle build -y`
 
 A plugin bundle is a packaged version of the plugin, it may also contain a cryptographic signature of its contents. The `-y` flag tells the Tyk CLI tool to skip the signing process in order to simplify the flow of this tutorial. For more information on the Tyk CLI tool, see [here][4].
 


### PR DESCRIPTION
In the upcoming release, the `tyk-cli` functionality is integrated into the gateway binary, I've added some compatibility notes