### PR TITLE
Adds: Prerequisites page for Tutorial

### DIFF
--- a/tyk-docs/content/try-out-tyk/tutorials/create-api.mmark
+++ b/tyk-docs/content/try-out-tyk/tutorials/create-api.mmark
@@ -5,7 +5,7 @@ markup: mmark
 menu:
   main:
     parent: "Tutorials"
-weight: 1
+weight: 2
 ---
 <span data-filetype="mmark"></span>
 

--- a/tyk-docs/content/try-out-tyk/tutorials/important-prerequisites.mmark
+++ b/tyk-docs/content/try-out-tyk/tutorials/important-prerequisites.mmark
@@ -1,0 +1,72 @@
+---
+date: 2020-02-18T15:08:55Z
+Title: Important Prerequisites
+menu:
+  main:
+    parent: "Tutorials"
+weight: 1
+---
+These are some common settings that you need before proceeding with other parts of this tutorial.
+
+{{% tabs %}}
+{{% tab "Community Edition" %}}
+
+## Tyk Config
+
+### Path to Web API configurations directory
+
+You may need to explicitly define path to the directory where you will add
+the APIs for Tyk to serve those, in your Tyk config.
+
+```
+...
+"app_path": "/opt/tyk-gateway/apps",
+...
+```
+
+### Path to Policies file
+
+You need to explicitly set the path to Policies JSON file in your Tyk config.
+
+```
+...
+  "policies": {
+    "policy_source": "file",
+    "policy_record_name": "policies/policies.json"
+  },
+...
+```
+
+### Remove Tyk Dashboard related config options
+
+Some config options for Community Edition are not compatible with the Dashboard
+version, which requires license. So, **remove** any section in Tyk config which
+starts with
+
+```
+...
+"db_app_conf_options" {
+  ...
+},
+...
+```
+
+## Files vs API
+
+For Community Edition, note that you will need to know when to use the Tyk API
+endpoint and when mere placing files will do. So far
+
+- Files: Policies, Web APIs
+- Tyk API: API key generation
+
+## Hot reload is critical
+
+Each time you add an API endpoint to Tyk, you need to request to a Tyk reload
+API endpoint.
+
+```
+curl -H "x-tyk-authorization: {your-secret}" -s https://{your-tyk-host}:{port}/tyk/reload/group | python -mjson.tool
+```
+
+{{% /tab %}}
+{{% /tabs %}}

--- a/tyk-docs/content/try-out-tyk/tutorials/important-prerequisites.mmark
+++ b/tyk-docs/content/try-out-tyk/tutorials/important-prerequisites.mmark
@@ -13,10 +13,10 @@ These are some common settings that you need before proceeding with other parts 
 
 ## Tyk Config
 
-### Path to Web API configurations directory
+### Path to Tyk API Definitions configurations directory
 
-You may need to explicitly define path to the directory where you will add
-the APIs for Tyk to serve those, in your Tyk config.
+You may need to explicitly define the path in your Tyk config to the directory where you will add
+the API definitions for Tyk to serve.
 
 ```
 ...
@@ -26,7 +26,7 @@ the APIs for Tyk to serve those, in your Tyk config.
 
 ### Path to Policies file
 
-You need to explicitly set the path to Policies JSON file in your Tyk config.
+You need to explicitly set the path to your Policies JSON file in your Tyk config.
 
 ```
 ...
@@ -39,9 +39,9 @@ You need to explicitly set the path to Policies JSON file in your Tyk config.
 
 ### Remove Tyk Dashboard related config options
 
-Some config options for Community Edition are not compatible with the Dashboard
-version, which requires license. So, **remove** any section in Tyk config which
-starts with
+Some config options for the Community Edition are not compatible with the Dashboard
+version, which requires a licence. So, **remove** any section in your Tyk config which
+starts with:
 
 ```
 ...
@@ -54,14 +54,14 @@ starts with
 ## Files vs API
 
 For Community Edition, note that you will need to know when to use the Tyk API
-endpoint and when mere placing files will do. So far
+endpoint and when mere placing files will do. So far:
 
-- Files: Policies, Web APIs
+- Files: Policies, API Definitions
 - Tyk API: API key generation
 
 ## Hot reload is critical
 
-Each time you add an API endpoint to Tyk, you need to request to a Tyk reload
+Each time you add an API definition to Tyk, you need to request a hot reload call to the Tyk reload
 API endpoint.
 
 ```


### PR DESCRIPTION
This PR adds a new page - Important Prerequisites to the Tutorials section for the Community Edition to begin with.

This is needed because many of those details are scattered and some are easy to miss. This page adds those in one page before anyone embarks on the journey to create a Community Edition Tyk setup.