### PR TITLE
[DX-402] Update APIM Best Practices tab so maps to path "" : This will display home tab when clicked

### DIFF
--- a/scripts/menu_generator.py
+++ b/scripts/menu_generator.py
@@ -192,7 +192,7 @@ with open(categories_path, "r") as file:
                     "Managing APIs": "/getting-started",
                     "Product Stack": "/tyk-stack",
                     "Developer Support": "/frequently-asked-questions/faq",
-                    "APIM Best Practice": "/getting-started/key-concepts",
+                    "APIM Best Practice": "",
                     "Orphan": "/orphan",
                 }
 


### PR DESCRIPTION
- The python script has been updated so that the tabURLs for APIM Best Practice maps to empty string instead of getting-started/keyconcepts. This was causing a duplicate tabs to be highlighted as active (Product Stack) and (APIM Best Practice)

Please note that the spreadsheet data must be updated so that Delete Page is added to the bottom of the data bank. This will ensure that Data Bank appears as the rightmost menu tab.
