### PR TITLE
Update hugo config.toml in release 5.1 branch so that baseurl has trailing slash

### DIFF
--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -1,4 +1,4 @@
-baseurl = "//tyk.io/docs"
+baseurl = "//tyk.io/docs/"
 languageCode = "en-gb"
 title = "Tyk Documentation"
 theme = "tykio"


### PR DESCRIPTION
Update config.toml in release 5.1 branch to update baseurl with trailing slash

baseurl=//tyk.io/docs/


