### PR TITLE
Merging to release-5: Update error-templates.md (#2546)

### DIFF
--- a/tyk-docs/content/advanced-configuration/error-templates.md
+++ b/tyk-docs/content/advanced-configuration/error-templates.md
@@ -11,6 +11,8 @@ In v2.2 the error handler allowed the use a single JSON template to communicate 
 
 As of v2.3 it is possible to use different templates for specific `HTTP error codes`. The `content-type` header of the request is also checked, enabling the usage of different template formats, e.g. an XML template.
 
+Please note that it is not possible to override the default message for HTTP 404 errors. These errors indicate that the requested resource could not be found (e.g. the requested URL does not exist).
+
 ## Use Cases
 
 ### JSON Request


### PR DESCRIPTION
Update error-templates.md (#2546)

* Update error-templates.md

Added note that it's not possible to use a template for HTTP 404

* Update tyk-docs/content/advanced-configuration/error-templates.md

Co-authored-by: dcs3spp <dcs3spp@users.noreply.github.com>

---------

Co-authored-by: dcs3spp <dcs3spp@users.noreply.github.com>