### PR TITLE
4.3 trailing slash add in dropdown list of release 4.2

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -157,7 +157,7 @@
             <select onchange="var path = location.pathname.match('\/docs\/(?:nightly|[1-9][^\/]*\)?(.*)')[1].replace(/^\//,''); window.location = this.options[this.selectedIndex].value + path" id="version-selector" style="border: 1px solid #ccc">
               <option value="/docs/">Latest - 5.1</option>
               <option value="/docs/5.0/">5 LTS</option>
-              <option value="/docs/4.3">4.3</option>
+              <option value="/docs/4.3/">4.3</option>
               <option value="/docs/4.2/" selected="selected">4.2</option>
               <option value="/docs/4.1/">4.1</option>
               <option value="/docs/4.0/">4 LTS</option>

--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -155,7 +155,9 @@
          <div style="padding-left: 30px">
             <label for="version-selector">Version: </label>
             <select onchange="var path = location.pathname.match('\/docs\/(?:nightly|[1-9][^\/]*\)?(.*)')[1].replace(/^\//,''); window.location = this.options[this.selectedIndex].value + path" id="version-selector" style="border: 1px solid #ccc">
-              <option value="/docs/">Latest - 4.3</option>
+              <option value="/docs/">Latest - 5.1</option>
+              <option value="/docs/5.0/">5 LTS</option>
+              <option value="/docs/4.3">4.3</option>
               <option value="/docs/4.2/" selected="selected">4.2</option>
               <option value="/docs/4.1/">4.1</option>
               <option value="/docs/4.0/">4 LTS</option>


### PR DESCRIPTION
add trailing slash to 4.3 drop down to fix the broken link that was previously occurring