### PR TITLE
[TT-9019] Improved wording of size limits

### DIFF
--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -17,7 +17,7 @@ Tyk offers a flexible tiered system of limiting request sizes ranging from globa
 
 All size limits are stated in bytes and are applied only to the request _body_, excluding the headers.
 
-Tyk compares each incoming API request with the configured maximum size(s) and will reject any request that exceeds the size you have set, returning an HTTP 400 error with the message "Request is too large".
+Tyk compares each incoming API request with the configured maximum size(s) and will reject any request that exceeds the size you have set, returning an HTTP 4xx error as detailed below.
 
 {{< note success >}}
 **Note**  
@@ -31,7 +31,7 @@ You can optionally configure a request size limit (in bytes) that will be applie
 "max_request_body_size": 5000
 ```
 
-This Gateway-wide size limit will be evaluated before per-API or per-endpoint settings.
+This Gateway-wide size limit will be evaluated before per-API or per-endpoint settings. If this test fails, the Tyk Gateway will report `413 Request Entity Too Large`.
 
 ### Applying a size limit for a specific API
 You can optionally configure a request size limit (in bytes) to an API by adding `global_size_limit` to the `version` element of the API Definition, for example:
@@ -39,14 +39,14 @@ You can optionally configure a request size limit (in bytes) to an API by adding
 "global_size_limit": 2500 
 ```
 
-This limit is applied for all endpoints _within an API_. It is evaluated after the Gateway-wide size limit and before any endpoint-specific size limit.
+This limit is applied for all endpoints _within an API_. It is evaluated after the Gateway-wide size limit and before any endpoint-specific size limit. If this test fails, the Tyk Gateway will report `400 Request is too large`.
 
 ### Applying a size limit for a specific API endpoint
 Tyk provides a _Request Size Limit_ middleware that can be configured per API endpoint. This gives you the most granular control over request sizes.
 
 You can configure this easily from the API Designer in the Tyk Dashboard, or by manually adding the configuration to your API definition.
 
-This limit will be applied after any Gateway-level or API-level size limits; in keeping with the other size limit options provided by Tyk, this value is given in bytes.
+This limit will be applied after any Gateway-level or API-level size limits; in keeping with the other size limit options provided by Tyk, this value is given in bytes. If this test fails, the Tyk Gateway will report `400 Request is too large`.
 
 #### Using the Tyk Dashboard
 You can enforce a request size limit for a specific API endpoint using the API Endpoint Designer:

--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -46,7 +46,7 @@ Tyk provides a _Request Size Limit_ middleware that can be configured per API en
 
 You can configure this easily from the API Designer in the Tyk Dashboard, or by manually adding the configuration to your API definition.
 
-This limit will be applied after any Gateway-level or API-level size limits; as for all of the size limit options provided by Tyk, this value is given in bytes.
+This limit will be applied after any Gateway-level or API-level size limits; in keeping with the other size limit options provided by Tyk, this value is given in bytes.
 
 #### Using the Tyk Dashboard
 To enforce a request size limit for a specific API endpoint, you will use from your API Endpoint Designer:

--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -26,7 +26,7 @@ Tyk Cloud Classic automatically enforces a strict request size limit of 1MB on a
 {{< /note >}}
 
 ### Applying a size limit for all APIs on your Gateway
-You can optionally configure a request size limit (in bytes) that will be applied to all APIs on your Tyk Gateway by adding `max_request_body_size` to the `http_server_options` [element]({{< ref "/tyk-oss-gateway/configuration#http_server_options" >}}) of your `tyk.conf` Gateway configuration, for example:
+You can optionally configure a request size limit (in bytes) that will be applied to all APIs on your Tyk Gateway by adding `max_request_body_size` to the `http_server_options` [element]({{< ref "/tyk-oss-gateway/configuration#http_server_options" >}}) of your `tyk.conf` Gateway configuration. For example:
 ```
 "max_request_body_size": 5000
 ```

--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -11,7 +11,7 @@ weight: 4
 
 ## Overview
 
-With Tyk, you are able to apply limits to the size of requests made to your HTTP APIs; you might do this to protect your upstream services or even the gateway itself, for example, to avoid excessive memory usage or brute force attacks.
+With Tyk, you can apply limits to the size of requests made to your HTTP APIs. You might use this feature to protect your Tyk Gateway or upstream services from avoid excessive memory usage or brute force attacks.
 
 Tyk offers a flexible tiered system of limiting request sizes ranging from globally applied limits across all APIs deployed on the gateway down to specific size limits for individual API endpoints.
 

--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -22,7 +22,7 @@ Tyk compares each incoming API request with the configured maximum size(s) and w
 {{< note success >}}
 **Note**  
 
-Tyk Cloud Classic automatically enforces a strict request size limit of 1MB on all inbound requests via our cloud architecture. This does not affect Multi-Cloud users.
+Tyk Cloud Classic enforces a strict request size limit of 1MB on all inbound requests via our cloud architecture. This does not affect Multi-Cloud users.
 {{< /note >}}
 
 ### Applying a size limit for all APIs on your Gateway

--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -39,10 +39,10 @@ You can optionally configure a request size limit (in bytes) to an API by adding
 "global_size_limit": 2500 
 ```
 
-This limit is applied for all endpoints _within an API_, is evaluated after the Gateway-wide size limit and before any endpoint-specific size limit.
+This limit is applied for all endpoints _within an API_. It is evaluated after the Gateway-wide size limit and before any endpoint-specific size limit.
 
 ### Applying a size limit for a specific API endpoint
-Tyk provides a _Request Size Limit_ middleware that can be configured per API endpoint, to give you the most granular control over request sizes.
+Tyk provides a _Request Size Limit_ middleware that can be configured per API endpoint. This gives you the most granular control over request sizes.
 
 You can configure this easily from the API Designer in the Tyk Dashboard, or by manually adding the configuration to your API definition.
 

--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -22,7 +22,7 @@ Tyk compares each incoming API request with the configured maximum size(s) and w
 {{< note success >}}
 **Note**  
 
-Tyk Cloud Classic automatically enforces a strict request size limit of 1MB an all inbound requests via our cloud architecture. This does not affect Multi-Cloud users.
+Tyk Cloud Classic automatically enforces a strict request size limit of 1MB on all inbound requests via our cloud architecture. This does not affect Multi-Cloud users.
 {{< /note >}}
 
 ### Applying a size limit for all APIs on your Gateway

--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -66,7 +66,7 @@ You can enforce a request size limit for a specific API endpoint using the API E
 5.  Save the API.
 
 #### Manually configuring the API Definition
-To add the _Request Size Limit_ middleware in your API Definition, simply add a new section to the `extended_paths` block of your API Definition configuration called `size_limits`:
+To add the _Request Size Limit_ middleware to your API Definition, create a new section in the `extended_paths` block of your API Definition configuration called `size_limits`:
 
 ```{.copyWrapper}
 "size_limits": [

--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -2,27 +2,54 @@
 date: 2017-03-23T17:18:54Z
 title: Request Size Limits
 tags: ["Request size limits"]
-description: "The key concepts for implementing rate limits and quotas with Tyk"
+description: "The key concepts for implementing request size limits with Tyk"
 menu:
   main:
     parent: "Control & Limit Traffic"
 weight: 4 
 ---
 
-## Maximum Request Sizes
+## Overview
 
-Tyk supports forcing request size limits at the API and individual endpoint level. Tyk will reject any request that exceeds the size you set.
+With Tyk, you are able to apply limits to the size of requests made to your HTTP APIs; you might do this to protect your upstream services or even the gateway itself, for example, to avoid excessive memory usage or brute force attacks.
+
+Tyk offers a flexible tiered system of limiting request sizes ranging from globally applied limits across all APIs deployed on the gateway down to specific size limits for individual API endpoints.
+
+All size limits are stated in bytes and are applied only to the request _body_, excluding the headers.
+
+Tyk compares each incoming API request with the configured maximum size(s) and will reject any request that exceeds the size you have set, returning an HTTP 400 error with the message "Request is too large".
 
 {{< note success >}}
 **Note**  
 
-Tyk Cloud Classic enforces a strict request size limit of 1MB an all inbound requests via our cloud architecture. This does not affect Multi-Cloud users.
+Tyk Cloud Classic automatically enforces a strict request size limit of 1MB an all inbound requests via our cloud architecture. This does not affect Multi-Cloud users.
 {{< /note >}}
 
+### Applying a size limit for all APIs on your Gateway
+You can optionally configure a request size limit (in bytes) that will be applied to all APIs on your Tyk Gateway by adding `max_request_body_size` to the `http_server_options` [element]({{< ref "/tyk-oss-gateway/configuration#http_server_options" >}}) of your `tyk.conf` Gateway configuration, for example:
+```
+"max_request_body_size": 5000
+```
 
-## Max Request Size with the Dashboard
+This Gateway-wide size limit will be evaluated before per-API or per-endpoint settings.
 
-To enforce a request size from your API Endpoint Designer:
+### Applying a size limit for a specific API
+You can optionally configure a request size limit (in bytes) to an API by adding `global_size_limit` to the `version` element of the API Definition, for example:
+```
+"global_size_limit": 2500 
+```
+
+This limit is applied for all endpoints _within an API_, is evaluated after the Gateway-wide size limit and before any endpoint-specific size limit.
+
+### Applying a size limit for a specific API endpoint
+Tyk provides a _Request Size Limit_ middleware that can be configured per API endpoint, to give you the most granular control over request sizes.
+
+You can configure this easily from the API Designer in the Tyk Dashboard, or by manually adding the configuration to your API definition.
+
+This limit will be applied after any Gateway-level or API-level size limits; as for all of the size limit options provided by Tyk, this value is given in bytes.
+
+#### Using the Tyk Dashboard
+To enforce a request size limit for a specific API endpoint, you will use from your API Endpoint Designer:
 
 1.  Click **ADD ENDPOINT**.
 
@@ -38,29 +65,19 @@ To enforce a request size from your API Endpoint Designer:
 
 5.  Save the API.
 
-
-## <a name="max-request-size-with-api"></a> Max Request Size with API Definition
-
-To set up this middleware in your API Definition, simply add a new section to the `extended_paths` block of your API Definition configuration called `size_limits`:
+#### Manually configuring the API Definition
+To add the _Request Size Limit_ middleware in your API Definition, simply add a new section to the `extended_paths` block of your API Definition configuration called `size_limits`:
 
 ```{.copyWrapper}
 "size_limits": [
   {
     "path": "widget/{id}",
     "method": "PUT",
-    "size_limit": 25
+    "size_limit": 1000
   }
   ]
 ```
 
-The size limit must be in in **bytes**.
-
-### Global size limiting for your API
-
-To add an API size limit, simply add:
-```
-"global_size_limit": 500 
-```
 
 
-To the version element of your API Definition, the global size limit will be checked before the specific path-based one.
+

--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-size-limits.md
@@ -49,7 +49,7 @@ You can configure this easily from the API Designer in the Tyk Dashboard, or by 
 This limit will be applied after any Gateway-level or API-level size limits; in keeping with the other size limit options provided by Tyk, this value is given in bytes.
 
 #### Using the Tyk Dashboard
-To enforce a request size limit for a specific API endpoint, you will use from your API Endpoint Designer:
+You can enforce a request size limit for a specific API endpoint using the API Endpoint Designer:
 
 1.  Click **ADD ENDPOINT**.
 


### PR DESCRIPTION
TT-9019
Added new gateway-level request body size limit
Improved flow and wording for the rest of the page.

This relates to the new max_request_body_size config option introduced in TT-5186