### PR TITLE
Merging to release-4.3: Improve OAS low level concepts pages (#2349)

### DIFF
--- a/tyk-docs/content/getting-started/key-concepts/low-level-concepts.md
+++ b/tyk-docs/content/getting-started/key-concepts/low-level-concepts.md
@@ -11,17 +11,12 @@ weight: 2
 
 ### Introduction
 
-Tyk and the OpenAPI Specification (OAS) talk about a number of topics in different ways and without a decoder ring this can be confusing. This page aims to be that ring.
+Tyk and the OpenAPI Specification (OAS) talk about a number of topics in different ways and without a decoder ring this can be confusing.
 
-- [Servers]({{< ref "/content/getting-started/key-concepts/servers.md" >}})
-- **Authentication** - [copied in the specific low level concepts page]
-- **Mock responses** - <more details to be added>
-- **Validation** - OAS lets you define validation in a very flexible way. It fundamentally boils down to having a json schema that defines what the body of a request or response should look like. However, the cleve part is that in the schema for a particular validation you can reference another schema defined elsewhere in the API Definition, or even externally via a URL. This lets your write complex validation very efficiently since you don’t need to re-define the validation for a particular object every time you wish to refer to it.
+This page aims to be that ring.
 
-{{< note success >}}
-**Note**  
-
-Tyk at this time only supports local references to schema within the same API Definition
-{{< /note >}}
-
-- Paths
+- [Servers]({{< ref "/getting-started/key-concepts/servers.md" >}}) - find out how Tyk integrates neatly between your clients and upstream services, automatically configuring where it will proxy requests
+- [Authentication]({{< ref "/getting-started/key-concepts/authentication.md" >}}) - with Tyk's OpenAPI implementation you have to option of delegating authentication to the upstream service, or handling it on the Tyk Gateway 
+- [Mock Responses]({{< ref "/getting-started/using-oas-definitions/mock-response.md" >}}) - Tyk can automatically configure mock response middleware using the configuration included in your OAS document; this allows you to test your APIs without connecting to the upstream services
+- [Request Validation]({{< ref "/getting-started/key-concepts/request-validation.md" >}})  - Tyk can protect your APIs by automatically validating the request parameters and payload against a schema that defines what it *should* look like
+- [Paths]({{< ref "/getting-started/key-concepts/paths.md" >}}) - this is a section within the OAS definition that instructs Tyk which API paths (also referred to as endpoints) should be configured; Tyk uses this information to determine which middleware should be enabled for each

--- a/tyk-docs/content/getting-started/key-concepts/request-validation.md
+++ b/tyk-docs/content/getting-started/key-concepts/request-validation.md
@@ -1,7 +1,12 @@
 ---
 title: "Request Validation"
+<<<<<<< HEAD
 date: 2022-07-07
 tags: ["API", "OAS", "OpenAPI Specification", "Servers"]
+=======
+date: 2023-02-13
+tags: ["API", "OAS", "OpenAPI Specification", "Request Validation"]
+>>>>>>> 85345e8b... Improve OAS low level concepts pages (#2349)
 description: "The low level concepts around OpenAPI Specification support in Tyk"
 menu:
   main:
@@ -13,13 +18,60 @@ weight: 3
 
 ### Introduction
 
+<<<<<<< HEAD
 Tyk can protect any Gateway incoming request by validating the request payload against the schema provided for the path's request body in the OAS API Definition.
+=======
+Tyk can protect any Gateway incoming request by validating the request
+parameters and payload against a schema provided for that path's request
+body in the OAS API Definition.
+>>>>>>> 85345e8b... Improve OAS low level concepts pages (#2349)
+
+The clever part is that in this schema you can reference another schema defined elsewhere in the API Definition; this lets you write complex validations very efficiently since you don’t need to re-define the validation for a particular object every time you wish to refer to it.
+
+{{< note success >}}
+**Note**  
+
+At this time Tyk only supports local references to schema within the same API Definition, but in future we aim to support schemas defined externally (via URL).
+{{< /note >}}
 
 ### How it works
 
+<<<<<<< HEAD
 In order to enable request validation features, for a specific path, the following criteria needs to be met:
+=======
+Request Validation works on operations. To enable request validations for
+the parameters, you must declare at least one parameter on an Open API
+operation:
 
-1. A schema needs to be defined for an `application/json` content type in the `requestBody` section of a path.
+```json
+"/pet/{petId}": {
+  "get": {
+    "summary": "Find pet by ID",
+    "operationId": "getPetById",
+    "parameters": [
+      {
+        "name": "petId",
+        "in": "path",
+        "description": "ID of pet to return",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    ],
+    ...
+  }
+}    
+```
+
+If there is at least one parameter, that parameter will enable validation
+of parameters.
+
+To configure Request Validation, which will check the body of each API request sent to the endpoint, follow these simple steps:
+>>>>>>> 85345e8b... Improve OAS low level concepts pages (#2349)
+
+1. Define a schema for an `application/json` content type in the `requestBody` section of a path.
 
 ```.json
 {
@@ -45,7 +97,11 @@ In order to enable request validation features, for a specific path, the followi
 }
 ```
 
+<<<<<<< HEAD
 1. `validateRequest` middleware needs to be enabled for that specific path.
+=======
+2. Enable `validateRequest` middleware within the `operations` section of the API definition, using the [operationId]({{< ref "getting-started/key-concepts/paths#operation-id" >}}) to identify the specific endpoint for which validation is to be applied.
+>>>>>>> 85345e8b... Improve OAS low level concepts pages (#2349)
 
 ```.json
 {
@@ -85,10 +141,21 @@ In order to enable request validation features, for a specific path, the followi
   }
 }
 ```
+<<<<<<< HEAD
 3. Your Tyk Gateway can validate an incoming request if the schema is defined within the OAS API Definition in the `requestBody` directly, or via a relative reference to the `components.schemas` section.
 
 ```.json
 //GOOD
+=======
+
+#### Using references to access shared schemas
+
+You can define the validation schema directly within the `requestBody` of the path's definition, or you can define it in the separate `components.schemas` section and include a relative reference within the `requestBody`. This allows you to re-use a schema across multiple paths.
+
+
+```json
+//SCHEMA DEFINED WITHIN PATH DEFINITION
+>>>>>>> 85345e8b... Improve OAS low level concepts pages (#2349)
 {
   ...
   "paths":{
@@ -96,7 +163,7 @@ In order to enable request validation features, for a specific path, the followi
         "put":{
           ...
           "requestBody":{
-            "description":"Update an existent pet in the store",
+            "description":"Update an existing pet in the store",
             "content":{
               "application/json":{
                   "schema":{
@@ -111,7 +178,7 @@ In order to enable request validation features, for a specific path, the followi
   ...
 }
 
-//GOOD
+//SCHEMA DEFINED WITHIN COMPONENTS.SCHEMAS AND ACCESSED USING RELATIVE REFERENCE
 {
   ...
   "components": {
@@ -126,7 +193,7 @@ In order to enable request validation features, for a specific path, the followi
         "put":{
           ...
           "requestBody":{
-            "description":"Update an existent pet in the store",
+            "description":"Update an existing pet in the store",
             "content":{
               "application/json":{
                   "schema":{
@@ -142,6 +209,7 @@ In order to enable request validation features, for a specific path, the followi
 }
 ```
 
+<<<<<<< HEAD
 4. If the schema reference points to an external resource, your Tyk Gateway will just ignore it and won’t validate the request.
 
 ```.json
@@ -172,3 +240,11 @@ In order to enable request validation features, for a specific path, the followi
 ### Automatically enable request validation
 
 While importing an OAS API Definition or updating a Tyk OAS API Definition, `validateRequest` middleware can be automatically configured by Tyk for all the paths that have a schema configured, by passing the `validateRequest=true` query parameter, together with the import API or with a PATCH request for updating the API.
+=======
+### Automatically enable request validation
+
+When importing an OAS API Definition or updating an existing Tyk OAS API
+Definition, `validateRequest` middleware can be automatically configured
+by Tyk for all the paths that have a schema configured, by passing
+`validateRequest=true` as a query parameter for the IMPORT or PATCH request respectively.
+>>>>>>> 85345e8b... Improve OAS low level concepts pages (#2349)


### PR DESCRIPTION
Improve OAS low level concepts pages (#2349)

* Update low-level-concepts.md

Added links to sub-pages and cleaned up the descriptions; moved Request Validation detail to correct page

* Update request-validation.md

Tidied up; removed example of "how Tyk would work with external schema references but doesn't yet as we don't support that"

* fix link

* Update tyk-docs/content/getting-started/key-concepts/request-validation.md

* Removed /content from links

---------

Co-authored-by: Yaara <letz.yaara@gmail.com>
Co-authored-by: Yaara <yaara@tyk.io>