### PR TITLE
added video instructions on setting up tyk cloud account

### DIFF
--- a/tyk-docs/content/tyk-cloud/getting-started-tyk-cloud/create-account.md
+++ b/tyk-docs/content/tyk-cloud/getting-started-tyk-cloud/create-account.md
@@ -20,10 +20,6 @@ When you create your Tyk Cloud account, we do the following for you:
 * Assign the account creator as a [Billing Admin](/docs/tyk-cloud/teams-users/user-roles/#user-roles-within-tyk-cloud) for the Organisation. This user role allows you to manage the billing and plans for your org. You can also add other billing admins as required.
 * Assign the new account to our [free 14 day Tyk Cloud trial plan](/docs/tyk-cloud/account-billing/plans/#14-day-trial)
 
-Watch our video on setting up your Tyk Cloud account.
-
-{{< youtube Y4Zd4DCwjk8 >}}
-
 ## Creating your first account
 
 [Start here](https://account.cloud-ara.tyk.io/signup).

--- a/tyk-docs/content/tyk-cloud/getting-started-tyk-cloud/create-account.md
+++ b/tyk-docs/content/tyk-cloud/getting-started-tyk-cloud/create-account.md
@@ -22,6 +22,8 @@ When you create your Tyk Cloud account, we do the following for you:
 
 Watch our video on setting up your Tyk Cloud account.
 
+{{< youtube Y4Zd4DCwjk8 >}}
+
 ## Creating your first account
 
 [Start here](https://account.cloud-ara.tyk.io/signup).


### PR DESCRIPTION
There was a **"Watch our video on setting up your Tyk Cloud account."** section under the **"1. Task 1 - Create Your Account"** that did not have a video on setting up the cloud account. Instead I had to search YouTube for it. This provides ease of access to users.