### PR TITLE
lint: Fixing page names & nav order

### DIFF
--- a/tyk-docs/content/concepts/api-catalogue.md
+++ b/tyk-docs/content/concepts/api-catalogue.md
@@ -1,13 +1,11 @@
 ---
 date: 2017-03-23T13:02:38Z
-title: API Catalogue
+title: Portal API Catalogue
 menu:
   main:
     parent: "Concepts"
-weight: 7 
+weight: 90
 ---
-
-## Concept: API Catalogue
 
 The API Catalogue is part of the API Developer Portal of the Dashboard. It is the central place for you to manage which APIs your registered developers have access to.
 

--- a/tyk-docs/content/concepts/context-variables.md
+++ b/tyk-docs/content/concepts/context-variables.md
@@ -1,13 +1,11 @@
 ---
 date: 2017-03-23T13:01:30Z
-title: Context Variables
+title: Request Context Variables
 menu:
   main:
     parent: "Concepts"
-weight: 6 
+weight: 65 
 ---
-
-## Concept: Context Variables
 
 Context variables are extracted from the request at the start of the middleware chain, and must be explicitly enabled in order for them to be made available to your transforms. These values can be very useful for later transformation of request data, for example, in converting a Form-based POST into a JSON-based PUT or to capture an IP address as a header.
 

--- a/tyk-docs/content/concepts/dashboard-api.md
+++ b/tyk-docs/content/concepts/dashboard-api.md
@@ -4,10 +4,8 @@ title: Dashboard API
 menu:
   main:
     parent: "Concepts"
-weight: 9 
+weight: 100 
 ---
-
-## Dashboard API Overview
 
 The Tyk Dashboard API is a superset of the Tyk Gateway API, enabling (almost) all of the core features and adding many more. The Dashboard API is also more granular and supports Access Control on a multi-tenant, and user basis.
 

--- a/tyk-docs/content/concepts/gateway-api.md
+++ b/tyk-docs/content/concepts/gateway-api.md
@@ -5,10 +5,8 @@ menu:
   main:
     parent: "Concepts"
     identifier: concepts-gateway-api
-weight: 8 
+weight: 95 
 ---
-
-## Concept: Gateway API
 
 The Tyk Gateway REST API is the primary means for integrating your application with the Tyk API Gateway system. This API is very small, and has no granular permissions system. It is intended to be used *purely* for internal automation and integration.
 

--- a/tyk-docs/content/concepts/middleware-execution-order.md
+++ b/tyk-docs/content/concepts/middleware-execution-order.md
@@ -1,9 +1,9 @@
 ---
-title: Middleware Execution Order
+title: Request Middleware Chain
 menu:
   main:
     parent: "Concepts"
-weight: 10 
+weight: 70
 ---
 
 To aid the debugging of middleware transformations, below is a diagram that illustrates the flow of a request.

--- a/tyk-docs/content/concepts/session-meta-data.md
+++ b/tyk-docs/content/concepts/session-meta-data.md
@@ -4,10 +4,8 @@ title: Session Meta Data
 menu:
   main:
     parent: "Concepts"
-weight: 3 
+weight: 85 
 ---
-
-## Concept: Meta Data
 
 As described in [What is a Session Object?][1], all Tyk tokens can contain a meta data field. This field is a string key/value map that can store any kind of information about the underlying identity of a session.
 

--- a/tyk-docs/content/concepts/versioning.md
+++ b/tyk-docs/content/concepts/versioning.md
@@ -1,10 +1,11 @@
 ---
-title: Versioning
+title: API Versioning
 menu:
   main:
     parent: "Concepts"
-weight: 5
+weight: 60
 ---
+
 ## <a name="why-version"></a>Why Version your APIs?
 Tyk enables full version life-cycle management for your APIs. It includes the ability to define different configurations for different versions of an API and have Tyk manage route and middleware configurations on the same listen path of any given API. By default, Tyk expects to find version information in a header key, a query parameter or the first part of a URL.
 

--- a/tyk-docs/content/concepts/what-is-a-security-policy.md
+++ b/tyk-docs/content/concepts/what-is-a-security-policy.md
@@ -1,10 +1,10 @@
 ---
 date: 2017-03-23T12:59:51Z
-title: What is a Security Policy?
+title: Security Policy
 menu:
   main:
     parent: "Concepts"
-weight: 4 
+weight: 75
 ---
 
 A Tyk security policy incorporates several security options that can be applied to an API key. It acts as a template that can override individual sections of an API key (or identity) in Tyk. For example, if you had 10,000 API keys issued, how would you ensure that all 10,000 users received an upgraded quota or access a new API that you have published?

--- a/tyk-docs/content/concepts/what-is-a-session-object.md
+++ b/tyk-docs/content/concepts/what-is-a-session-object.md
@@ -1,13 +1,11 @@
 ---
 date: 2017-03-23T12:56:30Z
-title: What is a Session Object?
+title: Session Object
 menu:
   main:
     parent: "Concepts"
-weight: 2 
+weight: 80 
 ---
-
-## Concept: API Session Object
 
 In Tyk, all identities are mapped to a session object. Identities can be in the form of Bearer Tokens, HMAC Keys, JSON Web Tokens, OpenID Connect identities and Basic Auth users.
 

--- a/tyk-docs/content/concepts/what-is-an-api-definition.md
+++ b/tyk-docs/content/concepts/what-is-an-api-definition.md
@@ -1,13 +1,11 @@
 ---
 date: 2017-03-23T12:53:47Z
-Title: What is an API Definition?
+Title: API Definition Object
 menu:
   main:
     parent: "Concepts"
-weight: 1 
+weight: 55
 ---
-
-## Concept: API Definition
 
 Tyk handles APIs through files / objects called API Definitions – these are JSON objects – and either live in the `/var/tyk-gateway/apps` directory or in a MongoDB collection as part of a Pro Edition installation.
 


### PR DESCRIPTION
- Fix page names - e.g. remove "What is" from nav titles
- Removed duplicate page headings from content body
- Logical order for concepts pages

![Screenshot 2019-08-09 at 12 51 31](https://user-images.githubusercontent.com/1465130/62777153-8d53e800-baa4-11e9-951e-e6d86511bc01.png)
