### PR TITLE
Merging to release-5: Fix tyk-sync go installation instructions (#2434)

### DIFF
--- a/tyk-docs/content/tyk-sync.md
+++ b/tyk-docs/content/tyk-sync.md
@@ -51,10 +51,12 @@ dependent tokens continue to have access to your services.
 
 ## Installation
 
-Currently the application is available via Go, [Docker](https://hub.docker.com/r/tykio/tyk-sync) and [Packagecloud](https://packagecloud.io/tyk/tyk-sync).  To install via Go you must have Go installed and run:
+Currently the application is available via Go, [Docker](https://hub.docker.com/r/tykio/tyk-sync) and [Packagecloud](https://packagecloud.io/tyk/tyk-sync).
 
+### Go:
+To install via Go you must have Go installed and run:
 ```
-go get -u github.com/TykTechnologies/tyk-sync
+go install github.com/TykTechnologies/tyk-sync@latest
 ```
 
 This should make the `tyk-sync` command available to your console.


### PR DESCRIPTION
Fix tyk-sync go installation instructions (#2434)