### PR TITLE
Merging to release-4.3: Fix "trim" function (#2404)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/list.netlify.json
+++ b/tyk-docs/themes/tykio/layouts/_default/list.netlify.json
@@ -3,11 +3,9 @@
   {{- printf "# %s - ./content/%s\n" $value.Title .File.Path }}
   {{- end }}
   {{- range $value.Aliases }}
-     {{- $from := trim . " " }}
-     {{- $from := trim $from "/docs" }}
-     {{- if (hasPrefix $from "/") }}
-       {{- $from := trim $from "/" }}
-     {{- end }}
+     {{- $from := strings.TrimPrefix " " . }}
+     {{- $from := strings.TrimPrefix "/docs" $from }}
+     {{- $from := strings.TrimPrefix "/" $from }}
     {{- $to := printf "%s" (replace $value.RelPermalink "/nightly" "")}}
     {{- printf "/docs/%s %s %d\n" $from $to 301 }}
   {{- end }}

--- a/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
+++ b/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
@@ -2,11 +2,9 @@
    {{- $path := .File.Path }}
    {{- printf "{\"path\":\"%s\", \"file\": \"./content/%s\"}\n" (replace $value.RelPermalink "/nightly" "") $path}}
    {{- range $value.Aliases }}
-     {{- $from := trim . " " }}
-     {{- $from := trim $from "/docs" }}
-     {{- if (hasPrefix $from "/") }}
-       {{- $from := trim $from "/" }}
-     {{- end }}
+     {{- $from := strings.TrimPrefix " " . }}
+     {{- $from := strings.TrimPrefix "/docs" $from }}
+     {{- $from := strings.TrimPrefix "/" $from }}
      {{- printf "{\"path\":\"/docs/%s\", \"file\":\"./content/%s\", \"alias\":true}\n" $from $path}}
    {{- end }}
  {{- end }}


### PR DESCRIPTION
Fix "trim" function (#2404)

Apparently trim function was cutting all the characters in argument, and not
treated it as substring