### PR TITLE
fix side menu footer size and display

### DIFF
--- a/tyk-docs/assets/scss/_side-menu.scss
+++ b/tyk-docs/assets/scss/_side-menu.scss
@@ -29,6 +29,10 @@ Tree View
         padding: 1rem 0;
         border-top: 1px solid $brandpurple-3;
 
+        @include breakpoint(large) {
+            display: none;
+        }
+
         a {
             font-size: 14px;
             text-transform: uppercase;
@@ -362,7 +366,7 @@ Tree View
 
     a {
         display: inline-block;
-        padding-bottom: 0.5rem;
+        padding-bottom: 0.25rem;
         font-weight: 600;
         color: $brandgreen-3;
         text-decoration: underline;

--- a/tyk-docs/themes/tykio/layouts/partials/side_menu.html
+++ b/tyk-docs/themes/tykio/layouts/partials/side_menu.html
@@ -38,8 +38,7 @@
 </div>
 
 <div class="page-submenu__footer">
-    <span>Need help from one of our engineers?</span>
-    <br><br>
+    <p style="line-height: 1;">Need help from one of our engineers?</p>
     <a href="https://tyk.io/contact/" title="Contact us">Get in contact</a>
     <br>
     <a href="https://tyk.io/book-a-demo/" title="Book a personalised demo">Book a personalised demo</a>


### PR DESCRIPTION
## Description
Fixed display scenarios of main menu in the side bar nav to be shown only on mobile and so not be duplicated.
Reduce spacing between elements in side bar footer to make it more compact

direct link https://deploy-preview-2455--tyk-docs.netlify.app/docs/nightly/tyk-stack/ :)