### PR TITLE
Merging to release-4.3: Changelog for MDCB 2.0.4 release (#2107)

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -120,3 +120,4 @@
 /docs/planning-for-production/redis-mongodb/  /docs/planning-for-production/database-settings/
 /docs/tyk-multi-data-centre/setup-master-data-centre/  /docs/tyk-multi-data-centre/setup-controller-data-centre/
 /docs/tyk-multi-data-centre/setup-slave-data-centres/  /docs/tyk-multi-data-centre/setup-worker-data-centres/
+https://tyk.io/docs/release-notes/mdcb/ https://tyk.io/docs/release-notes/mdcb-2.0/

--- a/tyk-docs/content/release-notes/mdcb-2.0.md
+++ b/tyk-docs/content/release-notes/mdcb-2.0.md
@@ -1,11 +1,20 @@
 ---
-title: MDCB
+title: MDCB v2.0
 menu:
   main:
     parent: "Release Notes"
 weight: 255
-url: "/release-notes/mdcb"
 ---
+## 2.0.4
+Release date: 2022-12-06
+
+### Added
+- Changes in the API definition introduced in Tyk Gateway 4.3 
+- Update to Go 1.16 
+- Update the embedded Pump to the latest (v1.7.0)
+
+### Fixed
+- Fixed a minor security issue when logging Mongo URL 
 
 ## 2.0.3
 Release date: 2022-08-12


### PR DESCRIPTION
Changelog for MDCB 2.0.4 release (#2107)

* adding changelog for mdcb 2.0.4 release

* renaming mdcb page

* removing url from mdcb page

* Removed mdcb directory and put mdcb in the list like tyk and dashboard

* updated the redirect due to file name change

Co-authored-by: Yaara <3155222+letzya@users.noreply.github.com>