### PR TITLE
[TT-6100] Update Tyk GW deployment type on tyk-headless docs

### DIFF
--- a/tyk-docs/content/tyk-stack/tyk-gateway/install/ce-helm-chart.md
+++ b/tyk-docs/content/tyk-stack/tyk-gateway/install/ce-helm-chart.md
@@ -113,6 +113,14 @@ helm install redis tyk-helm/simple-redis -n tyk
 helm install tyk-ce tyk-helm/tyk-headless -f values.yaml -n tyk
  ```
 
+Please note that by default, Gateway runs as DaemonSet. If you are using more than a Node, please update Gateway kind to `Deployment` because multiple instances of headless gateways won't sync API Definition.
+
+To configure Gateway kind, update `.gateway.kind` field in the `values.yaml` to `Deployment`,
+Alternatively, you can use `--set gateway.kind=Deployment` while doing helm install.
+```bash
+helm install tyk-ce tyk-helm/tyk-headless --set gateway.kind=Deployment -n tyk
+```
+
 #### Installation Video
 
 See our short video on how to install the Tyk Open Source Gateway.


### PR DESCRIPTION
As part of https://github.com/TykTechnologies/tyk-helm-chart/pull/215, `tyk-headless` documentation is updated.

This PR updates official documentation of OSS Helm Chart according to https://github.com/TykTechnologies/tyk-helm-chart/pull/215