### PR TITLE
Update Stable branch update GH action to make release-5.1 the stable branch (DO NOT MERGE UNTIL AFTER RELEASE!)

### DIFF
--- a/.github/workflows/stable-updater.yaml
+++ b/.github/workflows/stable-updater.yaml
@@ -9,14 +9,13 @@ on:
 jobs:
   stable:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/release-5'
+    if: github.ref == 'refs/heads/release-5.1'
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true  # Fetch Hugo themes (true OR recursive)
-          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+          submodules: true # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
       - name: Update branch
         run: |
           git checkout -b stable
           git push origin -f stable
-


### PR DESCRIPTION
Update Stable branch update GH action to make release-5.1 the stable branch.

This needs to be merged to master and also it should exist on the release-5.1 branch. This is similar to what the state of release-5 branch was during release.