### PR TITLE
Merging to release-4.3: Fixing display of UDG docs on GQL datasource (#2147)

### DIFF
--- a/tyk-docs/content/universal-data-graph/datasources/graphql.md
+++ b/tyk-docs/content/universal-data-graph/datasources/graphql.md
@@ -3,7 +3,7 @@ title: "GraphQL Datasource"
 date: 2020-06-03
 menu:
   main:
-    parent: "UDG Datasources"
+    parent: "UDG DataSources"
 weight: 2
 aliases:
     - /universal-data-graph/data-sources/graphql


### PR DESCRIPTION
Fixing display of UDG docs on GQL datasource (#2147)

Quick fix to move GraphQL datasource page to the correct spot in the
docs hierarchy