### PR TITLE
Added additional details on the health-check endpoint

### DIFF
--- a/tyk-docs/content/planning-for-production/ensure-high-availability/health-check.md
+++ b/tyk-docs/content/planning-for-production/ensure-high-availability/health-check.md
@@ -31,6 +31,8 @@ The following component status will not be returned:
 * MongDB or SQL
 * Tyk Pump
 
+Please keep in mind that the health-check API endpoint is listening on the port that is specified in the `control_port_api` gateway configuration option. This change affects versions 3.0+.
+
 {{< note success >}}
 **Note**  
 

--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -841,11 +841,17 @@ Set this value to `true` to have the node capture and record analytics data rega
 ### health_check
 This section enables the configuration of the health-check API endpoint and the size of the sample data cache (in seconds).
 
+{{< note success >}}
+**Note**
+
+Please keep in mind that the health-check API endpoint on `/hello` and `/tyk/health` is listening on the port that is specified in `control_port_api`. This change affects versions 3.0+.
+{{< /note >}}
+
 ### health_check.enable_health_checks
 EV: <b>TYK_GW_HEALTHCHECK_ENABLEHEALTHCHECKS</b><br />
 Type: `bool`<br />
 
-Setting this value to `true` will enable the health-check endpoint on /Tyk/health.
+Setting this value to `true` will enable the health-check endpoint on /tyk/health.
 
 ### health_check.health_check_value_timeouts
 EV: <b>TYK_GW_HEALTHCHECK_HEALTHCHECKVALUETIMEOUT</b><br />

--- a/tyk-docs/content/tyk-cloud/getting-started-tyk-cloud/create-account.md
+++ b/tyk-docs/content/tyk-cloud/getting-started-tyk-cloud/create-account.md
@@ -20,10 +20,6 @@ When you create your Tyk Cloud account, we do the following for you:
 * Assign the account creator as a [Billing Admin](/docs/tyk-cloud/teams-users/user-roles/#user-roles-within-tyk-cloud) for the Organisation. This user role allows you to manage the billing and plans for your org. You can also add other billing admins as required.
 * Assign the new account to our [free 14 day Tyk Cloud trial plan](/docs/tyk-cloud/account-billing/plans/#14-day-trial)
 
-Watch our video on setting up your Tyk Cloud account.
-
-{{< youtube Y4Zd4DCwjk8 >}}
-
 ## Creating your first account
 
 [Start here](https://account.cloud-ara.tyk.io/signup).

--- a/tyk-docs/content/tyk-cloud/getting-started-tyk-cloud/create-account.md
+++ b/tyk-docs/content/tyk-cloud/getting-started-tyk-cloud/create-account.md
@@ -22,6 +22,8 @@ When you create your Tyk Cloud account, we do the following for you:
 
 Watch our video on setting up your Tyk Cloud account.
 
+{{< youtube Y4Zd4DCwjk8 >}}
+
 ## Creating your first account
 
 [Start here](https://account.cloud-ara.tyk.io/signup).

--- a/tyk-docs/static/others/gateway-swagger.yaml
+++ b/tyk-docs/static/others/gateway-swagger.yaml
@@ -41,7 +41,10 @@ tags:
     description:
       Force restart of the Gateway or whole cluster
   - name: Health Checking
-    description: Check health check of the Gateway and loaded APIs
+    description: |-
+      Check health check of the Gateway and loaded APIs
+
+      <b>Note: The following health check endpoints are only valid for versions older than 3.0.0</b>. For versions 3.0.0+, see [Liveness health check](/docs/planning-for-production/ensure-high-availability/health-check/).
   - name: Organisation Quotas
     description: |-
       It is possible to force API quota and rate limit across all keys that belong to a specific organisation ID. Rate limiting at an organisation level is useful for creating tiered access levels and trial accounts.

--- a/tyk-docs/static/others/gateway-swagger.yml
+++ b/tyk-docs/static/others/gateway-swagger.yml
@@ -45,7 +45,10 @@ tags:
     description:
       Force restart of the Gateway or whole cluster
   - name: Health Checking
-    description: Check health check of the Gateway and loaded APIs
+    description: |-
+      Check health check of the Gateway and loaded APIs
+
+      <b>Note: The following health check endpoints are only valid for versions older than 3.0.0</b>. For versions 3.0.0+, see [Liveness health check](/docs/planning-for-production/ensure-high-availability/health-check/).
   - name: Organisation Quotas
     description: |-
       It is possible to force API quota and rate limit across all keys that belong to a specific organisation ID. Rate limiting at an organisation level is useful for creating tiered access levels and trial accounts.


### PR DESCRIPTION
We had a support ticket that a client upgraded to v3.0.9 and was having issues on the health-check API endpoint. I added important details on the use of that endpoint. Thanks to @OldStubbsy for providing that guidance! This documentation will provide guidance for users configuring the `control_api_port` and are receiving `404 page not found error`.