### PR TITLE
[DX-329] Add release 5.1 to dropdown and make 4.3 selected menu item

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -163,9 +163,11 @@
          <div style="padding-left: 30px">
             <label for="version-selector">Version: </label>
             <select onchange="var path = location.pathname.match('\/docs\/(?:nightly|[1-9][^\/]*\)?(.*)')[1].replace(/^\//,''); window.location = this.options[this.selectedIndex].value + path" id="version-selector" style="border: 1px solid #ccc">
-              <option value="/docs/" selected="selected" >Latest - 4.3</option>
+              <option value="/docs/">Latest - 5.1</option>
+              <option value="/docs/5.0/">5 LTS</option>
+              <option value="/docs/4.3/">4.3</option>
               <option value="/docs/4.2/">4.2</option>
-              <option value="/docs/4.1/">4.1</option>
+              <option value="/docs/4.1/" selected="selected">4.1</option>
               <option value="/docs/4.0/">4 LTS</option>
               <option value="/docs/3.2/">3.2</option>
               <option value="/docs/3.1/">3.1</option>


### PR DESCRIPTION
Add release 5.1 to dropdown and make 4.3 selected menu item

[DX-329](https://tyktech.atlassian.net/browse/DX-329)

GitHub checks are displayed as pending on preceding PR. Testing if this is due to branches of release-* being used as deploy branches in Netlify.

The checks that are stalled are
- Link checker
- Deploy
- Htmltest

Why do these stall for child branches of release-x.x?

[DX-329]: https://tyktech.atlassian.net/browse/DX-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ