### PR TITLE
Update rich-plugins-work.md

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-work.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-work.md
@@ -60,11 +60,11 @@ type CoProcessObject struct {
 
 ### Coprocess Dispatcher - Hooks
 
-This component is in charge of dispatching your HTTP requests to the custom middlewares, in the right order. The dispatcher follows the standard middleware chain logic and provides a simple mechanism for "hooking" your custom middleware behavior, the supported hooks are:
+This component is in charge of dispatching your HTTP requests to the custom middlewares. The list, from top to bottom, shows the order of execution. The dispatcher follows the standard middleware chain logic and provides a simple mechanism for "hooking" your custom middleware behavior, the supported hooks are:
 
 *   **Pre**: gets executed before the request is sent to your upstream target and before any authentication information is extracted from the header or parameter list of the request. When enabled, this applies to both keyless and protected APIs.
+*   **AuthCheck**: gets executed as a custom authentication middleware, instead of the standard ones provided by Tyk. Use this to provide your own authentication mechanism.
 *   **PostKeyAuth**: gets executed right after the authentication process.
-*   **CustomAuthCheck**: gets executed as a custom authentication middleware, instead of the standard ones provided by Tyk. Use this to provide your own authentication mechanism.
 *   **Post**: gets executed after the authentication, validation, throttling, and quota-limiting middleware has been executed, just before the request is proxied upstream. Use this to post-process a request before sending it to your upstream API. This is only called when using protected APIs. If you want to call a hook after the authentication but before the validation, throttling and other middleware, see **PostKeyAuth**.
 *   **Response**: gets executed after the upstream API replies. The arguments passed to this hook include both the request and response data. Use this to modify the HTTP response before it's sent to the client. This hook also receives the request object, the session object, the metadata and API definition associated with the request.
 


### PR DESCRIPTION
Re-arranging the middleware list in terms or order of execution, from top to bottom. Also relabeling "CustomAuthCheck" to "AuthCheck" in order to match the standard hook name in the API definition.