### PR TITLE
Merging to release-4.3: Fix the search dropdown. (#2244)

### DIFF
--- a/tyk-docs/static/css/custom_search.css
+++ b/tyk-docs/static/css/custom_search.css
@@ -1,0 +1,3 @@
+.algolia-autocomplete .ds-dropdown-menu [class^='ds-dataset-'] {
+    max-height: 400px!important;
+}

--- a/tyk-docs/static/js/docs-search.js
+++ b/tyk-docs/static/js/docs-search.js
@@ -3,6 +3,10 @@
  */
 
  docsearch({
+  algoliaOptions: {
+   hitsPerPage: 200,
+   // See https://www.algolia.com/doc/api-reference/api-parameters/
+  },
   // Your apiKey and indexName will be given to you once
   // we create your config
   apiKey: 'ALGOLIA_API_KEY',

--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="{{ "css/docs.css" | relURL }}">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ "css/cookie.css" | relURL }}">
-  
+  <link rel="stylesheet" href="{{ "css/custom_search.css" | relURL }}">
   {{ if not (or (findRE `docs/nightly` .Permalink) (findRE `docs/\d\.\d` .Permalink)) }}
   <link rel="canonical" href="{{ .Permalink }}" />
   {{ else }}


### PR DESCRIPTION
Fix the search dropdown. (#2244)

* fix search to make the search result scrollable

* return a maximum of 20 items for each search

* change hitsPerPage to 200

Co-authored-by: Yaara <yaara@tyk.io>