### PR TITLE
Fix broken link to Tyk On-Prem page

### DIFF
--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-pro-demo/docker-pro-demo.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-pro-demo/docker-pro-demo.md
@@ -17,12 +17,12 @@ weight: 1
 
 ## Prerequisites
 
-* Our Pro Demo Docker [GitHub repo](https://github.com/TykTechnologies/tyk-pro-docker-demo)
+* Our [Tyk Pro Docker demo on GitHub](https://github.com/TykTechnologies/tyk-pro-docker-demo)
 * A free Tyk On-Premises [Developer licence](https://tyk.io/get-started/)
 
-### Step One - Clone the Repo
+### Step One - Clone the GitHub repo
 
-Clone the repo above to a location on your machine.
+Clone the Docker demo repo from GitHub to a location on your machine.
 
 ### Step Two - Edit your hosts file
 
@@ -33,7 +33,7 @@ You need to add the following to your hosts file:
 127.0.0.1 www.tyk-test.com
 ```
 
-### Step Three - Add your Developer Licence
+### Step Three - Add your developer licence
 
 You should have received an e-mail with your free developer licence after going through
 [the signup process](https://signup.tyk.io/product/tyk-on-premises-free-edition/).
@@ -44,7 +44,7 @@ Copy the license key to the following location in your `/confs/tyk_analytics.con
 "license_key": ""
 ```
 
-### Step Four - Run the Docker Compose File
+### Step Four - Run the Docker Compose file
 
 Run the following command from your installation folder:
 
@@ -64,9 +64,9 @@ Go to:
 
 You should get to the Tyk Dashboard Setup screen:
 
-![Tyk Dashboard Bootstrap Screen][1]
+![Tyk Dashboard Bootstrap screen][1]
 
-### Step Six - Create your Organisation and Default User
+### Step Six - Create your organisation and default user
 
 You need to enter the following:
 
@@ -82,7 +82,7 @@ letters.
 
 Click **Bootstrap** to save the details.
 
-### Step Seven - Login to the Dashboard
+### Step Seven - log in to the Tyk Dashboard
 
 You can now log in to the Tyk Dashboard from `127.0.0.1:3000`, using the username and password created in the Dashboard
 Setup screen.

--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-pro-demo/docker-pro-demo.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-pro-demo/docker-pro-demo.md
@@ -17,7 +17,7 @@ This demo is great for proof of concept and demo purposes, but if you want to te
 ## Prerequisites
 
 * Our Pro Demo Docker [GitHub repo](https://github.com/TykTechnologies/tyk-pro-docker-demo)
-* A free Tyk On-Premises [Developer licence](https://tyk.io/product/tyk-on-premises-free-edition/)
+* A free Tyk On-Premises [Developer licence](https://tyk.io/get-started/)
 
 ### Step One - Clone the Repo
 

--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-pro-demo/docker-pro-demo.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-pro-demo/docker-pro-demo.md
@@ -9,9 +9,11 @@ weight: 1
 
 ## Get Started with Docker & Tyk API Gateway
 
-> **Warning!** This demo is **NOT** designed for production use or performance testing. The Tyk Pro Docker Demo is our full, [On-Premises](https://tyk.io/api-gateway/on-premise/) solution, which includes our Gateway, Dashboard and analytics processing pipeline.
-This demo will run Tyk On-Premises on your machine, which contains 5 containers: Tyk Gateway, Tyk Dashboard, Tyk Pump, Redis and MongoDB.
-This demo is great for proof of concept and demo purposes, but if you want to test performance, you need to move each component to a separate machine.
+> **Warning!** This demo is **NOT** designed for production use or performance testing. The Tyk Pro Docker demo is our
+> full [On-Premises](https://tyk.io/api-gateway/on-premise/) solution, which includes our Gateway, Dashboard, and
+> analytics processing pipeline. This demo will run Tyk On-Premises on your machine, which contains 5 containers: Tyk
+> Gateway, Tyk Dashboard, Tyk Pump, Redis and MongoDB. This demo is great for proof of concept and demo purposes, but
+> if you want to test performance, you will need to move each component to a separate machine.
 
 ## Prerequisites
 
@@ -33,7 +35,10 @@ You need to add the following to your hosts file:
 
 ### Step Three - Add your Developer Licence
 
-You should have received your free developer licence via email. Copy the licence key in the following location from your `/confs/tyk_analytics.conf` file:
+You should have received an e-mail with your free developer licence after going through
+[the signup process](https://signup.tyk.io/product/tyk-on-premises-free-edition/).
+
+Copy the license key to the following location in your `/confs/tyk_analytics.conf` file:
 
 ``` conf
 "license_key": ""
@@ -72,12 +77,14 @@ You need to enter the following:
 * A **Password** for your User
 * **Re-enter** your user **Password**
 
-> **NOTE**: For a password, we recommend a combination of alphanumeric characters, with both upper and lower case letters.
+> **NOTE**: For a password, we recommend a combination of alphanumeric characters, with both upper and lower case
+letters.
 
 Click **Bootstrap** to save the details.
 
 ### Step Seven - Login to the Dashboard
 
-You can now log in to the Tyk Dashboard from `127.0.0.1:3000`, using the username and password created in the Dashboard Setup screen.
+You can now log in to the Tyk Dashboard from `127.0.0.1:3000`, using the username and password created in the Dashboard
+Setup screen.
 
 [1]: /docs/img/dashboard/system-management/bootstrap_screen.png

--- a/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-pro-demo/docker-pro-demo.md
+++ b/tyk-docs/content/get-started/with-tyk-on-premise/installation/docker/docker-pro-demo/docker-pro-demo.md
@@ -5,7 +5,6 @@ menu:
   main:
     parent: "With Docker"
 weight: 1
-
 ---
 
 ## Get Started with Docker & Tyk API Gateway
@@ -36,7 +35,7 @@ You need to add the following to your hosts file:
 
 You should have received your free developer licence via email. Copy the licence key in the following location from your `/confs/tyk_analytics.conf` file:
 
-```
+``` conf
 "license_key": ""
 ```
 
@@ -80,9 +79,5 @@ Click **Bootstrap** to save the details.
 ### Step Seven - Login to the Dashboard
 
 You can now log in to the Tyk Dashboard from `127.0.0.1:3000`, using the username and password created in the Dashboard Setup screen.
-
-
-
-
 
 [1]: /docs/img/dashboard/system-management/bootstrap_screen.png


### PR DESCRIPTION
Found that https://tyk.io/product/tyk-on-premises-free-edition/ goes to a 404.
I hope [the link I replaced it with](https://tyk.io/get-started/) is OK?

Did a quick pass over the rest of the page as well.