### PR TITLE
Use POST request instead of PUT for issuing keys

### DIFF
--- a/tyk-docs/content/tyk-developer-portal/customise/custom-developer-portal.md
+++ b/tyk-docs/content/tyk-developer-portal/customise/custom-developer-portal.md
@@ -207,7 +207,7 @@ To generate a key for the developer, first he should send a request to the admin
 
 ```{.copyWrapper}
 curl https://admin.cloud.tyk.io/api/portal/requests \
--X PUT \
+-X POST \
 -H "authorization: $TYK_API_KEY" \
 -d \
 '{


### PR DESCRIPTION
When I tested my local setup, I realized issuing keys request works with `POST` request instead of `PUT`.