### PR TITLE
[TT-414] documented tib env vars

### DIFF
--- a/tyk-docs/content/tyk-stack/tyk-identity-broker/tyk-identity-broker-configuration.md
+++ b/tyk-docs/content/tyk-stack/tyk-identity-broker/tyk-identity-broker-configuration.md
@@ -18,6 +18,7 @@ The Tyk Identity Broker (TIB) is configured through two files: The configuration
 ```{.copyWrapper}
 {
  "Secret": "test-secret",
+ "ProfileDir": "path-to-backup-directory",
  "HttpServerOptions": {
    "UseSSL": true,
    "CertFile": "./certs/server.pem",
@@ -61,6 +62,12 @@ The various options for `tib.conf` file are:
 The REST API secret to configure the Tyk Identity Broker remotely.
 
 (env var:**TYK_TIB_SECRET**)
+
+### ProfileDir
+
+Directory where the backup files will be stored. Backups files are created each time that a create, update or delete action is performed over any profile (and profiles are being read from a file not from mongo, in which case it will create a new document in the `profiles_backup` collection).
+
+(env var:**TYK_IB_PROFILEDIR**)
 
 ### HttpServerOptions.UseSSL
 
@@ -108,9 +115,16 @@ The password for your Redis AUTH Username.
 
 ### BackEnd.IdentityBackendSettings.Hosts
 
-Add your Redis hosts here as a map of hostname:port. Since TIB uses the same cluster driver as Tyk, it is possible to have TIB interact with your existing Redis cluster if you enable it.
+Add your Redis hosts here as a map of hostname:port. Since TIB uses the same cluster driver as Tyk, it is possible to have TIB interact with your existing Redis cluster if you enable it. 
 
 (env var:**TYK_TIB_BACKEND_IDENTITYBACKENDSETTINGS_HOSTS**)
+
+{{< note success >}}
+**Note**  
+
+To set this value via env var you must follow the declaration syntax like `export TYK_TIB_BACKEND_IDENTITYBACKENDSETTINGS_HOSTS="host1:port,host2:port`"
+
+{{< /note >}}
 
 ### BackEnd.IdentityBackendSettings.MaxIdle
 

--- a/tyk-docs/content/tyk-stack/tyk-identity-broker/tyk-identity-broker-configuration.md
+++ b/tyk-docs/content/tyk-stack/tyk-identity-broker/tyk-identity-broker-configuration.md
@@ -115,7 +115,7 @@ The password for your Redis AUTH Username.
 
 ### BackEnd.IdentityBackendSettings.Hosts
 
-Add your Redis hosts here as a map of hostname:port. Since TIB uses the same cluster driver as Tyk, it is possible to have TIB interact with your existing Redis cluster if you enable it. 
+Add your Redis hosts here as a map of hostname:port. Since TIB uses the same cluster driver as Tyk, it is possible to have TIB interact with your existing Redis cluster if you enable it.
 
 (env var:**TYK_TIB_BACKEND_IDENTITYBACKENDSETTINGS_HOSTS**)
 


### PR DESCRIPTION
We already have the env vars documented. So added one config missing `ProfileDir` and set an example on how to configure  `BackEnd.IdentityBackendSettings.Hosts` as this might be very confusing to users due that its a map value