### PR TITLE
Fix inline link

### DIFF
--- a/tyk-docs/content/plugins/rich-plugins/rich-plugins-work.md
+++ b/tyk-docs/content/plugins/rich-plugins/rich-plugins-work.md
@@ -19,7 +19,7 @@ This feature implements an in-process message passing mechanism, based on [Proto
 
 The main interoperability task is achieved by using [cgo](https://golang.org/cmd/cgo/) as a bridge between a supported language -like Python- and the Go codebase.
 
-Your C bridge function must accept and return a `CoProcessMessage` data structure like the one described in [`api.h`][https://github.com/TykTechnologies/tyk/blob/master/coprocess/api.h], where `p_data` is a pointer to the serialized data and `length` indicates the length of it.
+Your C bridge function must accept and return a `CoProcessMessage` data structure like the one described in [`api.h`](https://github.com/TykTechnologies/tyk/blob/master/coprocess/api.h), where `p_data` is a pointer to the serialized data and `length` indicates the length of it.
 
 ```{.copyWrapper}
 struct CoProcessMessage {


### PR DESCRIPTION
Fixes an error in the link to [`api.h`](https://github.com/TykTechnologies/tyk/blob/master/coprocess/api.h) in https://tyk.io/docs/plugins/rich-plugins/rich-plugins-work/#interoperability.

![Screenshot at 2020-05-20 13-42-28](https://user-images.githubusercontent.com/1731933/82473349-cee7d980-9a9f-11ea-8ec1-806795aeb761.png)
