### PR TITLE
redis key events are now true by default. Merge when 3.0.1 is released

### DIFF
--- a/tyk-docs/content/tyk-multi-data-centre/setup-master-data-centre.md
+++ b/tyk-docs/content/tyk-multi-data-centre/setup-master-data-centre.md
@@ -251,10 +251,10 @@ New fields are between the `...` .
   "hybrid_enabled": true,
   "event_options": {
     "key_event": {
-      "redis": true
+      "email": "test@test.com"
     },
     "hashed_key_event": {
-      "redis": true
+      "email": "test@test.com"
     }
   },
   ...
@@ -271,7 +271,7 @@ New fields are between the `...` .
 
 `hybrid_enabled:` Allows a worker to login as an organisation member into MDCB
 
-`event_options:` Enables key events such as updates and deletes, to be propagated to the various instance zones. API Definitions and Policies will be propagated by default.
+`event_options:` Enables key events such as updates and deletes, to be propagated to the various instance zones. API Definitions and Policies will be propagated by default, as well as the redis key events, meaning that hashed and not hashed keys events will be propagated by default in redis and any config related to `hashed_key_event.redis` or `key_event.redis` will not be taken into consideration.
 
 
 6.Update your organisation with a PUT request to the same endpoint, but this time, passing in your modified `myorg.json` file.

--- a/tyk-docs/content/tyk-multi-data-centre/setup-master-data-centre.md
+++ b/tyk-docs/content/tyk-multi-data-centre/setup-master-data-centre.md
@@ -271,7 +271,7 @@ New fields are between the `...` .
 
 `hybrid_enabled:` Allows a worker to login as an organisation member into MDCB
 
-`event_options:` Enables key events such as updates and deletes, to be propagated to the various instance zones. API Definitions and Policies will be propagated by default, as well as the redis key events, meaning that hashed and not hashed keys events will be propagated by default in redis and any config related to `hashed_key_event.redis` or `key_event.redis` will not be taken into consideration.
+`event_options:` Enables key events such as updates and deletes, to be propagated to the various instance zones. API Definitions and Policies will be propagated by default, as well as the Redis key events, meaning that hashed and not hashed key events will be propagated by default in Redis and any config related to `hashed_key_event.redis` or `key_event.redis` will not be taken into consideration.
 
 
 6.Update your organisation with a PUT request to the same endpoint, but this time, passing in your modified `myorg.json` file.


### PR DESCRIPTION
In Dashboard 3.0.1 the redis key events will be propagated no matter what configuration we have in mongo for the organization, this is the documentation for https://github.com/TykTechnologies/tyk-analytics/pull/1900

This should be merge when 3.0.1 is released