### PR TITLE
[TT-774]  Update opentracing jaeger sample

### DIFF
--- a/tyk-docs/content/advanced-configuration/distributed-tracing/jaeger.md
+++ b/tyk-docs/content/advanced-configuration/distributed-tracing/jaeger.md
@@ -40,7 +40,7 @@ In `tyk.conf` on `tracing` setting
       "disabled": false,
       "headers": null,
       "reporter": {
-        "BufferFlushInterval": 0,
+        "BufferFlushInterval": "0s",
         "collectorEndpoint": "",
         "localAgentHostPort": "jaeger:6831",
         "logSpans": true,
@@ -52,7 +52,7 @@ In `tyk.conf` on `tracing` setting
       "sampler": {
         "maxOperations": 0,
         "param": 1,
-        "samplingRefreshInterval": 0,
+        "samplingRefreshInterval": "0s",
         "samplingServerURL": "",
         "type": "const"
       },


### PR DESCRIPTION
 Use strings for duration. Duration values are not numbers they are described
 with `s` for seconds `m` for minutes and `h` for hours.

 So a ten second duration becomes `10s`