### PR TITLE
Merging to release-4.3: Update Helm Chart docs for tyk-helm-chart release v0.13.2 (#2185)

### DIFF
--- a/tyk-docs/content/tyk-oss/ce-helm-chart.md
+++ b/tyk-docs/content/tyk-oss/ce-helm-chart.md
@@ -104,13 +104,7 @@ helm install redis tyk-helm/simple-redis -n tyk
 helm install tyk-ce tyk-helm/tyk-headless -f values.yaml -n tyk
  ```
 
-Please note that by default, Gateway runs as DaemonSet. If you are using more than a Node, please update Gateway kind to `Deployment` because multiple instances of headless gateways won't sync API Definition.
-
-To configure Gateway kind, update `.gateway.kind` field in the `values.yaml` to `Deployment`,
-Alternatively, you can use `--set gateway.kind=Deployment` while doing helm install.
-```bash
-helm install tyk-ce tyk-helm/tyk-headless --set gateway.kind=Deployment -n tyk
-```
+Please note that by default, Gateway runs as `Deployment` with `ReplicaCount` is 1. You should not update this part because multiple instances of OSS gateways won't sync the API Definition.
 
 #### Installation Video
 

--- a/tyk-docs/content/tyk-self-managed/tyk-helm-chart.md
+++ b/tyk-docs/content/tyk-self-managed/tyk-helm-chart.md
@@ -144,9 +144,8 @@ or use `--set dash.license={YOUR-LICENSE_KEY}` with the `helm install` command.
 
 
 Tyk Self-Managed licensing allow for different numbers of Gateway nodes to connect to a single Dashboard instance.
-To ensure that your Gateway pods will not scale beyond your license allowance, change the Gateway's resource kind from *DaemonSet* to *Deployment*
-and the replica count to your license node limit. For example, use the following options for a single node license:
-`--set gateway.kind=Deployment --set gateway.replicaCount=1` in your `values.yaml` file or in the Helm install command.
+To ensure that your Gateway pods will not scale beyond your license allowance, please ensure that the Gateway's resource kind is `Deployment`
+and the replica count to your license node limit. By default, the chart is configured to work with a single node license: `gateway.kind=Deployment` and `gateway.replicaCount=1`.
 
 {{< note success >}}
 **Please Note**


### PR DESCRIPTION
Update Helm Chart docs for tyk-helm-chart release v0.13.2 (#2185)

Update Helm Chart docs to reflect latest settings
(https://github.com/TykTechnologies/tyk-helm-chart/pull/252):
- Default deployment kind=Deployment, ReplicaCount=1