### PR TITLE
add docs prefix to button element to resolve url

### DIFF
--- a/tyk-docs/themes/tykio/layouts/shortcodes/button.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/button.html
@@ -1,1 +1,1 @@
-<center><a href="{{.Get "href"}}" class="button center button-{{.Get "color"}}">{{.Get "content"}}</a></center>
+<center><a href="/docs/{{.Get "href"}}" class="button center button-{{.Get "color"}}">{{.Get "content"}}</a></center>

--- a/tyk-docs/themes/tykio/layouts/shortcodes/button.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/button.html
@@ -1,1 +1,1 @@
-<center><a href="/docs{{.Get "href"}}" class="button center button-{{.Get "color"}}">{{.Get "content"}}</a></center>
+<center><a href="{{strings.TrimPrefix "/docs" (.Get "href") | relURL }}" class="button center button-{{.Get "color"}}">{{.Get "content"}}</a></center>

--- a/tyk-docs/themes/tykio/layouts/shortcodes/button.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/button.html
@@ -1,1 +1,1 @@
-<center><a href="/docs/{{.Get "href"}}" class="button center button-{{.Get "color"}}">{{.Get "content"}}</a></center>
+<center><a href="/docs{{.Get "href"}}" class="button center button-{{.Get "color"}}">{{.Get "content"}}</a></center>


### PR DESCRIPTION
When the compare button is clicked it takes you to https://tyk.io/apim. instead of https://tyk.io/docs/apim/. I have fixed this issue so that you can be directed to correct Url.