### PR TITLE
Simplify TTL expiration

### DIFF
--- a/tyk-docs/content/tyk-stack/tyk-manager/analytics/capping-analytics-data-storage.md
+++ b/tyk-docs/content/tyk-stack/tyk-manager/analytics/capping-analytics-data-storage.md
@@ -46,9 +46,7 @@ An alternative to capped collections is MongoDB's **Time To Live** indexing (TTL
 
 ## Time Based Cap
 
-If you wish to reduce or manage the amount of data in your MongoDB, you can  add an expire index to the collection and have Tyk enforce organisation quotas.
-
-To add an expiry index to your analytics log data simply follow these three steps.
+If you wish to reduce or manage the amount of data in your MongoDB, you can  add an TTL expire index to the collection, so older records will be evicted automatically. 
 
 {{< note success >}}
 **Note**  
@@ -57,48 +55,12 @@ Time based caps (TTL indexes) are incompatible with already configured size base
 {{< /note >}}
 
 
-### Step 1: Add the Index to MongoDB
-
-Run the following command in your preferred MongoDB tool:
+Run the following command in your preferred MongoDB tool (2592000 in our example is 30 days):
 
 ```{.copyWrapper}
-db.tyk_analytics.createIndex( { "expireAt": 1 }, { expireAfterSeconds: 0 } )
+db.tyk_analytics.createIndex( { "timestamp": 1 }, { expireAfterSeconds: 2592000 } )
 ```
-This [command](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) sets the value of `expireAt` to correspond to the time the document should expire. MongoDB will automatically delete documents from the `tyk_analytics` collection 0 seconds after the `expireAt` time in the document. The `expireAt` will be calculated and created by Tyk in the following step.
-
-### Step 2. Create an Organisation Quota
-
-```{.copyWrapper}
-curl --header "x-tyk-authorization: {tyk-gateway-secret}" --header "content-type: application/json" --data @expiry.txt http://{tyk-gateway-ip}:{port}/tyk/org/keys/{org-id}
-```
-
-@expiry.txt:
-
-```{.json}
-{
-"allowance": 10000,
-"rate": 10000,
-"per": 0,
-"expires": 0,
-"quota_max": -1,
-"quota_renews": 1406121006,
-"quota_remaining": 100000,
-"quota_renewal_rate": 100000,
-"org_id": "{your-org-id}",
-"data_expires": 86400
-}
-```
-
-`data_expires` - Sets the data expires to a time in seconds for it to expire. Tyk will calculate the expiry date for you.
-
-### Step 3: Make Sure the Setting is Enabled in `tyk.conf`
-
-```{.json}
-"enforce_org_data_age": true, 
-"enforce_org_quotas": false
-```
-
-> **Note**: This will only work for v2.2.0.23 or above, if you are running an earlier patch, you will need to `enforce_org_quotas` set to `true`.
+This [command](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) sets expiration rule to evict all the record from the collection which `timestamp` field is older then specified expiration time.
 
 ## Size Based Cap
 


### PR DESCRIPTION
We do not need multi-org capping as default option. 