### PR TITLE
Clarify /oauth/authorize-client's api_id value for on-premise installations

### DIFF
--- a/tyk-docs/content/tyk-apis/tyk-dashboard-api/oauth-key-management.md
+++ b/tyk-docs/content/tyk-apis/tyk-dashboard-api/oauth-key-management.md
@@ -147,7 +147,7 @@ curl -vX DELETE -H "Authorization: {{API Access Credentials}}" \
 | Type         | Form-Encoded                                   |
 | Body         | Fields (see below)                             |
 
-* `api_id`: Unlike the other requests on this page, this should be the `api_id` value and **NOT** the API's `id` value. 
+* `api_id`: For Tyk Cloud, unlike the other requests on this page, this should be the `api_id` value and **NOT** the API's `id` value. For on-premise installations this must be be your API's `listen_path`.
 * `response_type`: Should be provided by requesting client as part of authorisation request, this should be either `code` or `token` depending on the methods you have specified for the API.
 * `client_id`: Should be provided by requesting client as part of authorisation request. The Client ID that is making the request.
 * `redirect_uri`: Should be provided by requesting client as part of authorisation request. Must match with the record stored with Tyk.

--- a/tyk-docs/content/tyk-apis/tyk-dashboard-api/oauth-key-management.md
+++ b/tyk-docs/content/tyk-apis/tyk-dashboard-api/oauth-key-management.md
@@ -147,7 +147,7 @@ curl -vX DELETE -H "Authorization: {{API Access Credentials}}" \
 | Type         | Form-Encoded                                   |
 | Body         | Fields (see below)                             |
 
-* `api_id`: For Tyk Cloud, unlike the other requests on this page, this should be the `api_id` value and **NOT** the API's `id` value. For on-premise installations this must be be your API's `listen_path`.
+* `api_id`: For Tyk Cloud, unlike the other requests on this page, this should be the `api_id` value and **NOT** the API's `id` value. For Self Managed installations this must be be your API's `listen_path`.
 * `response_type`: Should be provided by requesting client as part of authorisation request, this should be either `code` or `token` depending on the methods you have specified for the API.
 * `client_id`: Should be provided by requesting client as part of authorisation request. The Client ID that is making the request.
 * `redirect_uri`: Should be provided by requesting client as part of authorisation request. Must match with the record stored with Tyk.


### PR DESCRIPTION
This is mentioned in an info box on https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/oauth2-0/auth-code-grant/ but was otherwise extremely hard to discover from just looking at https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/oauth-2-0/#authorisation-token-flow-eg-server-side-web-apps or these API docs.