### PR TITLE
[TT-3303] Update JWT claims documentation

### DIFF
--- a/tyk-docs/content/advanced-configuration/integrate/api-auth-mode/open-id-connect.md
+++ b/tyk-docs/content/advanced-configuration/integrate/api-auth-mode/open-id-connect.md
@@ -94,7 +94,11 @@ To enable this feature you will need to add the following fields in your API:
 Here we have set:
 
 * `jwt_scope_to_policy_mapping` provides a mapping of scopes (read from claim) to an actual policy ID. In this example we specify that scope "admin" will apply policy `"59672779fa4387000129507d"` to a key.
-* `jwt_scope_claim_name` identifies the JWT claim name which contains scopes. This API Spec field is optional with default value `"scope"`. This claim value is a string with space delimited list of values (by standard)
+* `jwt_scope_claim_name` identifies the JWT claim name which contains scopes. This API Spec field is optional with default value `"scope"`. This claim value could be any of the following:
+  - a string with space delimited list of values (by standard)
+  - a slice of strings
+  - a string with space delimited list of values inside a nested key. In this case, provide `"jwt_scope_claim_name"` in dot notation. For eg. `"scope1.scope2"`, `"scope2"` will be having the list of values nested inside `"scope1"`
+  - a slice of strings inside a nested key. In this case, provide `"jwt_scope_claim_name"` in dot notation. For eg. `"scope1.scope2"`, `"scope2"` will be having a slice of strings nested inside `"scope1"`
 
 {{< note success >}}
 **Note**  

--- a/tyk-docs/content/basic-config-and-security/security/Authentication & Authorization/json-web-tokens.md
+++ b/tyk-docs/content/basic-config-and-security/security/Authentication & Authorization/json-web-tokens.md
@@ -220,7 +220,11 @@ You can map JWT scopes to security policies to be applied to a key. To enable th
 Here we have set:
 
 - `"jwt_scope_to_policy_mapping"` provides mapping of scopes (read from claim) to actual policy ID. I.e. in this example we specify that scope "admin" will apply policy `"59672779fa4387000129507d"` to a key
-- `"jwt_scope_claim_name"` identifies the JWT claim name which contains scopes. This API Spec field is optional with default value `"scope"`. This claim value is a string with space delimited list of values (by standard)
+- `"jwt_scope_claim_name"` identifies the JWT claim name which contains scopes. This API Spec field is optional with default value `"scope"`. This claim value could be any of the following:
+  - a string with space delimited list of values (by standard)
+  - a slice of strings
+  - a string with space delimited list of values inside a nested key. In this case, provide `"jwt_scope_claim_name"` in dot notation. For eg. `"scope1.scope2"`, `"scope2"` will be having the list of values nested inside `"scope1"`
+  - a slice of strings inside a nested key. In this case, provide `"jwt_scope_claim_name"` in dot notation. For eg. `"scope1.scope2"`, `"scope2"` will be having a slice of strings nested inside `"scope1"`
 
 {{< note success >}}
 **Note**  


### PR DESCRIPTION
JWT claims can support more complex scopes now as per changes made in [PR](https://github.com/TykTechnologies/tyk/pull/3529). This PR updates the documentation to align with these changes. 