### PR TITLE
Corrected typo in hyperlink

### DIFF
--- a/tyk-docs/content/tyk-multi-data-centre/setup-worker-data-centres.md
+++ b/tyk-docs/content/tyk-multi-data-centre/setup-worker-data-centres.md
@@ -13,7 +13,7 @@ aliases:
 
 ## Overview
 
-You may configure an unlimited number of [Tyk Data Planes]({{< ref "tyk-multi-data-centre/mdcb-components.md#data-plane" >}}) containing Worker Gateways for ultimate High Availablity (HA). We recommend that you deploy your worker gateways as close to your upstream services as possible in order to reduce latency.
+You may configure an unlimited number of [Tyk Data Planes]({{< ref "tyk-multi-data-centre/mdcb-components/#data-plane" >}}) containing Worker Gateways for ultimate High Availablity (HA). We recommend that you deploy your worker gateways as close to your upstream services as possible in order to reduce latency.
 
 It is a requirement that all your Worker Gateways in a Data Plane DC share the same Redis DB in order to take advantage of Tyk's DRL and quota features.
 Your Data Plane can be in the same physical data centre as the Control Plane with just a logical network separation. If you have many Tyk Data Planes, they can be deployed in a private-cloud, public-cloud, or even on bare-metal.

--- a/tyk-docs/content/tyk-multi-data-centre/setup-worker-data-centres.md
+++ b/tyk-docs/content/tyk-multi-data-centre/setup-worker-data-centres.md
@@ -13,7 +13,7 @@ aliases:
 
 ## Overview
 
-You may configure an unlimited number of [Tyk Data Planes]({{< ref "tyk-multi-data-centre/mdcb.components.md" >}}) containing Worker Gateways for ultimate High Availablity (HA). We recommend that you deploy your worker gateways as close to your upstream services as possible in order to reduce latency.
+You may configure an unlimited number of [Tyk Data Planes]({{< ref "tyk-multi-data-centre/mdcb-components.md#data-plane" >}}) containing Worker Gateways for ultimate High Availablity (HA). We recommend that you deploy your worker gateways as close to your upstream services as possible in order to reduce latency.
 
 It is a requirement that all your Worker Gateways in a Data Plane DC share the same Redis DB in order to take advantage of Tyk's DRL and quota features.
 Your Data Plane can be in the same physical data centre as the Control Plane with just a logical network separation. If you have many Tyk Data Planes, they can be deployed in a private-cloud, public-cloud, or even on bare-metal.

--- a/tyk-docs/content/tyk-multi-data-centre/setup-worker-data-centres.md
+++ b/tyk-docs/content/tyk-multi-data-centre/setup-worker-data-centres.md
@@ -13,7 +13,7 @@ aliases:
 
 ## Overview
 
-You may configure an unlimited number of [Tyk Data Planes]({{ ref "tyk-multi-data-centre/mdcb.components.md" }}) containing Worker Gateways for ultimate High Availablity (HA). We recommend that you deploy your worker gateways as close to your upstream services as possible in order to reduce latency.
+You may configure an unlimited number of [Tyk Data Planes]({{< ref "tyk-multi-data-centre/mdcb.components.md" >}}) containing Worker Gateways for ultimate High Availablity (HA). We recommend that you deploy your worker gateways as close to your upstream services as possible in order to reduce latency.
 
 It is a requirement that all your Worker Gateways in a Data Plane DC share the same Redis DB in order to take advantage of Tyk's DRL and quota features.
 Your Data Plane can be in the same physical data centre as the Control Plane with just a logical network separation. If you have many Tyk Data Planes, they can be deployed in a private-cloud, public-cloud, or even on bare-metal.

--- a/tyk-docs/content/tyk-multi-data-centre/setup-worker-data-centres.md
+++ b/tyk-docs/content/tyk-multi-data-centre/setup-worker-data-centres.md
@@ -13,7 +13,7 @@ aliases:
 
 ## Overview
 
-You may configure an unlimited number of [Tyk Data Planes]({{< ref "tyk-multi-data-centre/mdcb-components/#data-plane" >}}) containing Worker Gateways for ultimate High Availablity (HA). We recommend that you deploy your worker gateways as close to your upstream services as possible in order to reduce latency.
+You may configure an unlimited number of [Tyk Data Planes]({{< ref "tyk-multi-data-centre/mdcb-components#data-plane/" >}}) containing Worker Gateways for ultimate High Availablity (HA). We recommend that you deploy your worker gateways as close to your upstream services as possible in order to reduce latency.
 
 It is a requirement that all your Worker Gateways in a Data Plane DC share the same Redis DB in order to take advantage of Tyk's DRL and quota features.
 Your Data Plane can be in the same physical data centre as the Control Plane with just a logical network separation. If you have many Tyk Data Planes, they can be deployed in a private-cloud, public-cloud, or even on bare-metal.


### PR DESCRIPTION
## Description
Corrected a typo in the hyperlink on https://tyk.io/docs/tyk-multi-data-centre/setup-worker-data-centres/ that should take the reader to https://tyk.io/docs/tyk-multi-data-centre/mdcb-components/#data-plane

Link was incorrectly formed and did not reference the correct anchor on the target page.

## Motivation
Improve readability of documentation, remove error from page

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Fixing typo (please merge to production)
- [ ] Documenting a new feature (please merge to production)
- [ ] Documentation for future release (please do not merge to production)
- [ ] Something else (please add if needs merging to production or not)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x ] I have [reviewed the guidelines](../CONTRIBUTING.md) for contributing to this repository.
- [x] I have [read the technical guidelines](../CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x ] Make sure you have started *your change* off *our latest `master`*.
- [ ] I have added a preview link.

