### PR TITLE
Refresh token expires within 14 days not 1 hour

### DIFF
--- a/tyk-docs/content/configure/tyk-gateway-configuration-options.md
+++ b/tyk-docs/content/configure/tyk-gateway-configuration-options.md
@@ -451,7 +451,7 @@ Change the expiry time of OAuth token (in seconds).
 
 ### <a name="oauth_refresh_token_expire"></a> oauth_refresh_token_expire
 
-Change the expiry time of refresh token, by default 1 hour (in seconds).
+Change the expiry time of refresh token, by default 14 days (in seconds).
 
 ### <a name="oauth_token_expired_retain_period"></a>oauth_token_expired_retain_period
 


### PR DESCRIPTION
says by default 1 hour  but the code says 1209600https://github.com/TykTechnologies/tyk/blob/ad0bf0c3ff7ebaf331d6c28346be92ee9a411699/gateway/oauth_manager.go#L831