### PR TITLE
Fix compare button broken link

### DIFF
--- a/tyk-docs/content/content.md
+++ b/tyk-docs/content/content.md
@@ -30,7 +30,7 @@ url: /
 
 {{< /grid >}}
 
-{{< button href="/apim/" color="green" content="Compare" >}}
+{{< button href="/docs/apim/" color="green" content="Compare" >}}
 
 ## The Tyk Stack
 

--- a/tyk-docs/content/content.md
+++ b/tyk-docs/content/content.md
@@ -30,7 +30,7 @@ url: /
 
 {{< /grid >}}
 
-{{< button href="/apim" color="green" content="Compare" >}}
+{{< button href="/apim/" color="green" content="Compare" >}}
 
 ## The Tyk Stack
 

--- a/tyk-docs/content/content.md
+++ b/tyk-docs/content/content.md
@@ -74,7 +74,7 @@ The Tyk Identity Broker (TIB) is a microservice portal that provides a bridge be
 
 {{< /grid >}}
 
-{{< button href="/getting-started/key-concepts/" color="red" content="Tyk Concepts" >}}
+{{< button href="/docs/getting-started/key-concepts/" color="red" content="Tyk Concepts" >}}
 
 ## Feature Setups
 
@@ -106,6 +106,6 @@ Log into your Tyk Dashboard and Portal with your existing IDP.
 
 {{< /grid >}}
 
-{{< button href="/basic-config-and-security/" color="black" content="More Tyk Configuration" >}}
+{{< button href="/docs/basic-config-and-security/" color="black" content="More Tyk Configuration" >}}
 
 </div>

--- a/tyk-docs/content/content.md
+++ b/tyk-docs/content/content.md
@@ -30,7 +30,7 @@ url: /
 
 {{< /grid >}}
 
-{{< button href="/docs/apim/" color="green" content="Compare" >}}
+{{< button href="/docs/apim" color="green" content="Compare" >}}
 
 ## The Tyk Stack
 


### PR DESCRIPTION
When the compare button is clicked it takes you to https://tyk.io/apim. instead of https://tyk.io/docs/apim/. I have fixed this issue so that you can be directed to correct Url.