### PR TITLE
[DX-344] Add cases insensitive matching between data bank and paths mappings: Fixes Developer Support Tab Menu Items

### DIFF
--- a/scripts/menu_generator.py
+++ b/scripts/menu_generator.py
@@ -52,7 +52,7 @@ fileMaybeDelete = outputFileName + "-maybeDelete.txt"
 fileDoesntExists = outputFileName + "-doesntExists.txt"
 fileUrlCheckNoTitle = outputFileName + "-urlcheck-noTitle.txt"
 fileUrlCheckAliases = outputFileName + "-urlcheck-aliases.txt"
-fileCaseInsensitiveMatches = outputFileName + "-urlcheck-caseInsensitiveMatches.txt"
+fileCaseInsensitiveMatches = outputFileName + "-caseInsensitiveMappings.txt"
 fileMenu = "./tyk-docs/data/menu.yaml"
 
 # Open the output files
@@ -240,7 +240,7 @@ with open(pages_path, "r") as file:
 
     # Iterate over rows in the CSV file
     counter = 0
-    for row in reader:
+    for row_index, row in enumerate(reader):
         if counter < 1:
             counter += 1
             continue
@@ -277,7 +277,7 @@ with open(pages_path, "r") as file:
                     current_level = node["children"]
                     found = True
                     print(
-                        f"Databank = {node['name']}    Page List = {part}",
+                        f"Row#:{row_index+1} :: Path={data[0]} :: Databank={node['name']} :: Page List={part}",
                         file=openCaseInsensitiveMatches,
                     )
                     break

--- a/scripts/menu_generator.py
+++ b/scripts/menu_generator.py
@@ -262,10 +262,12 @@ with open(pages_path, "r") as file:
         parts = data[2].split(" --> ")
         current_level = tree
         found = True
+
         for i, part in enumerate(parts):
             found = False
+            lowercase_part = part.lower()
             for node in current_level:
-                if node["name"] == part:
+                if node["name"].lower() == lowercase_part:
                     current_level = node["children"]
                     found = True
                     break

--- a/scripts/menu_generator.py
+++ b/scripts/menu_generator.py
@@ -52,6 +52,7 @@ fileMaybeDelete = outputFileName + "-maybeDelete.txt"
 fileDoesntExists = outputFileName + "-doesntExists.txt"
 fileUrlCheckNoTitle = outputFileName + "-urlcheck-noTitle.txt"
 fileUrlCheckAliases = outputFileName + "-urlcheck-aliases.txt"
+fileCaseInsensitiveMatches = outputFileName + "-urlcheck-caseInsensitiveMatches.txt"
 fileMenu = "./tyk-docs/data/menu.yaml"
 
 # Open the output files
@@ -63,6 +64,7 @@ openDoesntExists = open(fileDoesntExists, "w")
 openFileMenu = open(fileMenu, "w")
 openUrlCheckNoTitle = open(fileUrlCheckNoTitle, "w")
 openUrlCheckAliases = open(fileUrlCheckAliases, "w")
+openCaseInsensitiveMatches = open(fileCaseInsensitiveMatches, "w")
 
 #
 # Mapping of paths in urlcheck to title
@@ -267,9 +269,17 @@ with open(pages_path, "r") as file:
             found = False
             lowercase_part = part.lower()
             for node in current_level:
-                if node["name"].lower() == lowercase_part:
+                if node["name"] == part:
                     current_level = node["children"]
                     found = True
+                    break
+                elif node["name"].lower() == lowercase_part:
+                    current_level = node["children"]
+                    found = True
+                    print(
+                        f"Databank = {node['name']}    Page List = {part}",
+                        file=openCaseInsensitiveMatches,
+                    )
                     break
 
         if found:
@@ -344,3 +354,4 @@ openOrphanFile.close()
 openMaybeDelete.close()
 openFileMenu.close()
 openUrlCheckNoTitle.close()
+openCaseInsensitiveMatches.close()


### PR DESCRIPTION
Update Python script to add case insensitive matching between data bank and mapped paths.
Occurrences of case insensitive matches are written to file _check-pages-urlcheck-caseInsensitiveMatches.txt_

This fixes empty menu items in Developer Support:
- Debugging Series
- Release Summary
- Tyk API reference

[DX-344](https://tyktech.atlassian.net/browse/DX-344)



[DX-344]: https://tyktech.atlassian.net/browse/DX-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ