### PR TITLE
Change Postman collection buttons to a link

### DIFF
--- a/tyk-docs/content/tyk-apis/tyk-apis.md
+++ b/tyk-docs/content/tyk-apis/tyk-apis.md
@@ -16,37 +16,9 @@ This API is very small, and has no granular permissions system. It is used purel
 * Hot reloads / reloading a cluster configuration
 * OAuth client creation (only when not using the Dashboard)
 
-<div class="postman-run-button"
-data-postman-action="collection/fork"
-data-postman-var-1="17155284-f9cc8548-5c01-4e52-98b8-2d9ac3e77c69"
-data-postman-collection-url="entityId=17155284-f9cc8548-5c01-4e52-98b8-2d9ac3e77c69&entityType=collection&workspaceId=379673ec-4cc5-4b8e-bef5-8a6a988071cb"></div>
-<script type="text/javascript">
-  (function (p,o,s,t,m,a,n) {
-    !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });
-    !o.getElementById(s+t) && o.getElementsByTagName("head")[0].appendChild((
-      (n = o.createElement("script")),
-      (n.id = s+t), (n.async = 1), (n.src = m), n
-    ));
-  }(window, document, "_pm", "PostmanRunObject", "https://run.pstmn.io/button.js"));
-</script>
-
 ## [Tyk Dashboard API](/docs/tyk-dashboard-api/)
 
 The Tyk Dashboard API allows much more fine-grained, secure and multi-user access to your Tyk cluster, and should be used to manage a database-backed Tyk node. The Tyk Dashboard API works seamlessly with the Tyk Dashboard (the two come bundled together).
-
-<div class="postman-run-button"
-data-postman-action="collection/fork"
-data-postman-var-1="17155284-85d19715-5b29-46bd-b6ef-e211ccd78b43"
-data-postman-collection-url="entityId=17155284-85d19715-5b29-46bd-b6ef-e211ccd78b43&entityType=collection&workspaceId=379673ec-4cc5-4b8e-bef5-8a6a988071cb"></div>
-<script type="text/javascript">
-  (function (p,o,s,t,m,a,n) {
-    !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });
-    !o.getElementById(s+t) && o.getElementsByTagName("head")[0].appendChild((
-      (n = o.createElement("script")),
-      (n.id = s+t), (n.async = 1), (n.src = m), n
-    ));
-  }(window, document, "_pm", "PostmanRunObject", "https://run.pstmn.io/button.js"));
-</script>
 
 ## [Tyk Dashboard Admin API](/docs/dashboard-admin-api/)
 
@@ -55,3 +27,7 @@ The Dashboard Admin API is a special bootstrapping API that can be used to set u
 ## [Tyk Portal API](/docs/tyk-portal-api/)
 
 The Tyk Portal API covers all available endpoints for your developer portal.
+
+## Tyk Postman Collections
+
+We have a [Postman public workspace](https://www.postman.com/tyk-technologies/workspace/379673ec-4cc5-4b8e-bef5-8a6a988071cb/overview) where you can view, fork and test our Gateway and Dashboard APIs. 

--- a/tyk-docs/content/tyk-apis/tyk-apis.md
+++ b/tyk-docs/content/tyk-apis/tyk-apis.md
@@ -7,6 +7,10 @@ url: "/tyk-apis"
 
 Tyks own APIs allow you to access to the following
 
+## Tyk Postman Collections
+
+We have a [Postman public workspace](https://www.postman.com/tyk-technologies/workspace/379673ec-4cc5-4b8e-bef5-8a6a988071cb/overview) where you can view, fork and test our Gateway and Dashboard APIs. 
+
 ## [Tyk Gateway API](/docs/tyk-gateway-api/)
 
 This API is very small, and has no granular permissions system. It is used purely for internal automation and integration. It offers the following endpoints:
@@ -27,7 +31,3 @@ The Dashboard Admin API is a special bootstrapping API that can be used to set u
 ## [Tyk Portal API](/docs/tyk-portal-api/)
 
 The Tyk Portal API covers all available endpoints for your developer portal.
-
-## Tyk Postman Collections
-
-We have a [Postman public workspace](https://www.postman.com/tyk-technologies/workspace/379673ec-4cc5-4b8e-bef5-8a6a988071cb/overview) where you can view, fork and test our Gateway and Dashboard APIs. 

--- a/tyk-docs/content/tyk-apis/tyk-apis.md
+++ b/tyk-docs/content/tyk-apis/tyk-apis.md
@@ -5,7 +5,14 @@ menu: none
 url: "/tyk-apis"
 ---
 
-Tyk's own APIs allow you to access to the following
+We have our own APIs and a Postman public workspace.
+
+## Tyk Postman Collections
+
+We have a Postman public workspace where you can view, fork and test our Gateway and Dashboard APIs.
+
+
+{{< button_left href="https://www.postman.com/tyk-technologies/workspace/379673ec-4cc5-4b8e-bef5-8a6a988071cb/overview" target="_blank" color="green" content="Tyk Postman Collections">}}
 
 ## [Tyk Gateway API](/docs/tyk-gateway-api/)
 
@@ -16,25 +23,18 @@ This API is very small, and has no granular permissions system. It is used purel
 * Hot reloads / reloading a cluster configuration
 * OAuth client creation (only when not using the Dashboard)
 
-Our Gateway API is available as a [Postman Collection](#tyk-postman-collections) that you can use to test our Gateway endpoints.
+This allows you to test, connect to and control your Gateway.
 
 ## [Tyk Dashboard API](/docs/tyk-dashboard-api/)
 
-The Tyk Dashboard API allows much more fine-grained, secure and multi-user access to your Tyk cluster, and should be used to manage a database-backed Tyk node. The Tyk Dashboard API works seamlessly with the Tyk Dashboard (the two come bundled together).
+The Tyk Dashboard API allows much more fine-grained, secure and multi-user access to your Tyk cluster, and should be used to manage a database-backed Tyk node. The Tyk Dashboard API works seamlessly with the Tyk Dashboard.
 
-Our Dashboard API is available as a [Postman Collection](#tyk-postman-collections) that you can use to test our Dashboard endpoints.
 
 ## [Tyk Dashboard Admin API](/docs/dashboard-admin-api/)
 
-The Dashboard Admin API is a special bootstrapping API that can be used to set up and provision a Tyk Dashboard instance without the command line and is used by the bootstrap scripts that come with a Tyk On-Premises installation.
+The Dashboard Admin API is a special bootstrapping API that can be used to set up and provision a Tyk Dashboard instance without the command line and is used by the bootstrap scripts that come with a Tyk On-Premises installation. There is no public Postman collection for this API.
 
 ## [Tyk Portal API](/docs/tyk-portal-api/)
 
 The Tyk Portal API covers all available endpoints for your developer portal.
 
-## Tyk Postman Collections
-
-We have a Postman public workspace where you can view, fork and test our Gateway and Dashboard APIs.
-
-
-{{< button_left href="https://www.postman.com/tyk-technologies/workspace/379673ec-4cc5-4b8e-bef5-8a6a988071cb/overview" target="_blank" color="green" content="Tyk Postman Collections">}}

--- a/tyk-docs/content/tyk-apis/tyk-apis.md
+++ b/tyk-docs/content/tyk-apis/tyk-apis.md
@@ -5,11 +5,7 @@ menu: none
 url: "/tyk-apis"
 ---
 
-Tyks own APIs allow you to access to the following
-
-## Tyk Postman Collections
-
-We have a [Postman public workspace](https://www.postman.com/tyk-technologies/workspace/379673ec-4cc5-4b8e-bef5-8a6a988071cb/overview) where you can view, fork and test our Gateway and Dashboard APIs. 
+Tyk's own APIs allow you to access to the following
 
 ## [Tyk Gateway API](/docs/tyk-gateway-api/)
 
@@ -20,9 +16,13 @@ This API is very small, and has no granular permissions system. It is used purel
 * Hot reloads / reloading a cluster configuration
 * OAuth client creation (only when not using the Dashboard)
 
+Our Gateway API is available as a [Postman Collection](#tyk-postman-collections) that you can use to test our Gateway endpoints.
+
 ## [Tyk Dashboard API](/docs/tyk-dashboard-api/)
 
 The Tyk Dashboard API allows much more fine-grained, secure and multi-user access to your Tyk cluster, and should be used to manage a database-backed Tyk node. The Tyk Dashboard API works seamlessly with the Tyk Dashboard (the two come bundled together).
+
+Our Dashboard API is available as a [Postman Collection](#tyk-postman-collections) that you can use to test our Dashboard endpoints.
 
 ## [Tyk Dashboard Admin API](/docs/dashboard-admin-api/)
 
@@ -31,3 +31,10 @@ The Dashboard Admin API is a special bootstrapping API that can be used to set u
 ## [Tyk Portal API](/docs/tyk-portal-api/)
 
 The Tyk Portal API covers all available endpoints for your developer portal.
+
+## Tyk Postman Collections
+
+We have a Postman public workspace where you can view, fork and test our Gateway and Dashboard APIs.
+
+
+{{< button_left href="https://www.postman.com/tyk-technologies/workspace/379673ec-4cc5-4b8e-bef5-8a6a988071cb/overview" target="_blank" color="green" content="Tyk Postman Collections">}}

--- a/tyk-docs/content/tyk-apis/tyk-dashboard-api/tyk-dashboard-api.md
+++ b/tyk-docs/content/tyk-apis/tyk-dashboard-api/tyk-dashboard-api.md
@@ -7,8 +7,6 @@ menu:
 weight: 3
 url: "/tyk-dashboard-api"
 type: "swagger-ui"
-data-postman-var-1: "17155284-85d19715-5b29-46bd-b6ef-e211ccd78b43"
-data-postman-collection-url: "entityId=17155284-85d19715-5b29-46bd-b6ef-e211ccd78b43&entityType=collection&workspaceId=379673ec-4cc5-4b8e-bef5-8a6a988071cb"
 swagger: "/docs/others/dashboard-swagger.yml"
 aliases:
     - /tyk-rest-api/

--- a/tyk-docs/content/tyk-apis/tyk-gateway-api/tyk-gateway-api.md
+++ b/tyk-docs/content/tyk-apis/tyk-gateway-api/tyk-gateway-api.md
@@ -7,8 +7,6 @@ menu:
 weight: 3
 url: "/tyk-gateway-api"
 type: "swagger-ui"
-data_postman_var-1: "17155284-f9cc8548-5c01-4e52-98b8-2d9ac3e77c69"
-data_postman_collection_url: "entityId=17155284-f9cc8548-5c01-4e52-98b8-2d9ac3e77c69&entityType=collection&workspaceId=379673ec-4cc5-4b8e-bef5-8a6a988071cb"
 swagger: "/docs/others/gateway-swagger.yml"
 aliases:
     - /tyk-rest-api/

--- a/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
+++ b/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
@@ -1,17 +1,5 @@
 {{ define "content" }}
-<div class="postman-run-button"
-data-postman-action="collection/fork"
-data-postman-var-1="{{ .Params.data_postman_var_1}}"
-data-postman-collection-url="{{ .Params.data_postman_collection_url}}"></div>
-<script type="text/javascript">
-  (function (p,o,s,t,m,a,n) {
-    !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });
-    !o.getElementById(s+t) && o.getElementsByTagName("head")[0].appendChild((
-      (n = o.createElement("script")),
-      (n.id = s+t), (n.async = 1), (n.src = m), n
-    ));
-  }(window, document, "_pm", "PostmanRunObject", "https://run.pstmn.io/button.js"));
-</script>
+<a href="https://www.postman.com/tyk-technologies/workspace/379673ec-4cc5-4b8e-bef5-8a6a988071cb/overview" target="_blank">Visit our Postman Collections</a>
 <div id="swagger-ui">Loading...</div>
 <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.20.3/swagger-ui.css">
 <script src="https://unpkg.com/swagger-ui-dist@3.20.3/swagger-ui-standalone-preset.js"></script>


### PR DESCRIPTION
Postman buttons no longer work properly after the addition of the Dashboard API. Changing to a link to the collections as a whole to replace the buttons.