### PR TITLE
Merging to release-5: DX-332 Manual triggered:  Import config documentation from mdcb:update-configs-mongo-driver (#2608)

### DIFF
--- a/tyk-docs/content/shared/mdcb-config.md
+++ b/tyk-docs/content/shared/mdcb-config.md
@@ -270,6 +270,25 @@ Type: `int`<br />
 
 Sets the batch size for mongo results.
 
+<<<<<<< HEAD
+=======
+### analytics.driver
+EV: <b>TYK_MDCB_ANALYTICSCONFIG_DRIVER</b><br />
+Type: `string`<br />
+
+This config determines the driver used by the storage. It could be `mongo-go` to use the official mongo driver for go or `mgo` to use the old driver. By default, the value is `mgo`.
+
+### analytics.mongo_direct_connection
+EV: <b>TYK_MDCB_ANALYTICSCONFIG_MONGODIRECTCONNECTION</b><br />
+Type: `bool`<br />
+
+MongoDirectConnection informs whether to establish connections only with the specified seed servers,
+or to obtain information for the whole cluster and establish connections with further servers too.
+If true, the client will only connect to the host provided in the analytics.connection_string configuration
+and won't attempt to discover other hosts in the cluster. Useful when network restrictions
+prevent discovery, such as with SSH tunneling. Default is false.
+
+>>>>>>> ca9b3103... DX-332 Manual triggered:  Import config documentation from mdcb:update-configs-mongo-driver (#2608)
 ### hash_keys
 EV: <b>TYK_MDCB_HASHKEYS</b><br />
 Type: `bool`<br />


### PR DESCRIPTION
DX-332 Manual triggered:  Import config documentation from mdcb:update-configs-mongo-driver (#2608)

 Import config documentation from mdcb:update-configs-mongo-driver