### PR TITLE
[TT-1923] Documentation for pump omit_detailed_recording

### DIFF
--- a/tyk-docs/content/tyk-stack/tyk-pump/useful-debug-modes.md
+++ b/tyk-docs/content/tyk-stack/tyk-pump/useful-debug-modes.md
@@ -26,7 +26,7 @@ Detailed logging is not available for Tyk Cloud Classic customers.
 
 Enabling detailed logging is very simple and it can be done with either of the following methods:
 
-- Enable detailed analytics at the global configuration level. You will need to update your `tyk.conf` file as follows:
+Enable detailed analytics at the global configuration level. You will need to update your `tyk.conf` file as follows:
 
 ```{.copyWrapper}
 "enable_analytics" : true,
@@ -34,26 +34,36 @@ Enabling detailed logging is very simple and it can be done with either of the f
   "enable_detailed_recording": true
 }
 ```
+{{< note success >}}
+**Note**  
 
-> This will enable detailed recording for all APIs and it also requires the gateway to be restarted.
+This will enable detailed recording for all APIs and it also requires the Gateway to be restarted.
+{{< /note >}}
 
-- Enable detailed analytics at the API level. This involves updating your [API definition](/docs/tyk-gateway-api/api-definition-objects) to include this at the root level:
 
-```{.copyWrapper}
-"enable_detailed_recording": true
-```
-
-> This will enable detailed recording for this API only.
-
-- Enable detailed analytics at the key level. You will need to update your key
-  with the following setting. This should also come in at the root level:
-
+Enable detailed analytics at the API level. This involves updating your [API definition](/docs/tyk-gateway-api/api-definition-objects) to include this at the root level:
 
 ```{.copyWrapper}
 "enable_detailed_recording": true
 ```
+{{< note success >}}
+**Note**  
 
-> This will enable detailed recording only for APIs the key is used to access.
+This will enable detailed recording for this API only.
+{{< /note >}}
+
+
+Enable detailed analytics at the key level. You will need to update your key with the following setting. This should also come in at the root level:
+
+
+```{.copyWrapper}
+"enable_detailed_recording": true
+```
+{{< note success >}}
+**Note**  
+
+This will enable detailed recording only for APIs the key is used to access.
+{{< /note >}}
 
 
 Please note that each of these methods have different level of priorities. The
@@ -71,11 +81,11 @@ You will also need your Tyk Pump configured to move data into your preferred dat
 #### Disabling detailed recording for a particular pump
 
 In some cases, you don't want to send the detailed request and response to a particular data store. 
-In order to do that, you can use `omit_detailed_recording` in Tyk Pump configuration to disable the detailed logging for a specific pump.
+In order to do that, you can set `omit_detailed_recording` in your Tyk Pump configuration file to `true`. This will disable the detailed logging for a specific pump.
 
-For example, if we have an ElasticSearch, Kafka and CSV stores, and we want to save the detailed recording in all of them except Kafka we need the following configuration:
+For example, if we have an ElasticSearch, Kafka and CSV stores, and you want to save the detailed recording in all of them except Kafka you can use the following configuration:
 
-- Enable detailed analytics on the gateway `tyk.conf` using:
+Enable detailed analytics on the Gateway `tyk.conf` using:
 ```{.copyWrapper}
 "enable_analytics" : true,
 "analytics_config": {

--- a/tyk-docs/content/tyk-stack/tyk-pump/useful-debug-modes.md
+++ b/tyk-docs/content/tyk-stack/tyk-pump/useful-debug-modes.md
@@ -67,3 +67,32 @@ be enabled:
 - Global configuration.
 
 You will also need your Tyk Pump configured to move data into your preferred data store.
+
+#### Disabling detailed recording for a particular pump
+
+In some cases, you don't want to send the detailed request and response to a particular data store. 
+In order to do that, you can use `omit_detailed_recording` in Tyk Pump configuration to disable the detailed logging for a specific pump.
+
+For example, if we have an ElasticSearch, Kafka and CSV stores, and we want to save the detailed recording in all of them except Kafka we need the following configuration:
+
+- Enable detailed analytics on the gateway `tyk.conf` using:
+```{.copyWrapper}
+"enable_analytics" : true,
+"analytics_config": {
+  "enable_detailed_recording": true
+}
+```
+- Configure each pump on `pump.conf`.
+- Add the `omit_detailed_recording` variable to the Kafka pump:
+```{.copyWrapper}
+"pumps": {
+  "kafka": {
+      "type": "kafka",
+      "omit_detailed_recording":"true"
+      "meta": {
+        ...
+      }
+  },
+  ... 
+},
+```


### PR DESCRIPTION
Adding docs for Pump config option `omit_detailed_recording` since it could be a little bit misleading with our current pump debugging page.

https://tyktech.atlassian.net/browse/TT-1923