### PR TITLE
[TT-7767] Mention OpenAPI on Data Graphs API page.

### DIFF
--- a/tyk-docs/content/tyk-apis/tyk-dashboard-api/data-graphs-api.md
+++ b/tyk-docs/content/tyk-apis/tyk-dashboard-api/data-graphs-api.md
@@ -9,18 +9,28 @@ weight: 1
 
 ### Import an AsyncAPI Document
 
-The Dashboard exposes the `/api/data-graphs/data-sources/import` Dashboard API which allows you to import an AsyncAPI document.
+The Dashboard exposes the `/api/data-graphs/data-sources/import` Dashboard API which allows you to import an AsyncAPI or OpenAPI document.
 
 You should provide JSON payload with the following data:
 
-* `type` - document type (it should be `"asyncapi"` to import an AsyncAPI document).
-* `data` - AsyncAPI document
+* `type` - document type, valid document types are `asyncapi` and `openapi`.
+* `data` - AsyncAPI or OpenAPI document
 
-| **Property** | **Description**                                     |
-| ------------ |-----------------------------------------------------|
-| Resource URL | `/api/data-graphs/data-sources/import`              |
-| Method       | POST                                                |
-| Body         | {"type": "asyncapi", "data": "<asyncapi_document>"} |
+| **Property** | **Description**                                       |
+|--------------|-------------------------------------------------------|
+| Resource URL | `/api/data-graphs/data-sources/import`                |
+| Method       | POST                                                  |
+| Body         | {"type": "<document-type>", "data": "<the-document>"} |
+
+
+Supported AsyncAPI versions:
+* 2.0.0
+* 2.1.0
+* 2.3.0
+* 2.4.0
+
+Supported OpenAPI versions:
+* 3.0.0
 
 #### Sample Response
 


### PR DESCRIPTION
OpenAPI is now supported by `/api/data-graphs/data-sources/import`. I updated the document to mention this new feature. I also added supported versions of the specs. 