### PR TITLE
Merging to release-5: [TT-7126] add authority header to grpc (#2532)

### DIFF
--- a/tyk-docs/static/js/docs.js
+++ b/tyk-docs/static/js/docs.js
@@ -157,7 +157,7 @@ $(document).ready(function(e){
 		});   
 	};
 
-	$('[class^="language"]').copyToClipboard();
+	$('code[class^="language"]:not(.language-diff)').copyToClipboard();
 
 //Handle header hyperlinks
 	$('h2, h3, h4, h5').hover(function () {


### PR DESCRIPTION
[TT-7126] add authority header to grpc (#2532)

* Improve gRPC plugin api content for readability/sensibility, add authority field

* Don't add copy to clipboard button for .language-diff blocks

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-7126]: https://tyktech.atlassian.net/browse/TT-7126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ