### PR TITLE
Authorise endpoint API name clarification

### DIFF
--- a/tyk-docs/content/tyk-apis/tyk-dashboard-api/oauth-key-management.md
+++ b/tyk-docs/content/tyk-apis/tyk-dashboard-api/oauth-key-management.md
@@ -147,7 +147,7 @@ curl -vX DELETE -H "Authorization: {{API Access Credentials}}" \
 | Type         | Form-Encoded                                   |
 | Body         | Fields (see below)                             |
 
-* `api_id`: Unlike the other requests on this page, this should be the `api_id` value and **NOT** the API's `id` value. 
+* `api_id`: Unlike the other requests on this page, this should be the *name* of the underlying API to which the client belongs and **NOT** the API's `id` value. 
 * `response_type`: Should be provided by requesting client as part of authorisation request, this should be either `code` or `token` depending on the methods you have specified for the API.
 * `client_id`: Should be provided by requesting client as part of authorisation request. The Client ID that is making the request.
 * `redirect_uri`: Should be provided by requesting client as part of authorisation request. Must match with the record stored with Tyk.


### PR DESCRIPTION
The Authorise client endpoint on the dashboard builds the URL to call the Gateway in the form: 

`config.Global().TykApi.Host + ":" + config.Global().TykApi.Port + "/" + apiID + "/tyk/oauth/authorize-client/"`

Where the APIID is read from the path of the dashboard endpoint. 

However the gateway API builds its path in the form:

`spec.Proxy.ListenPath + pathSeparator + "tyk/oauth/authorize-client{_:/?}"`

Meaning the dashboard should in fact pass the API name and not the ID, otherwise a 404 will be received.

