### PR TITLE
Extra info around different role types

### DIFF
--- a/tyk-docs/content/tyk-cloud/teams-&-users/user-roles.md
+++ b/tyk-docs/content/tyk-cloud/teams-&-users/user-roles.md
@@ -21,6 +21,10 @@ We have the following user roles defined in Tyk Cloud for your team members
 * Team Admin
 * Team Member
 
+Billing Admins are responsible for the billing management of the Tyk Cloud account. Organisation Admins, Team Admins and Team Members are responsible for managing the Tyk Cloud organisation hierarchy and deploying/managing stacks, as well as having access to the Tyk Dashboard to manage APIs. Users of Tyk Cloud are usually DevOps, Architects and sometimes Engineers or Managers.
+
+You can [add users to the Tyk Dashboard](/docs/basic-config-and-security/security/dashboard/create-users/) itself instead of inviting them as Tyk Cloud users. These users would likely be your API Developers and Engineers who manage the APIs.   
+
 ## Use Case Matrix
 
 The following table shows the scope for each user role.


### PR DESCRIPTION
Have added in more explainer text on what the roles are between Tyk Cloud and the Dashboard users.