### PR TITLE
fix quotation in rendered markdown

### DIFF
--- a/tyk-docs/content/tyk-cloud/configuration-options/using-custom-domains/custom-domains.md
+++ b/tyk-docs/content/tyk-cloud/configuration-options/using-custom-domains/custom-domains.md
@@ -52,4 +52,4 @@ In this example we are going to set up a custom domain called `edge.corp.com` fo
 
 ### How our Custom Domain functionality works
 
-When you point your custom domain to your deployment, we use [Let's Encrypt's](https://letsencrypt.org/docs/challenge-types/#http-01-challenge) HTTP01 ACME challenge type, which verifies ownership by accessing your custom CNAME on your Control Plane or Edge deployment. For example - `something-something.aws-euw2.cloud-ara.tyk.io` above.
+When you point your custom domain to your deployment, we use [Let\'s Encrypt\'s](https://letsencrypt.org/docs/challenge-types/#http-01-challenge) HTTP01 ACME challenge type, which verifies ownership by accessing your custom CNAME on your Control Plane or Edge deployment. For example - `something-something.aws-euw2.cloud-ara.tyk.io` above.


### PR DESCRIPTION
Currently the quotes inside a markdown link block are been rendered as shown below;
![Screenshot from 2021-12-23 19-06-28](https://user-images.githubusercontent.com/5163857/147265590-1cb0170e-66bb-4b86-b5ec-939e1ac6c81c.png)
actual link: https://tyk.io/docs/tyk-cloud/using-custom-domains/

With this fix, they get rendered as 
![Screenshot from 2021-12-23 19-09-03](https://user-images.githubusercontent.com/5163857/147265769-2a59e457-23f0-4468-b4be-c86caad3f615.png)
