### PR TITLE
[TT-6013] Include note to substitute ubuntu release

### DIFF
--- a/tyk-docs/content/tyk-on-premises/debian-ubuntu/analytics-pump.md
+++ b/tyk-docs/content/tyk-on-premises/debian-ubuntu/analytics-pump.md
@@ -98,9 +98,9 @@ sudo apt-get install -y apt-transport-https
 Now lets add the required repos and update again (notice the `-a` flag in the second Tyk commands - this is important!):
 
 ```bash
-echo "deb https://packagecloud.io/tyk/tyk-pump/ubuntu/ <ubuntu-release>" | sudo tee /etc/apt/sources.list.d/tyk_tyk-pump.list
+echo "deb https://packagecloud.io/tyk/tyk-pump/ubuntu/ bionic main" | sudo tee /etc/apt/sources.list.d/tyk_tyk-pump.list
 
-echo "deb-src https://packagecloud.io/tyk/tyk-pump/ubuntu/ <ubuntu-release>" | sudo tee -a /etc/apt/sources.list.d/tyk_tyk-pump.list
+echo "deb-src https://packagecloud.io/tyk/tyk-pump/ubuntu/ bionic main" | sudo tee -a /etc/apt/sources.list.d/tyk_tyk-pump.list
 
 sudo apt-get update
 ```
@@ -111,7 +111,7 @@ sudo apt-get update
 
 
 
-Substitute your particular Ubuntu release, e.g. Bionic.
+Substitute your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
 
 {{< /note >}}
 

--- a/tyk-docs/content/tyk-on-premises/debian-ubuntu/analytics-pump.md
+++ b/tyk-docs/content/tyk-on-premises/debian-ubuntu/analytics-pump.md
@@ -111,7 +111,7 @@ sudo apt-get update
 
 
 
-Substitute your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
+`bionic` is the code name for Ubuntu 18.04. Please substitute it with your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
 
 {{< /note >}}
 

--- a/tyk-docs/content/tyk-on-premises/debian-ubuntu/analytics-pump.md
+++ b/tyk-docs/content/tyk-on-premises/debian-ubuntu/analytics-pump.md
@@ -111,7 +111,7 @@ sudo apt-get update
 
 
 
-`bionic` is the code name for Ubuntu 18.04. Please substitute it with your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
+`bionic` is the code name for Ubuntu 18.04. Please substitute it with your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. `focal`.
 
 {{< /note >}}
 

--- a/tyk-docs/content/tyk-on-premises/debian-ubuntu/dashboard.md
+++ b/tyk-docs/content/tyk-on-premises/debian-ubuntu/dashboard.md
@@ -118,7 +118,7 @@ sudo apt-get update
 
 
 
-`bionic` is the code name for Ubuntu 18.04. Please substitute it with your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
+`bionic` is the code name for Ubuntu 18.04. Please substitute it with your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. `focal`.
 
 {{< /note >}}
 

--- a/tyk-docs/content/tyk-on-premises/debian-ubuntu/dashboard.md
+++ b/tyk-docs/content/tyk-on-premises/debian-ubuntu/dashboard.md
@@ -118,7 +118,7 @@ sudo apt-get update
 
 
 
-Substitute your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
+`bionic` is the code name for Ubuntu 18.04. Please substitute it with your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
 
 {{< /note >}}
 

--- a/tyk-docs/content/tyk-on-premises/debian-ubuntu/dashboard.md
+++ b/tyk-docs/content/tyk-on-premises/debian-ubuntu/dashboard.md
@@ -105,9 +105,9 @@ sudo apt-get install -y apt-transport-https
 Now lets add the required repos and update again (notice the `-a` flag in the second Tyk commands - this is important!):
 
 ```bash
-echo "deb https://packagecloud.io/tyk/tyk-dashboard/ubuntu/ <ubuntu-release>" | sudo tee /etc/apt/sources.list.d/tyk_tyk-dashboard.list
+echo "deb https://packagecloud.io/tyk/tyk-dashboard/ubuntu/ bionic main" | sudo tee /etc/apt/sources.list.d/tyk_tyk-dashboard.list
 
-echo "deb-src https://packagecloud.io/tyk/tyk-dashboard/ubuntu/ <ubuntu-release>" | sudo tee -a /etc/apt/sources.list.d/tyk_tyk-dashboard.list
+echo "deb-src https://packagecloud.io/tyk/tyk-dashboard/ubuntu/ bionic main" | sudo tee -a /etc/apt/sources.list.d/tyk_tyk-dashboard.list
 
 sudo apt-get update
 ```
@@ -118,7 +118,7 @@ sudo apt-get update
 
 
 
-Substitute your particular Ubuntu release, e.g. Bionic.
+Substitute your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
 
 {{< /note >}}
 

--- a/tyk-docs/content/tyk-on-premises/debian-ubuntu/gateway.md
+++ b/tyk-docs/content/tyk-on-premises/debian-ubuntu/gateway.md
@@ -122,7 +122,7 @@ deb-src https://packagecloud.io/tyk/tyk-gateway/ubuntu/ bionic main
 
 
 
-Substitute your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
+`bionic` is the code name for Ubuntu 18.04. Please substitute it with your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
 
 {{< /note >}}
 

--- a/tyk-docs/content/tyk-on-premises/debian-ubuntu/gateway.md
+++ b/tyk-docs/content/tyk-on-premises/debian-ubuntu/gateway.md
@@ -116,6 +116,15 @@ Create a file `/etc/apt/sources.list.d/tyk_tyk-gateway.list` with the following 
 deb https://packagecloud.io/tyk/tyk-gateway/ubuntu/ bionic main
 deb-src https://packagecloud.io/tyk/tyk-gateway/ubuntu/ bionic main
 ```
+{{< note success >}}
+
+**Note**
+
+
+
+Substitute your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
+
+{{< /note >}}
 
 Now you can refresh the list of packages with:
 ```bash

--- a/tyk-docs/content/tyk-on-premises/debian-ubuntu/gateway.md
+++ b/tyk-docs/content/tyk-on-premises/debian-ubuntu/gateway.md
@@ -122,7 +122,7 @@ deb-src https://packagecloud.io/tyk/tyk-gateway/ubuntu/ bionic main
 
 
 
-`bionic` is the code name for Ubuntu 18.04. Please substitute it with your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. focal.
+`bionic` is the code name for Ubuntu 18.04. Please substitute it with your particular [ubuntu release](https://wiki.ubuntu.com/Releases), e.g. `focal`.
 
 {{< /note >}}
 


### PR DESCRIPTION
Add a note about substituting ubuntu release in repo source file

Replaces [previous PR](https://github.com/TykTechnologies/tyk-docs/pull/2028) since the files to be changed now under a new file structure