### PR TITLE
Add text below heading for search purposes.

### DIFF
--- a/tyk-docs/content/planning-for-production/database-settings/mongodb-sizing.md
+++ b/tyk-docs/content/planning-for-production/database-settings/mongodb-sizing.md
@@ -41,5 +41,7 @@ Request_logs_index ( 30% * (1GB * 7) ) + aggregated(3month * 30MB) ~= 2.1GB + 90
 
 In addition to storing working data in memory, MongoDB also requires space for some internal data structures. In general multiplying the resulting number by 2x should be enough. In the above example, your MongoDB server should have around 4.4GB of available memory.
 
-## Database Storage Calculator
+## MongoDB Database Storage Calculator
+You can calculate your MongoDB storage requirements by entering your known values in the middle section of the calculator settings below:
+
 {{< database-calculator >}}

--- a/tyk-docs/content/planning-for-production/database-settings/postgresql.md
+++ b/tyk-docs/content/planning-for-production/database-settings/postgresql.md
@@ -68,5 +68,7 @@ So for 1 million requests per day, it will generate 1KB * 1M request stats (1GB)
 
 Per month: 30GB request logs + 30MB aggregate logs
 
-## Database Storage Calculator
+## PostgreSQL Database Storage Calculator
+You can calculate your PostgreSQL storage requirements by entering your known values in the middle section of the calculator settings below:
+
 {{< database-calculator >}}

--- a/tyk-docs/content/planning-for-production/redis-sizing.md
+++ b/tyk-docs/content/planning-for-production/redis-sizing.md
@@ -23,5 +23,7 @@ MDCB and Multi-Cloud clients - the Gateways write the data to a temporary Redis 
 {{< /note >}}
 
 ## Redis RAM Calculator
+You can calculate your Redis RAM requirements by entering your known values in the middle section of the calculator settings below:
+
 {{< redis-calculator >}}
 


### PR DESCRIPTION
We needed to add text below the heading to enable the search crawler to pick up the heading.