### PR TITLE
Revert "more search results"

### DIFF
--- a/tyk-docs/static/js/docs-search.js
+++ b/tyk-docs/static/js/docs-search.js
@@ -13,8 +13,4 @@
   inputSelector: '#searchbox input',
   // Set debug to true to inspect the dropdown
   // debug: true,
-  algoliaOptions: {
-    advancedSyntax: true,
-    hitsPerPage: 10,
-  }
 });


### PR DESCRIPTION
Reverts TykTechnologies/tyk-docs#2022. Showing 10 results doesn't work. We need to find a way of paginating results