### PR TITLE
add remove notice to removed config param optimisations_use_async_session_write (TT-580)

### DIFF
--- a/tyk-docs/content/tyk-configuration-reference/tyk-gateway-configuration-options.md
+++ b/tyk-docs/content/tyk-configuration-reference/tyk-gateway-configuration-options.md
@@ -593,9 +593,13 @@ Tyk will auto-reload when a change is detected when using the Dashboard, this us
 
 ### optimisations_use_async_session_write
 
-> *DEPRECATED and no longer should be used*
-
 Set this value to `true` to have Tyk manage session data using a goroutine, this is quite safe and can significantly boost performance in HA environments where Tyk is installed on a machine with multiple cores.
+
+{{< note success >}}
+**Note**  
+
+This has been deprecated. Removed from v3.0.3+ and 3.1.1+ onwards.
+{{< /note >}}
 
 ### disable_dashboard_zeroconf
 


### PR DESCRIPTION
The config param ` optimisations_use_async_session_write` has been completely removed for the next releases. This change will reflect this change in the docs.