### PR TITLE
[TD-585] Remove helm chart version

### DIFF
--- a/tyk-docs/content/tyk-cloud/environments-&-deployments/hybrid-gateways.md
+++ b/tyk-docs/content/tyk-cloud/environments-&-deployments/hybrid-gateways.md
@@ -131,7 +131,7 @@ kubectl create namespace tyk
 ```
 
 #### Installing Redis
-If you have an external SaaS Redis you can skip this section. 
+If you have an external SaaS Redis you can skip this section.
 
 For Redis you can use these rather excellent chart provided by Bitnami:
 
@@ -150,7 +150,7 @@ Follow the notes from the installation output to get connection details and pass
 
 The DNS name of your Redis as set by Bitnami is `tyk-redis-master.tyk.svc.cluster.local:6379`
 You can update them in your local `values.yaml` file under `redis.addrs` and `redis.pass`
-Alternatively, you can use `--set` flag to set it in Tyk installation. For example  `--set redis.pass=$REDIS_PASSWORD` 
+Alternatively, you can use `--set` flag to set it in Tyk installation. For example  `--set redis.pass=$REDIS_PASSWORD`
 
 
 {{< note success >}}
@@ -160,14 +160,14 @@ If you a simple password-less version of redis, please check (these instructions
 {{< /note >}}
 
 #### Getting values.yaml
-Before we proceed with installation of the chart you need to set some custom values. 
+Before we proceed with installation of the chart you need to set some custom values.
 To see what options are configurable on a chart and save that options to a custom `values.yaml` file run:
  ```bash
 helm show values tyk-helm/tyk-hybrid > values.yaml
 ```
 
 #### Setting values.yaml
-1. to allow the *Tyk Hybrid Gateway* to connect to *Tyk control plane* (*MDCB* management layer), add your connection 
+1. to allow the *Tyk Hybrid Gateway* to connect to *Tyk control plane* (*MDCB* management layer), add your connection
 string in the `gateway.rpc.connString`. On the Tyk Cloud Console find this value in the endpoints panel for your control plane deployment.
 2. For *Tyk Gateway* to identify itself against *Tyk control plane*, add your Dashboard users API key in the `gateway.rpc.apiKey` field.
 3. Add your Dashboard users organisation ID in the `gateway.rpc.rpcKey` field
@@ -177,5 +177,5 @@ Check this (doc)[/tyk-multi-data-centre/setup-slave-data-centres/] for detailed 
 #### Installing Tyk Open Source Gateway as a hybrid gateway
 Now run the following command from the root of the repository:
 ```bash
-helm install tyk-hybrid tyk-helm/tyk-hybrid --version 0.9.1 -f values.yaml -n tyk
+helm install tyk-hybrid tyk-helm/tyk-hybrid -f values.yaml -n tyk
 ```

--- a/tyk-docs/content/tyk-on-prem/installation/kubernetes/helm-chart.md
+++ b/tyk-docs/content/tyk-on-prem/installation/kubernetes/helm-chart.md
@@ -12,8 +12,8 @@ url: "/tyk-self-managed/tyk-helm-chart"
 
 ## Introduction
 
-This is the preferred (and easiest) way to install *Tyk Self-Managed* on Kubernetes. 
-It will install full Tyk platform with *Tyk manager*, *Tyk gateways* and *Tyk pumps* into your Kubernetes cluster where 
+This is the preferred (and easiest) way to install *Tyk Self-Managed* on Kubernetes.
+It will install full Tyk platform with *Tyk manager*, *Tyk gateways* and *Tyk pumps* into your Kubernetes cluster where
 you can add and manage APIs via the *Tyk Operator*, and the *Tyk manager* (i.e *Tyk dashboard*).
 
 ### Prerequisites
@@ -28,13 +28,13 @@ The following are required for a Tyk Self-managed installation:
  - MongoDB - Should be installed in the cluster or be reachable by the *Tyk Manager* (for SaaS option).
 
 Installation instructions for Redis and MongoDB are detailed below.
-            
-## Installation 
+
+## Installation
 
 This is our official Helm repository [https://helm.tyk.io/public/helm/charts/](https://helm.tyk.io/public/helm/charts/).
 You can also find the *Tyk Self-Managed* Helm chart in [artifacthub](https://artifacthub.io/packages/helm/tyk-helm/tyk-pro).
 
-If you are interested in contributing, suggesting changes or creating PRs, please use our 
+If you are interested in contributing, suggesting changes or creating PRs, please use our
 [GitHub repo](https://github.com/TykTechnologies/tyk-helm-chart/tree/master/tyk-pro).
 
 ### Add the Tyk official Helm repo
@@ -49,7 +49,7 @@ kubectl create namespace tyk
 ```
 
 ### Getting the values.yaml of the chart
-Before we proceed with installation of the chart you need to set some custom values. 
+Before we proceed with installation of the chart you need to set some custom values.
 To see what options are configurable on a chart and save that options to a custom values.yaml file run:
 
  ```bash
@@ -77,7 +77,7 @@ Follow the notes from the installation output to get connection details and pass
 
 The DNS name of your Redis as set by Bitnami is `tyk-redis-master.tyk.svc.cluster.local:6379` (Tyk needs the name including the port)
 You can update them in your local `values.yaml` file under `redis.addrs` and `redis.pass`
-Alternatively, you can use `--set` flag to set it in Tyk installation. For example  `--set redis.pass=$REDIS_PASSWORD` 
+Alternatively, you can use `--set` flag to set it in Tyk installation. For example  `--set redis.pass=$REDIS_PASSWORD`
 
 #### MongoDB
 ```bash
@@ -92,9 +92,9 @@ Alternatively, you can use `--set` flag to set it in Tyk installation.
 {{< note success >}}
 **Important Note regarding MongoDB**
 
-This Helm chart enables the *PodDisruptionBudget* for MongoDB with an arbiter replica-count of 1. If you intend to perform 
-system maintenance on the node where the MongoDB pod is running and this maintenance requires for the node to be drained, 
-this action will be prevented due the replica count being 1. Increase the replica count in the helm chart deployment to 
+This Helm chart enables the *PodDisruptionBudget* for MongoDB with an arbiter replica-count of 1. If you intend to perform
+system maintenance on the node where the MongoDB pod is running and this maintenance requires for the node to be drained,
+this action will be prevented due the replica count being 1. Increase the replica count in the helm chart deployment to
 a minimum of 2 to remedy this issue.
 
 {{< /note >}}
@@ -104,9 +104,9 @@ a minimum of 2 to remedy this issue.
 {{< warning  success >}}
 **Warning**
 
-Another option for Redis and MongoDB, to get started quickly, is to use our *simple-redis* and *simple-mongodb* charts. 
-Please note that these provided charts must not ever be used in production and for anything 
-but a quick start evaluation only. Use external redis or Official Redis Helm chart in any other case. 
+Another option for Redis and MongoDB, to get started quickly, is to use our *simple-redis* and *simple-mongodb* charts.
+Please note that these provided charts must not ever be used in production and for anything
+but a quick start evaluation only. Use external redis or Official Redis Helm chart in any other case.
 We provide this chart, so you can quickly get up and running, however it is not meant for long term storage of data for example.
 
 ```bash
@@ -138,7 +138,7 @@ gateway pods is more than the license limit with lower amounts of Licensed nodes
 Now we can install the chart using our custom values:
 
 ```bash
-helm install tyk-pro tyk-helm/tyk-pro --version 0.9.1 -f ./values.yaml -n tyk --wait
+helm install tyk-pro tyk-helm/tyk-pro -f ./values.yaml -n tyk --wait
 ```
 
 >Please note the `--wait` argument is important to successfully finish the bootstrap job of *Tyk Manager*.
@@ -147,11 +147,11 @@ helm install tyk-pro tyk-helm/tyk-pro --version 0.9.1 -f ./values.yaml -n tyk --
 You can disable the bootstrapping of the Developer Portal by the `portal.bootstrap: false` in your local `values.yaml` file.
 
 #### Using TLS
-You can turn on the TLS option under the gateway section in your local `values.yaml` file which will make your Gateway 
+You can turn on the TLS option under the gateway section in your local `values.yaml` file which will make your Gateway
 listen on port 443 and load up a dummy certificate. You can set your own default certificate by replacing the file in the `certs/` folder.
 
 #### Mounting Files
-To mount files to any of the Tyk stack components, add the following to the mounts array in the section of that component. 
+To mount files to any of the Tyk stack components, add the following to the mounts array in the section of that component.
 For example:
  ```bash
  - name: aws-mongo-ssl-cert
@@ -160,50 +160,50 @@ For example:
 ```
 
 #### Sharding APIs
-Sharding is the ability for you to decide which of your APIs are loaded on which of your Tyk Gateways. This option is 
-turned off by default, however, you can turn it on by updating the `gateway.sharding.enabled` option. Once you do that you 
-will also need to set the `gateway.sharding.tags` field with the tags that you want that particular Gateway to load. (ex. tags: "external,ingress".) 
-You can then add those tags to your APIs in the API Designer, under the *Advanced Options* tab, and 
-the *Segment Tags (Node Segmentation)* section in your Tyk Dashboard. 
+Sharding is the ability for you to decide which of your APIs are loaded on which of your Tyk Gateways. This option is
+turned off by default, however, you can turn it on by updating the `gateway.sharding.enabled` option. Once you do that you
+will also need to set the `gateway.sharding.tags` field with the tags that you want that particular Gateway to load. (ex. tags: "external,ingress".)
+You can then add those tags to your APIs in the API Designer, under the *Advanced Options* tab, and
+the *Segment Tags (Node Segmentation)* section in your Tyk Dashboard.
 Check [Tyk Gateway Sharding]({{< ref "/content/advanced-configuration/manage-multiple-environments/manage-multiple-environments.md#api-sharding" >}}) for more details.
 
 
 ## Other Tyk Components
 
 ### Installing Tyk Self-managed Control Plane
-If you are deploying the *Tyk Control plane*, a.k.a *MDCB*, for a *Tyk Multi data Centre* deployment then you set 
-the `mdcb.enabled: true` option in the local `values.yaml` to add of the *MDCB* component to your installation. 
-Check [Tyk Control plane](https://tyk.io/docs/tyk-multi-data-centre/) for more configuration details. 
+If you are deploying the *Tyk Control plane*, a.k.a *MDCB*, for a *Tyk Multi data Centre* deployment then you set
+the `mdcb.enabled: true` option in the local `values.yaml` to add of the *MDCB* component to your installation.
+Check [Tyk Control plane](https://tyk.io/docs/tyk-multi-data-centre/) for more configuration details.
 
 This setting enables multi-cluster, multi Data-Centre API management from a single dashboard.
 
 #### Secrets
-Tyk *MDCB* registry is private and requires adding users to our organisation which you then define as a secret when pulling the *MDCB* image. 
+Tyk *MDCB* registry is private and requires adding users to our organisation which you then define as a secret when pulling the *MDCB* image.
 Please contact your account manager to arrange this.
 
 ### Tyk Identity Broker (TIB)
-The *Tyk Identity Broker* (TIB) is a micro-service portal that provides a bridge between various Identity Management Systems 
-such as LDAP, OpenID Connect providers and legacy Basic Authentication providers, to your Tyk installation. 
+The *Tyk Identity Broker* (TIB) is a micro-service portal that provides a bridge between various Identity Management Systems
+such as LDAP, OpenID Connect providers and legacy Basic Authentication providers, to your Tyk installation.
 See [TIB]({{< ref "/content/tyk-stack/tyk-identity-broker/getting-started.md" >}}) for more details.
 
-For SSO to *Tyk Manager* and *Tyk developer portal* purposes you do not need to install *TIB*, as its functionality is now 
+For SSO to *Tyk Manager* and *Tyk developer portal* purposes you do not need to install *TIB*, as its functionality is now
 part of the *Tyk Manager*. However, if you want to run it separately (as you used to before this merge) or if you need it
  as a broker for the *Tyk gateway* you can do so.
 
-Once you have installed *Tyk Gateway* and *Tyk Manager*, you can configure *TIB* by adding its configuration environment variables 
-under the `tib.extraEnvs` section and updating the `profile.json` in your `configs` folder. 
-See our [TIB GitHub repo](https://github.com/TykTechnologies/tyk-identity-broker#how-to-configure-tib). 
+Once you have installed *Tyk Gateway* and *Tyk Manager*, you can configure *TIB* by adding its configuration environment variables
+under the `tib.extraEnvs` section and updating the `profile.json` in your `configs` folder.
+See our [TIB GitHub repo](https://github.com/TykTechnologies/tyk-identity-broker#how-to-configure-tib).
 Once you complete your modifications you can run the following command from the root of the repository to update your helm chart.
 
 ```bash
 helm upgrade tyk-pro values.yaml -n tyk
 ```
 
-This chart implies there's a *ConfigMap* with a `profiles.json` definition in it. Please use `tib.configMap.profiles` value 
+This chart implies there's a *ConfigMap* with a `profiles.json` definition in it. Please use `tib.configMap.profiles` value
 to set the name of this *ConfigMap* (`tyk-tib-profiles-conf` by default).
 
 ### Tyk as an Ingress using Tyk operator
-To set up an ingress for your Tyk Gateways see our [Tyk Operator GitHub repository](https://github.com/TykTechnologies/tyk-operator). 
+To set up an ingress for your Tyk Gateways see our [Tyk Operator GitHub repository](https://github.com/TykTechnologies/tyk-operator).
 
 ### Istio Service Mesh with Tyk as an Ingress
 To use Tyk's gateways as the ingress to your Istio Service Mesh simply change `gateway.enableIstioIngress: true` in the

--- a/tyk-docs/content/tyk-stack/tyk-gateway/install/ce-helm-chart.md
+++ b/tyk-docs/content/tyk-stack/tyk-gateway/install/ce-helm-chart.md
@@ -12,22 +12,22 @@ url: "/tyk-oss/ce-helm-chart/"
 
 ## Introduction
 
-This is the preferred (and easiest) way to install the Tyk OSS Gateway on Kubernetes. 
+This is the preferred (and easiest) way to install the Tyk OSS Gateway on Kubernetes.
 It will install Tyk gateway in your Kubernetes cluster where you can add and manage APIs directly or via the *Tyk Operator*.
- 
+
 ## Prerequisites
 The following are required for a Tyk OSS installation:
  - Redis   - required for all the Tyk installations and must be installed in the cluster or reachable from inside K8s.
              You can find instructions for a simple Redis installation bellow.
- - MongoDB - Required only if you chose to use the MongoDB Tyk pump with your Tyk OSS installation. Same goes with any 
+ - MongoDB - Required only if you chose to use the MongoDB Tyk pump with your Tyk OSS installation. Same goes with any
              [other pump](/analytics-and-reporting/other-data-stores/) you choose to use.
-             
-## Installation 
+
+## Installation
 
 This is our official Helm repository [https://helm.tyk.io/public/helm/charts/](https://helm.tyk.io/public/helm/charts/).
 You can also find the *Tyk OSS* Helm chart in [artifacthub](https://artifacthub.io/packages/helm/tyk-helm/tyk-headless).
 
-If you are interested in contributing, suggesting changes or creating PRs, please use our 
+If you are interested in contributing, suggesting changes or creating PRs, please use our
 [GitHub repo](https://github.com/TykTechnologies/tyk-helm-chart/tree/master/tyk-headless).
 
 ### Add Tyk official Helm repo
@@ -45,7 +45,7 @@ kubectl create namespace tyk
 
 ### Getting values.yaml
 
-Before we proceed with installation of the chart you need to set some custom values. 
+Before we proceed with installation of the chart you need to set some custom values.
 To see what options are configurable on a chart and save that options to a custom values.yaml file run:
 
  ```bash
@@ -73,15 +73,15 @@ Follow the notes from the installation output to get connection details and pass
 
 The DNS name of your Redis as set by Bitnami is `tyk-redis-master.tyk.svc.cluster.local:6379`
 You can update them in your local `values.yaml` file under `redis.addrs` and `redis.pass`
-Alternatively, you can use `--set` flag to set it in Tyk installation. For example  `--set redis.pass=$REDIS_PASSWORD` 
+Alternatively, you can use `--set` flag to set it in Tyk installation. For example  `--set redis.pass=$REDIS_PASSWORD`
 
 
 {{< warning  success >}}
 **Warning**
 
-Another option for Redis, to get started quickly, is to use our *simple-redis* chart. 
-Please note that these provided charts must not ever be used in production and for anything 
-but a quick start evaluation only. Use external redis or Official Redis Helm chart in any other case. 
+Another option for Redis, to get started quickly, is to use our *simple-redis* chart.
+Please note that these provided charts must not ever be used in production and for anything
+but a quick start evaluation only. Use external redis or Official Redis Helm chart in any other case.
 We provide this chart, so you can quickly have *Tyk gateway* running, however it is not meant for long term storage of data for example.
 {{< /warning >}}
 
@@ -92,24 +92,24 @@ helm install redis tyk-helm/simple-redis -n tyk
 ### Installing Tyk Open Source Gateway
 
 ```bash
-helm install tyk-ce tyk-helm/tyk-headless --version 0.9.1 -f values.yaml -n tyk
+helm install tyk-ce tyk-helm/tyk-headless -f values.yaml -n tyk
  ```
 
-#### Installation Video 
+#### Installation Video
 
-See our short video on how to install the Tyk Open Source Gateway. 
-Please note that this video shows the use of GH repo, since it recorded before the official repo was available, However, 
+See our short video on how to install the Tyk Open Source Gateway.
+Please note that this video shows the use of GH repo, since it recorded before the official repo was available, However,
 it's very similar to the above commands.
 
 {{< youtube mkyl38sBAF0 >}}
 
 #### Using TLS
-You can turn on the TLS option under the gateway section in your local `values.yaml` file which will make your Gateway 
-listen on port 443 and load up a dummy certificate. 
+You can turn on the TLS option under the gateway section in your local `values.yaml` file which will make your Gateway
+listen on port 443 and load up a dummy certificate.
 You can set your own default certificate by replacing the file in the `certs/` folder.
 
 #### Mounting Files
-To mount files to any of the Tyk stack components, add the following to the mounts array in the section of that component. 
+To mount files to any of the Tyk stack components, add the following to the mounts array in the section of that component.
 For example:
  ```bash
  - name: aws-mongo-ssl-cert
@@ -118,7 +118,7 @@ For example:
 ```
 
 #### Tyk Ingress
-To set up an ingress for your Tyk Gateways see our [Tyk Operator GitHub repository](https://github.com/TykTechnologies/tyk-operator). 
+To set up an ingress for your Tyk Gateways see our [Tyk Operator GitHub repository](https://github.com/TykTechnologies/tyk-operator).
 
 ### Next Steps Tutorials
 Follow the Tutorials on the Open Source tabs for the following:


### PR DESCRIPTION
This PR is removing the need to specify helm chart version when installing our helm charts. If no version is specified then the latest one will be used.