### PR TITLE
[TT-4363] Document EL7 plugin build

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/golang-plugins/golang-plugins.md
+++ b/tyk-docs/content/plugins/supported-languages/golang-plugins/golang-plugins.md
@@ -807,5 +807,3 @@ If your plugin depends on third party libraries, ensure to vendor them, before b
 
 ### Known issues and Limitations 
 If a dependency that your plugin uses is also used by the gateway, the version _used by the gateway_ will be used in your plugin. This may mask conflicts between transitive dependencies. 
-
-The plugin compiler does not support on Ubuntu 16.04 (Xenial Xerus) as it uses glibc 2.23 which is incompatible with our standard build environment. If you absolutely must have go plugin support on Xenial, please write to our support.

--- a/tyk-docs/content/plugins/supported-languages/golang-plugins/golang-plugins.md
+++ b/tyk-docs/content/plugins/supported-languages/golang-plugins/golang-plugins.md
@@ -107,14 +107,14 @@ Run this command on initial plugin initialization, and every time you add a new 
 A specific of Golang plugins is that they need to be built using exactly the same Tyk binary as the one to be installed. In order to make it work, we provide a special Docker image, which we internally use for building our official binaries too.
 
 {{< tabs_start >}}
-{{< tab_start "v3.2.2" >}}
+{{< tab_start "RHEL 7/Ubuntu Xenial" >}}
 ```bash
-docker run --rm -v `pwd`:/plugin-source tykio/tyk-plugin-compiler:v3.2.2 plugin.so
+docker run --rm -v `pwd`:/plugin-source tykio/tyk-plugin-compiler:<version>-el7 plugin.so
 ```
 {{< tab_end >}}
-{{< tab_start "3.2.1" >}}
+{{< tab_start "Newer OSes" >}}
 ```bash
-docker run --rm -v `pwd`:/plugin-source tykio/tyk-plugin-compiler:v3.2.1 plugin.so
+docker run --rm -v `pwd`:/plugin-source tykio/tyk-plugin-compiler:<version> plugin.so
 ```
 {{< tab_end >}}
 {{< tab_start "Other" >}}

--- a/tyk-docs/content/tyk-stack/tyk-gateway/install/ce-debian-ubuntu.md
+++ b/tyk-docs/content/tyk-stack/tyk-gateway/install/ce-debian-ubuntu.md
@@ -52,9 +52,9 @@ You can choose to not install Redis by removing the `-t redis`. However Redis is
 ## Supported Distributions
 | Distribution | Version | Supported |
 | --------- | :---------: | :---------: |
-| Debian | 10 | ✅ |
-| Debian | 9 | ✅ |
-| Debian | 8 | ❌ |
+| Debian | 11 | ✅ |
+| Debian | 10 | ❌ |
+| Debian | 9 | ❌ |
 | Ubuntu | 20 | ✅ |
 | Ubuntu | 18 | ✅ |
 | Ubuntu | 16 | ✅ |


### PR DESCRIPTION
From 4.0 on, RHEL 7 and Xenial users will have to use a specially tagged plugin compiler.