### PR TITLE
Fix keycloak link in the DCR doc for the Enterprise portal.

### DIFF
--- a/tyk-docs/content/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/dynamic-client-registration.md
+++ b/tyk-docs/content/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/dynamic-client-registration.md
@@ -44,7 +44,7 @@ Before getting starting with configuring the portal, it's required to configure 
 Before setting up Tyk Enterprise Developer Portal to work with DCR, you need to configure the identity provider. Please refer to the guides for popular providers to create the initial access token for DCR:
 * [Gluu](https://gluu.org/docs/gluu-server/4.0/admin-guide/openid-connect/#dynamic-client-registration)
 * [Curity](https://curity.io/docs/idsvr/latest/token-service-admin-guide/dcr.html)
-* [Keycloak](https://gluu.org/docs/gluu-server/4.0/admin-guide/openid-connect/#dynamic-client-registration)
+* [Keycloak](https://github.com/keycloak/keycloak-documentation/blob/main/securing_apps/topics/client-registration.adoc)
 * [Okta](https://developer.okta.com/docs/reference/api/oauth-clients/)
 
 ### Create oAuth2.0 scopes to enforce access control and rate limit


### PR DESCRIPTION
## Related Issue (if applicable)
<!-- If applicable, please reference to a related issue in this repository. -->

## Description
- Fix the link to the keycloak DCR guide

## Motivation and Context
At the moment, [the DCR guide](https://github.com/TykTechnologies/tyk-docs/pull/2383/files#diff-dae8afc86acebb3da945f81b1896a65e103528c1bdf359cc04cf654eea38ab4cR47) for the Enterprise portal uses the wrong link to the keycloak's official DCR doc. This commit fixes that.

## Preview Link
https://deploy-preview-2388--tyk-docs.netlify.app/docs/nightly/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/dynamic-client-registration/

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fixing typo (please merge to production)
- [ ] Documenting a new feature (please merge to production)
- [ ] Documentation for future release (please do not merge to production)
- [ ] Something else (please add if needs merging to production or not)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have [reviewed the guidelines](../CONTRIBUTING.md) for contributing to this repository.
- [x] I have [read the technical guidelines](../CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x] Make sure you have started *your change* off *our latest `master`*.
- [x] I have added a preview link.

