### PR TITLE
update baseurl to remove docs/nightly

### DIFF
--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -1,4 +1,4 @@
-baseurl = "//tyk.io/docs/nightly/"
+baseurl = "//tyk.io/docs"
 languageCode = "en-gb"
 title = "Tyk Documentation"
 theme = "tykio"


### PR DESCRIPTION
Remove /docs/nightly from baseurl in hugo config.toml of release-5.1 branch