### PR TITLE
Fix image position in step 3

### DIFF
--- a/tyk-docs/content/control-limit-traffic/rate-limiting.md
+++ b/tyk-docs/content/control-limit-traffic/rate-limiting.md
@@ -68,7 +68,7 @@ Not yet, though IP-based rate limiting is possible using custom pre-processor mi
 
 3.  From the **Rate Limit** section, select the **rate** (number of requests) and the **per** period. If the period is not available in the drop down, you can set it to a custom value using the Dashboard REST API.
     
-  ![Tyk API Gateway Rate Limits][1]
+    ![Tyk API Gateway Rate Limits][1]
 
 4.  Save the token, it will be created instantly.
 

--- a/tyk-docs/content/control-limit-traffic/rate-limiting.md
+++ b/tyk-docs/content/control-limit-traffic/rate-limiting.md
@@ -68,7 +68,7 @@ Not yet, though IP-based rate limiting is possible using custom pre-processor mi
 
 3.  From the **Rate Limit** section, select the **rate** (number of requests) and the **per** period. If the period is not available in the drop down, you can set it to a custom value using the Dashboard REST API.
     
-![Tyk API Gateway Rate Limits][1]
+  ![Tyk API Gateway Rate Limits][1]
 
 4.  Save the token, it will be created instantly.
 


### PR DESCRIPTION
Step 4 in section 'Setting a rate limit from the Dashboard' shows as step 1 on website. I moved the image under step 3 to the right to see if this will fix the issue.

![tykdocs_PR975](https://user-images.githubusercontent.com/10401080/70515714-b0170b80-1b2d-11ea-8d71-340daec1a6fc.jpg)
