### PR TITLE
update auth field of the JSON related to API creation

### DIFF
--- a/tyk-docs/content/getting-started/tutorials/create-api.md
+++ b/tyk-docs/content/getting-started/tutorials/create-api.md
@@ -132,10 +132,8 @@ Create a file called `api1.json` and place it in the `/apps` folder of your Tyk 
   "slug": "test-api",
   "api_id": "1",
   "org_id": "1",
-  "auth_configs": {
-    "authToken": {
-      "auth_header_name": "Authorization"
-    }
+  "auth": {
+    "auth_header_name": "Authorization"
   },
   "definition": {
     "location": "header",


### PR DESCRIPTION
This PR updates the `auth_configs` field of the JSON that creates a file-based API definition.

As described in [the documentation](https://tyk.io/docs/tyk-apis/tyk-gateway-api/api-definition-objects/authentication/), 
```
From v2.9.2 auth has been deprecated in favour of auth_configs.
```

Signed-off-by: Burak Sekili <buraksekili@gmail.com>