### PR TITLE
Added new CI job to check for broken Hugo links

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -16,4 +16,4 @@ jobs:
           commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
           echo "Base PR commit: $commit_before_pull_request"
           
-          cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request
+          cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request || exit 1

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,0 +1,17 @@
+name: Link Checker
+on:
+  pull_request:
+
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+      - name: Check broken links
+        run: |
+          pull_request_branch=$(jq -r ".pull_request.head.ref" "$GITHUB_EVENT_PATH")
+          commit_before_pull_request=$(git log -1 --format=%P $pull_request_branch)
+
+          cd tyk-docs && bash ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -13,6 +13,6 @@ jobs:
         run: |
           base_branch=$(jq -r ".pull_request.base.ref" "$GITHUB_EVENT_PATH")
           git fetch origin $base_branch:refs/remotes/origin/$base_branch
-          commit_before_pull_request=$(git merge-base $base_branch HEAD)
+          commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
           
           cd tyk-docs && bash ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -16,4 +16,4 @@ jobs:
           commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
           echo "Base PR commit: $commit_before_pull_request"
           
-          cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request
+          # cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -15,4 +15,4 @@ jobs:
           git fetch origin $base_branch:refs/remotes/origin/$base_branch
           commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
           
-          cd tyk-docs && bash ../scripts/urlcheck.sh $commit_before_pull_request
+          cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -6,6 +6,10 @@ jobs:
   link-checker:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.92.1'
       - uses: actions/checkout@v3
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -12,6 +12,6 @@ jobs:
       - name: Check broken links
         run: |
           base_branch=$(jq -r ".pull_request.base.ref" "$GITHUB_EVENT_PATH")
-          commit_before_pull_request=$(git merge-base $base_branch HEAD)
+          commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
           
           cd tyk-docs && bash ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -20,4 +20,4 @@ jobs:
           commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
           echo "Base PR commit: $commit_before_pull_request"
           
-          cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request || exit 1
+          cd tyk-docs && bash ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -13,6 +13,7 @@ jobs:
         run: |
           base_branch=$(jq -r ".pull_request.base.ref" "$GITHUB_EVENT_PATH")
           git fetch origin $base_branch:refs/remotes/origin/$base_branch
+          git merge-base origin/$base_branch HEAD
           commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
           echo "Base PR commit: $commit_before_pull_request"
           

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -17,4 +17,6 @@ jobs:
           commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
           echo "Base PR commit: $commit_before_pull_request"
           
+          exit 0
+          
           # cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -12,9 +12,8 @@ jobs:
       - name: Check broken links
         run: |
           base_branch=$(jq -r ".pull_request.base.ref" "$GITHUB_EVENT_PATH")
-          git fetch origin $base_branch:refs/remotes/origin/$base_branch
-          git merge-base origin/$base_branch HEAD
-          commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
+          ! git fetch origin $base_branch:refs/remotes/origin/$base_branch
+          commit_before_pull_request=$(! git merge-base origin/$base_branch HEAD)
           echo "Base PR commit: $commit_before_pull_request"
           
           exit 0

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -11,7 +11,7 @@ jobs:
           submodules: true  # Fetch Hugo themes (true OR recursive)
       - name: Check broken links
         run: |
-          pull_request_branch=$(jq -r ".pull_request.head.ref" "$GITHUB_EVENT_PATH")
-          commit_before_pull_request=$(git log -1 --format=%P $pull_request_branch)
-
+          base_branch=$(jq -r ".pull_request.base.ref" "$GITHUB_EVENT_PATH")
+          commit_before_pull_request=$(git merge-base $base_branch HEAD)
+          
           cd tyk-docs && bash ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -9,13 +9,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0
       - name: Check broken links
         run: |
           base_branch=$(jq -r ".pull_request.base.ref" "$GITHUB_EVENT_PATH")
-          ! git fetch origin $base_branch:refs/remotes/origin/$base_branch
-          commit_before_pull_request=$(! git merge-base origin/$base_branch HEAD)
+          commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
           echo "Base PR commit: $commit_before_pull_request"
           
-          exit 0
-          
-          # cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request
+          cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -12,6 +12,7 @@ jobs:
       - name: Check broken links
         run: |
           base_branch=$(jq -r ".pull_request.base.ref" "$GITHUB_EVENT_PATH")
-          commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
+          git fetch origin $base_branch:refs/remotes/origin/$base_branch
+          commit_before_pull_request=$(git merge-base $base_branch HEAD)
           
           cd tyk-docs && bash ../scripts/urlcheck.sh $commit_before_pull_request

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -14,5 +14,6 @@ jobs:
           base_branch=$(jq -r ".pull_request.base.ref" "$GITHUB_EVENT_PATH")
           git fetch origin $base_branch:refs/remotes/origin/$base_branch
           commit_before_pull_request=$(git merge-base origin/$base_branch HEAD)
+          echo "Base PR commit: $commit_before_pull_request"
           
           cd tyk-docs && bash -x ../scripts/urlcheck.sh $commit_before_pull_request

--- a/scripts/urlcheck.sh
+++ b/scripts/urlcheck.sh
@@ -1,3 +1,5 @@
+set -e
+
 CURRENT_COMMIT=$(git rev-parse HEAD)
 hugo
 cp ./public/urlcheck.json /tmp/urlcheck.new.json
@@ -6,7 +8,7 @@ hugo
 cp ./public/urlcheck.json /tmp/urlcheck.prev.json
 git checkout $CURRENT_COMMIT
 NEW_URLS=$(cat /tmp/urlcheck.new.json | jq -r '.path')
-PREV_URLS=$(cat /tmp/urlcheck.pref.json | jq -r '.path')
+PREV_URLS=$(cat /tmp/urlcheck.prev.json | jq -r '.path')
 BROKEN_URLS=$(comm -3 -1 <(echo $NEW_URLS | sort) <(echo $PREV_URLS | sort))
 
 if [ -n "$BROKEN_URL" ]; then

--- a/scripts/urlcheck.sh
+++ b/scripts/urlcheck.sh
@@ -3,10 +3,10 @@ set -e
 CURRENT_COMMIT=$(git rev-parse HEAD)
 hugo
 cp ./public/urlcheck.json /tmp/urlcheck.new.json
-git checkout $1 || true
+git checkout $1
 hugo
 cp ./public/urlcheck.json /tmp/urlcheck.prev.json
-git checkout $CURRENT_COMMIT
+git checkout - 
 NEW_URLS=$(cat /tmp/urlcheck.new.json | jq -r '.path')
 PREV_URLS=$(cat /tmp/urlcheck.prev.json | jq -r '.path')
 BROKEN_URLS=$(comm -3 -1 <(echo $NEW_URLS | sort) <(echo $PREV_URLS | sort))

--- a/scripts/urlcheck.sh
+++ b/scripts/urlcheck.sh
@@ -13,7 +13,7 @@ NEW_URLS=$(cat /tmp/urlcheck.new.json | jq -r '.path')
 PREV_URLS=$(cat /tmp/urlcheck.prev.json | jq -r '.path')
 BROKEN_URLS=$(comm -3 -1 <(echo $NEW_URLS | sort) <(echo $PREV_URLS | sort))
 
-if [ -n "$BROKEN_URL" ]; then
+if [ -n "$BROKEN_URLS" ]; then
   echo "The following links are broken"
   echo $BROKEN_URLS
   exit 1

--- a/scripts/urlcheck.sh
+++ b/scripts/urlcheck.sh
@@ -1,0 +1,16 @@
+CURRENT_COMMIT=$(git rev-parse HEAD)
+hugo
+cp ./public/urlcheck.json /tmp/urlcheck.new.json
+git checkout $1 || true
+hugo
+cp ./public/urlcheck.json /tmp/urlcheck.prev.json
+git checkout $CURRENT_COMMIT
+NEW_URLS=$(cat /tmp/urlcheck.new.json | jq -r '.path')
+PREV_URLS=$(cat /tmp/urlcheck.pref.json | jq -r '.path')
+BROKEN_URLS=$(comm -3 -1 <(echo $NEW_URLS | sort) <(echo $PREV_URLS | sort))
+
+if [ -n "$BROKEN_URL" ]; then
+  echo "The following links are broken"
+  echo $BROKEN_URLS
+  exit 1
+fi

--- a/scripts/urlcheck.sh
+++ b/scripts/urlcheck.sh
@@ -3,10 +3,12 @@ set -e
 CURRENT_COMMIT=$(git rev-parse HEAD)
 hugo
 cp ./public/urlcheck.json /tmp/urlcheck.new.json
+rm -rf public/*
 git checkout $1
 hugo
 cp ./public/urlcheck.json /tmp/urlcheck.prev.json
-git checkout - 
+rm -rf public/*
+git checkout -
 NEW_URLS=$(cat /tmp/urlcheck.new.json | jq -r '.path')
 PREV_URLS=$(cat /tmp/urlcheck.prev.json | jq -r '.path')
 BROKEN_URLS=$(comm -3 -1 <(echo $NEW_URLS | sort) <(echo $PREV_URLS | sort))

--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -32,3 +32,12 @@ canonifyurls = "false"
     ordered = true
 [frontmatter]
 lastmod = ["lastmod", ":git", "date", "publishDate"]
+
+[outputFormats.urlcheck]
+   mediaType = "application/json"
+   baseName = "urlcheck"
+   isPlainText = true
+   notAlternative = true
+
+ [outputs]
+   home = ["HTML","urlcheck"]

--- a/tyk-docs/content/tyk-cloud/tyk-cloud.md
+++ b/tyk-docs/content/tyk-cloud/tyk-cloud.md
@@ -7,7 +7,7 @@ weight: 10
 menu:
     main:
         parent: "API Management"
-url: /tyk-cloud/
+url: /tyk-cloud2/
 ---
 
 The new Tyk Cloud platform allows you to quickly setup the full Tyk Enterprise API Management platform by simply choosing the regions where you want to locate your Tyk Gateways and where you wish your data to reside.

--- a/tyk-docs/content/upgrading-tyk/upgrading-tyk.md
+++ b/tyk-docs/content/upgrading-tyk/upgrading-tyk.md
@@ -4,7 +4,7 @@ weight: 251
 menu:
     main:
         parent: "FAQ"
-url: "/upgrading-tyk1"
+url: "/upgrading-tyk"
 ---
 
 ## Introduction

--- a/tyk-docs/content/upgrading-tyk/upgrading-tyk.md
+++ b/tyk-docs/content/upgrading-tyk/upgrading-tyk.md
@@ -4,7 +4,7 @@ weight: 251
 menu:
     main:
         parent: "FAQ"
-url: "/upgrading-tyk"
+url: "/upgrading-tyk1"
 ---
 
 ## Introduction

--- a/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
+++ b/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
@@ -1,0 +1,10 @@
+{{- range $key, $value := .Site.RegularPages }}
+   {{- $path := .File.Path }}
+   {{- if (len $value.Aliases) }}
+     {{- printf "{\"path\":\"%s\", \"file\": \"./content/%s\"}\n" $value.RelPermalink $path}}
+   {{- end }}
+   {{- range $value.Aliases }}
+     {{- $from := printf "%s" . }}
+     {{- printf "{\"path\":\"/docs%s\", \"file\":\"./content/%s\"}\n" $from $path}}
+   {{- end }}
+ {{- end }}

--- a/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
+++ b/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
@@ -1,8 +1,6 @@
 {{- range $key, $value := .Site.RegularPages }}
    {{- $path := .File.Path }}
-   {{- if (len $value.Aliases) }}
-     {{- printf "{\"path\":\"%s\", \"file\": \"./content/%s\"}\n" $value.RelPermalink $path}}
-   {{- end }}
+   {{- printf "{\"path\":\"%s\", \"file\": \"./content/%s\"}\n" $value.RelPermalink $path}}
    {{- range $value.Aliases }}
      {{- $from := printf "%s" . }}
      {{- printf "{\"path\":\"/docs%s\", \"file\":\"./content/%s\", \"alias\":true}\n" $from $path}}

--- a/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
+++ b/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
@@ -5,6 +5,6 @@
    {{- end }}
    {{- range $value.Aliases }}
      {{- $from := printf "%s" . }}
-     {{- printf "{\"path\":\"/docs%s\", \"file\":\"./content/%s\"}\n" $from $path}}
+     {{- printf "{\"path\":\"/docs%s\", \"file\":\"./content/%s\", \"alias\":true}\n" $from $path}}
    {{- end }}
  {{- end }}


### PR DESCRIPTION
New job will compare URL generated by Hugo (including all aliases), before and after latest PR change, and if URLs are missing will fail, with list of missing URLs.

You can also run it manually by running:

`../scripts/urlchecker.sh <prev-commit-sha>`