### PR TITLE
[DX-363] Recreate PR that fixes broken nav links checks

### DIFF
--- a/scripts/menu_generator.py
+++ b/scripts/menu_generator.py
@@ -91,14 +91,17 @@ with open(urlcheck_path, "r") as file:
             continue
 
         title = obj.get("title")
-        #linktitle = obj.get("linktitle")
+        # linktitle = obj.get("linktitle")
 
         # if title and link title are empty
         # log to file and continue to next row in urlcheck.json
         # if only title is empty then title = linktitle and
         # replace trailing slash
         if title is None or title == "":
-            print(f"no title, check for linktitle. {line.strip()}, ", file=openUrlCheckNoTitle)
+            print(
+                f"no title, check for linktitle. {line.strip()}, ",
+                file=openUrlCheckNoTitle,
+            )
 
             linktitle = obj.get("linktitle")
             if linktitle is None:
@@ -188,7 +191,7 @@ with open(categories_path, "r") as file:
                     "Managing APIs": "/getting-started",
                     "Product Stack": "/tyk-stack",
                     "Developer Support": "/frequently-asked-questions/faq",
-                    "APIM Best Practices": "/getting-started/key-concepts",
+                    "APIM Best Practice": "/getting-started/key-concepts",
                     "Orphan": "/orphan",
                 }
 
@@ -314,8 +317,8 @@ def print_tree_as_yaml(tree, level=1):
                 title = title_map[node["url"].replace("/", "")]
             except:
                 title = "Unknown url: " + node["url"]
-                #print(f"node[url] = {'https://tyk.io/docs' + node['url']},  node['name'] = {node['name']}")
-                print( 
+                # print(f"node[url] = {'https://tyk.io/docs' + node['url']},  node['name'] = {node['name']}")
+                print(
                     "Unknown menu url:" " https://tyk.io/docs" + node["url"],
                     file=openUnknownUrlFile,
                 )

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -15,14 +15,14 @@ menu:
     menu:
     - title: "Overview"
       category: Page
-    - title: "Quick start guides"
+    - title: "Quick Start Guides"
       category: Directory
       menu:
     - title: "Tyk Open Source API Gateway"
       category: Directory
       menu:
       - title: "Overview"
-        category: 
+        category: Directory
         menu:
         - title: "Tyk Open Source"
           path: /apim/open-source
@@ -104,7 +104,7 @@ menu:
         - title: "What we covered"
           path: /tyk-cloud/getting-started-tyk-cloud/to-conclude
           category: Page
-      - title: "Day 0 - Design phase"
+      - title: "Day 0 - Planning Phase"
         category: Directory
         menu:
         - title: "Availability of infrastructure"
@@ -150,11 +150,7 @@ menu:
       category: Directory
       menu:
       - title: "Overview"
-        category: 
-        menu:
-        - title: "Tyk Self-Managed"
-          path: /tyk-on-premises
-          category: Page
+        category: Page
       - title: "Getting Started"
         category: Directory
         menu:
@@ -225,7 +221,7 @@ menu:
           category: Directory
           menu:
           - title: "Single Region"
-            category: Label
+            category: Directory
             menu:
             - title: "Tyk & K8s demo"
               category: Page
@@ -235,7 +231,7 @@ menu:
               path: /tyk-self-managed/tyk-helm-chart
               category: Page
           - title: "Multi Region"
-            category: Label
+            category: Directory
             menu:
             - title: "Kuberenetes Demo"
               category: Page
@@ -251,7 +247,7 @@ menu:
         - title: "Dashboard on Red Hat (RHEL) / CentOS"
           path: /tyk-on-prem/installation/redhat-rhel-centos/dashboard
           category: Page
-      - title: "Day 0 - Design phase"
+      - title: "Day 0 - Planning Phase"
         category: Directory
         menu:
         - title: "Design for high availability and performance"
@@ -366,33 +362,26 @@ menu:
     menu:
     - title: "Overview"
       category: Page
-    - title: "Quick start demos"
+    - title: "Quick Start Guides"
       category: Directory
       menu:
       - title: "Protect an API using Tyk OSS Gateway"
         category: Page
-      - title: "Securely deploy a REST API (Dashboard)"
+      - title: "Securely deploy a REST API"
         category: Page
-      - title: "OpenAPI Spec operations (Dashboard)"
+      - title: "OpenAPI Specification"
         category: Page
       - title: "Publish your first API through the Developer Portal"
         category: Page
-      - title: "Add a Kafka data source (UDG)"
+      - title: "Add a Kafka data source"
         category: Page
-      - title: "Getting Started"
-        path: /getting-started
+      - title: "Tyk Local Demo library"
         category: Page
       - title: "Install"
         path: /getting-started/installation
         category: Page
       - title: "Quick Start"
         path: /getting-started/quick-start
-        category: Page
-      - title: "Quick Start in Docker"
-        path: /getting-started/quick-start/tyk-demo
-        category: Page
-      - title: "Quick Start in Kubernetes"
-        path: /getting-started/quick-start/tyk-k8s-demo
         category: Page
     - title: "Core API Management"
       category: Directory
@@ -515,10 +504,7 @@ menu:
           category: Page
         - title: "Manage data sources"
           category: Page
-        - title: "UDG Examples"
-          path: /universal-data-graph/udg-examples
-          category: Page
-      - title: "Data Graph management"
+      - title: "Data Graph Management"
         category: Directory
         menu:
         - title: "Define access to UDG APIs"
@@ -530,14 +516,6 @@ menu:
         - title: "Version UDG"
           category: Page
         - title: "Expose as a REST API"
-          category: Page
-    - title: "GraphQL"
-      category: Directory
-      menu:
-      - title: "GQL Federation"
-        category: Directory
-        menu:
-        - title: "Federated GraphQL"
           category: Page
   - title: "Product Stack"
     path: /tyk-stack
@@ -551,51 +529,39 @@ menu:
       - title: "Key Concepts"
         category: Directory
         menu:
-        - title: "OAS API definition"
+        - title: "Open API Specification"
           category: Directory
           menu:
-          - title: "OAS API Versioning"
-            path: /getting-started/key-concepts/oas-versioning
-            category: Page
-          - title: "Tyk OAS API definition"
-            path: /getting-started/key-concepts/openapi-specification
-            category: Page
-          - title: "Servers"
-            path: /getting-started/key-concepts/servers
-            category: Page
-          - title: "Using OAS API Definitions"
-            path: /getting-started/using-oas-definitions
-            category: Page
-          - title: "Create an OAS API"
-            path: /getting-started/using-oas-definitions/create-an-oas-api
-            category: Page
-          - title: "Export an OAS API"
-            path: /getting-started/using-oas-definitions/export-an-oas-api
-            category: Page
-          - title: "Get started with OAS and VS Code"
-            path: /getting-started/using-oas-definitions/get-started-oas
-            category: Page
-          - title: "Import an OAS API"
-            path: /getting-started/using-oas-definitions/import-an-oas-api
-            category: Page
-          - title: "Mock Response"
-            path: /getting-started/using-oas-definitions/mock-response
-            category: Page
-          - title: "Moving to OAS from Tyk Classic APIs"
-            path: /getting-started/using-oas-definitions/moving-to-oas
-            category: Page
-          - title: "OAS Glossary"
-            path: /getting-started/using-oas-definitions/oas-glossary
-            category: Page
-          - title: "OAS Reference"
-            path: /getting-started/using-oas-definitions/oas-reference
-            category: Page
-          - title: "Update existing Tyk API with changes in your OpenAPI definition"
-            path: /getting-started/using-oas-definitions/update-api-with-oas
-            category: Page
-          - title: "Versioning an OAS API"
-            path: /getting-started/using-oas-definitions/versioning-an-oas-api
-            category: Page
+          - title: "Basic concepts"
+            category: Directory
+            menu:
+            - title: "OpenAPI High Level Concepts"
+              path: /getting-started/key-concepts/high-level-concepts
+              category: Page
+            - title: "Tyk OAS API definition"
+              path: /getting-started/key-concepts/openapi-specification
+              category: Page
+          - title: "Advanced concepts"
+            category: Directory
+            menu:
+            - title: "Authentication"
+              path: /getting-started/key-concepts/authentication
+              category: Page
+            - title: "OpenAPI Low Level Concepts"
+              path: /getting-started/key-concepts/low-level-concepts
+              category: Page
+            - title: "OAS API Versioning"
+              path: /getting-started/key-concepts/oas-versioning
+              category: Page
+            - title: "Paths"
+              path: /getting-started/key-concepts/paths
+              category: Page
+            - title: "Request Validation"
+              path: /getting-started/key-concepts/request-validation
+              category: Page
+            - title: "Servers"
+              path: /getting-started/key-concepts/servers
+              category: Page
         - title: "GraphQL"
           category: Directory
           menu:
@@ -683,14 +649,8 @@ menu:
         - title: "Key Concepts"
           path: /getting-started/key-concepts
           category: Page
-        - title: "Paths"
-          path: /getting-started/key-concepts/paths
-          category: Page
         - title: "Rate Limiting in Tyk"
           path: /getting-started/key-concepts/rate-limiting
-          category: Page
-        - title: "Request Validation"
-          path: /getting-started/key-concepts/request-validation
           category: Page
         - title: "Session Metadata"
           path: /getting-started/key-concepts/session-meta-data
@@ -1076,6 +1036,9 @@ menu:
         - title: "WebSockets"
           path: /advanced-configuration/websockets
           category: Page
+        - title: "Request Context Variables"
+          path: /context-variables
+          category: Page
         - title: "Log Data"
           path: /log-data
           category: Page
@@ -1139,15 +1102,6 @@ menu:
         - title: "Tyk OAS API definition"
           category: Directory
           menu:
-          - title: "Authentication"
-            path: /getting-started/key-concepts/authentication
-            category: Page
-          - title: "OpenAPI High Level Concepts"
-            path: /getting-started/key-concepts/high-level-concepts
-            category: Page
-          - title: "OpenAPI Low Level Concepts"
-            path: /getting-started/key-concepts/low-level-concepts
-            category: Page
         - title: "Gateway API"
           path: /getting-started/key-concepts/gateway-api
           category: Page
@@ -1226,7 +1180,7 @@ menu:
         - title: "Error Response Status Codes"
           path: /error-response-codes
           category: Page
-      - title: "Release notes"
+      - title: "Release Notes"
         category: Directory
         menu:
         - title: "Changelog"
@@ -1372,9 +1326,6 @@ menu:
         menu:
         - title: "Tyk Dashboard Admin API"
           path: /dashboard-admin-api
-          category: Page
-        - title: "Portal API Catalogue"
-          path: /getting-started/key-concepts/api-catalogue
           category: Page
         - title: "Dashboard API"
           path: /getting-started/key-concepts/dashboard-api
@@ -1538,7 +1489,7 @@ menu:
         - title: "MongoDB X.509 Client Authentication"
           path: /tyk-stack/dependencies/mongodb/x509-client-auth
           category: Page
-      - title: "Release notes"
+      - title: "Release Notes"
         category: Directory
         menu:
         - title: "Changelog"
@@ -1557,6 +1508,9 @@ menu:
         - title: "Advanced Configurations"
           category: Directory
           menu:
+          - title: "Portal API Catalogue"
+            path: /getting-started/key-concepts/api-catalogue
+            category: Page
           - title: "Developer Profiles"
             path: /tyk-developer-portal/tyk-portal-classic/developer-profiles
             category: Page
@@ -1831,7 +1785,7 @@ menu:
       - title: "Troubleshooting"
         category: Directory
         menu:
-      - title: "Release notes"
+      - title: "Release Notes"
         category: Directory
         menu:
         - title: "Changelog"
@@ -1960,7 +1914,17 @@ menu:
         category: Directory
         menu:
         - title: "Configure Data Sinks"
-          category: Page
+          category: Directory
+          menu:
+          - title: "Datadog Setup"
+            path: /tyk-configuration-reference/tyk-pump-configuration/datadog
+            category: Page
+          - title: "Moesif Setup"
+            path: /tyk-configuration-reference/tyk-pump-configuration/moesif
+            category: Page
+          - title: "Splunk Setup"
+            path: /tyk-configuration-reference/tyk-pump-configuration/splunk
+            category: Page
         - title: "Monitor your APIs with Prometheus"
           path: /tyk-stack/tyk-pump/other-data-stores/monitor-apis-prometheus
           category: Page
@@ -1988,7 +1952,7 @@ menu:
         - title: "Useful Debug Modes"
           path: /tyk-stack/tyk-pump/useful-debug-modes
           category: Page
-      - title: "Release notes"
+      - title: "Release Notes"
         category: Directory
         menu:
         - title: "Changelog"
@@ -1999,8 +1963,6 @@ menu:
         - title: "Release highlights and upgrades"
           category: Directory
           menu:
-          - title: "[version]"
-            category: Page
       - title: "Supported Backends"
         path: /tyk-stack/tyk-pump/other-data-stores
         category: Page
@@ -2045,7 +2007,7 @@ menu:
       - title: "Troubleshooting"
         category: Directory
         menu:
-      - title: "Release notes"
+      - title: "Release Notes"
         category: Directory
         menu:
         - title: "Changelog"
@@ -2057,8 +2019,6 @@ menu:
         - title: "Release highlights and upgrades"
           category: Directory
           menu:
-          - title: "[version]"
-            category: Page
     - title: "Tyk Sync"
       category: Directory
       menu:
@@ -2096,6 +2056,12 @@ menu:
         - title: "TIB implementation with GitHub and OAuth 2.0"
           path: /tyk-stack/tyk-identity-broker/auth-user-for-api-access-github-oauth
           category: Page
+      - title: "Key Concepts"
+        category: Directory
+        menu:
+        - title: "About TIB Profiles"
+          path: /tyk-stack/tyk-identity-broker/about-profiles
+          category: Page
       - title: "API Documentation"
         category: Directory
         menu:
@@ -2114,7 +2080,7 @@ menu:
       - title: "Troubleshooting"
         category: Directory
         menu:
-      - title: "Release notes"
+      - title: "Release Notes"
         category: Directory
         menu:
   - title: "Developer Support"
@@ -2123,30 +2089,19 @@ menu:
     menu:
     - title: "Overview"
       category: Page
-    - title: "Tyk APIs reference"
+    - title: "Tyk APIs Reference"
       category: Directory
       menu:
-      - title: "Tyk APIs"
-        path: /tyk-apis
-        category: Page
     - title: "SDK"
       category: Hide
       menu:
     - title: "CLI"
       category: Hide
       menu:
-    - title: "Config reference"
-      category: Page
-    - title: "Debugging series"
+    - title: "Debugging Series"
       category: Directory
       menu:
-      - title: "Debugging Series"
-        path: /debugging-series/debugging-series
-        category: Page
-      - title: "MongoDB Debugging"
-        path: /debugging-series/mongodb-debugging
-        category: Page
-    - title: "Performance benchmarketing"
+    - title: "Performance Benchmarking"
       category: Directory
       menu:
     - title: "Troubleshooting and FAQ"
@@ -2170,30 +2125,46 @@ menu:
       - title: "All tyk container logs show up under the error status in Datadog logs"
         path: /frequently-asked-questions/datadog-logs-showup-as-errors
         category: Page
-    - title: "Marketplace of plugin, dev repositories and code snippet"
+    - title: "Marketplace of plugin, dev repositories and code snippets"
       category: Page
-    - title: "Tyk release summary"
-      category: Page
+    - title: "Tyk Release Summary"
+      category: Directory
+      menu:
     - title: "Contribute to Tyk Docs"
-      category: Page
-  - title: "APIM Best Practices"
+      category: Directory
+      menu:
+      - title: "Contribute"
+        path: /contribute
+        category: Page
+    - title: "Configuration Reference"
+      category: Directory
+      menu:
+      - title: "Tyk Environment Variables"
+        path: /tyk-environment-variables
+        category: Page
+  - title: "APIM Best Practice"
     path: /getting-started/key-concepts
     category: Tab
     menu:
     - title: "Overview"
       category: Page
-    - title: "API security best practice"
+    - title: "API Security Best Practice"
       category: Page
-    - title: "FLAPIM best practice"
+    - title: "API Lifecycle Best Practice"
       category: Page
-    - title: "API architectural patterns"
+    - title: "API Platform Architectures"
       category: Page
-    - title: "Sector specific guides"
+    - title: "Sector Specific Guides"
+      category: Page
+    - title: "API Observability"
+      category: Page
+    - title: "API Products"
       category: Page
     - title: "APIs as integration"
       category: Page
     - title: "Creating a PoC"
-      category: Page
+      category: Hide
+      menu:
     - title: "Deploy Tyk OSS using new Helm Chart"
       path: /tyk-oss/ce-helm-chart-new/
       category: Page
@@ -2235,6 +2206,9 @@ menu:
       category: Page
     - title: "Managing Edge Gateways"
       path: /tyk-cloud/environments-deployments/managing-gateways/
+      category: Page
+    - title: "Environments & Deployments"
+      path: /tyk-cloud/environments-deployments/
       category: Page
     - title: "Username and Password Grant Type"
       path: /basic-config-and-security/security/authentication-authorization/oauth2-0/username-password-grant/
@@ -2316,9 +2290,6 @@ menu:
       category: Page
     - title: "Response Plugins"
       path: /plugins/plugin-types/response-plugins/
-      category: Page
-    - title: "FAQ"
-      path: /frequently-asked-questions/faq/
       category: Page
     - title: "Analytics Plugins"
       path: /plugins/plugin-types/analytics-plugins/

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -726,6 +726,9 @@ menu:
           - title: "Authentication and Authorization"
             category: Directory
             menu:
+            - title: "Authentication & Authorization"
+              path: /basic-config-and-security/security/authentication-authorization
+              category: Page
             - title: "Basic Authentication"
               path: /basic-config-and-security/security/authentication-authorization/basic-auth
               category: Page
@@ -2191,50 +2194,56 @@ menu:
       category: Page
     - title: "Creating a PoC"
       category: Page
+    - title: "Deploy Tyk OSS using new Helm Chart"
+      path: /tyk-oss/ce-helm-chart-new/
+      category: Page
     - title: "Managing Organisations"
-      path: /tyk-cloud/environments--deployments/managing-organisations/
+      path: /tyk-cloud/environments-deployments/managing-organisations/
       category: Page
     - title: "Authorization Code Grant Type"
-      path: /basic-config-and-security/security/authentication--authorization/oauth2-0/auth-code-grant/
+      path: /basic-config-and-security/security/authentication-authorization/oauth2-0/auth-code-grant/
+      category: Page
+    - title: "JWT and Keycloak with Tyk"
+      path: /basic-config-and-security/security/authentication-authorization/json-web-tokens/jwt-keycloak/
       category: Page
     - title: "Managing Environments"
-      path: /tyk-cloud/environments--deployments/managing-environments/
+      path: /tyk-cloud/environments-deployments/managing-environments/
       category: Page
     - title: "Managing Teams"
-      path: /tyk-cloud/teams--users/managing-teams/
+      path: /tyk-cloud/teams-users/managing-teams/
       category: Page
     - title: "Refresh Token Grant Type"
-      path: /basic-config-and-security/security/authentication--authorization/oauth2-0/refresh-token-grant/
+      path: /basic-config-and-security/security/authentication-authorization/oauth2-0/refresh-token-grant/
       category: Page
     - title: "Update an OAS API"
       path: /getting-started/using-oas-definitions/update-an-oas-api/
       category: Page
     - title: "Managing Control Planes"
-      path: /tyk-cloud/environments--deployments/managing-control-planes/
+      path: /tyk-cloud/environments-deployments/managing-control-planes/
       category: Page
     - title: "Configuration Options"
       path: /tyk-cloud/configuration-options/
       category: Page
     - title: "Managing Users"
-      path: /tyk-cloud/teams--users/managing-users/
+      path: /tyk-cloud/teams-users/managing-users/
       category: Page
     - title: "Tyk Cloud User Roles"
-      path: /tyk-cloud/teams--users/user-roles/
+      path: /tyk-cloud/teams-users/user-roles/
       category: Page
     - title: "ID Extractor"
       path: /plugins/plugin-types/auth-plugins/id-extractor/
       category: Page
     - title: "Managing Edge Gateways"
-      path: /tyk-cloud/environments--deployments/managing-gateways/
-      category: Page
-    - title: "Environments & Deployments"
-      path: /tyk-cloud/environments--deployments/
+      path: /tyk-cloud/environments-deployments/managing-gateways/
       category: Page
     - title: "Username and Password Grant Type"
-      path: /basic-config-and-security/security/authentication--authorization/oauth2-0/username-password-grant/
+      path: /basic-config-and-security/security/authentication-authorization/oauth2-0/username-password-grant/
+      category: Page
+    - title: "Deploy Hybrid Gateways using new Helm Chart"
+      path: /tyk-cloud/environments-deployments/hybrid-gateways-helm/
       category: Page
     - title: "Teams & Users"
-      path: /tyk-cloud/teams--users/
+      path: /tyk-cloud/teams-users/
       category: Page
     - title: "“301 Moved permanently“ error in the Dashboard API"
       path: /troubleshooting/tyk-cloud-classic/301-moved-permanently/
@@ -2273,28 +2282,25 @@ menu:
       path: /troubleshooting/tyk-installation/404-trying-access-tyk-gateway-repo/
       category: Page
     - title: "Client Credentials Grant Type"
-      path: /basic-config-and-security/security/authentication--authorization/oauth2-0/client-credentials-grant/
-      category: Page
-    - title: "Authentication & Authorization"
-      path: /basic-config-and-security/security/authentication--authorization/
+      path: /basic-config-and-security/security/authentication-authorization/oauth2-0/client-credentials-grant/
       category: Page
     - title: "Tyk Cloud Classic"
       path: /troubleshooting/tyk-cloud/
       category: Page
     - title: "Managing APIs"
-      path: /tyk-cloud/environments--deployments/managing-apis/
+      path: /tyk-cloud/environments-deployments/managing-apis/
       category: Page
     - title: "Monitoring"
-      path: /tyk-cloud/environments--deployments/monitoring/
+      path: /tyk-cloud/environments-deployments/monitoring/
       category: Page
     - title: "Tyk Cloud FAQs"
-      path: /tyk-cloud/troubleshooting--support/faqs/
+      path: /tyk-cloud/troubleshooting-support/faqs/
       category: Page
     - title: "Troubleshooting & Support"
-      path: /tyk-cloud/troubleshooting--support/
+      path: /tyk-cloud/troubleshooting-support/
       category: Page
     - title: "Glossary"
-      path: /tyk-cloud/troubleshooting--support/glossary/
+      path: /tyk-cloud/troubleshooting-support/glossary/
       category: Page
     - title: "CICD - Automating Your Plugin Builds"
       path: /plugins/get-started-selfmanaged/deploy-plugins/

--- a/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
+++ b/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
@@ -3,6 +3,7 @@
    {{- $path := .File.Path }}
    {{- $url := printf "%s" (replace $value.RelPermalink "/docs/" "/") }}
    {{- $url = printf "%s" (replace $url "/nightly/" "/") }}
+   {{- $url = printf "%s" (replace $url "--" "-") }}
    {{- printf "{\"path\":\"%s\", \"title\":\"%s\", \"file\": \"./content/%s\"}\n" $url $title $path}}
    {{- range $value.Aliases }}
      {{- $from := strings.TrimPrefix " " . }}
@@ -11,3 +12,4 @@
      {{- printf "{\"path\":\"/docs/%s\", \"file\":\"./content/%s\", \"alias\":true}\n" $from $path}}
    {{- end }}
  {{- end }}
+ 


### PR DESCRIPTION
This PR recreates the changes in [PR 2623](https://github.com/TykTechnologies/tyk-docs/pull/2623) to avoid merging the rebased multiple commits. This relates to ticket [DX-363](https://tyktech.atlassian.net/browse/DX-363) and [DX-362](https://tyktech.atlassian.net/browse/DX-362). 

The PR relates to fixing the broken nav links GH checks introduced by reserved & characters in the file path. Hugo `PermaLink` strips the & to -- in list.urlcheck.json 

Steps to get navlink checks working for htmltest etc

list.urlcheck.json add new line to replace -- with -, i.e. {{- $url = printf "%s" (replace $url "--" "-") }}
run hugo
run python script to generate the data/menu.yaml file from the urlcheck.json paths.
The resultant menu.yaml file needs committed for html link checks to pass

https://deploy-preview-2623--tyk-docs.netlify.app/docs/nightly

The following paths and referencing links to them need checking from files under the following content directories:

- tyk-cloud/environments-&-deployments
- tyk-cloud/teams-&-users
- tyk-cloud/troubleshooting-&-support
- basic-config-and-security/security/authentication-&-authorization


[DX-362]: https://tyktech.atlassian.net/browse/DX-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DX-363]: https://tyktech.atlassian.net/browse/DX-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ