### PR TITLE
Added OAS 3.0 Note to Swagger Import section

### DIFF
--- a/tyk-docs/content/tyk-configuration-reference/import-apis.md
+++ b/tyk-docs/content/tyk-configuration-reference/import-apis.md
@@ -54,6 +54,7 @@ Create a new definition from Swagger:
 ```{.copyWrapper}
 ./tyk --import-swagger=petstore.json --create-api --org-id=<id> --upstream-target="http://widgets.com/api/"
 ```
+> **NOTE**: When creating a new definition from an OAS 3.0 spec, you will have to manually add the listen path after the API is created.
 
 #### Importing a swagger document as a version into an existing API
 


### PR DESCRIPTION
Added OAS 3.0 Note to Swagger Import section to let users know that the listen path must be added manually after import.