### PR TITLE
[DX-406] add release 5 LTS + release 5.1 to release 4.3 version dropdowns

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -140,8 +140,9 @@
          <div style="padding-left: 30px">
             <label for="version-selector">Version: </label>
             <select onchange="var path = location.pathname.match('\/docs\/(?:nightly|[1-9][^\/]*\)?(.*)')[1].replace(/^\//,''); window.location = this.options[this.selectedIndex].value + path" id="version-selector" style="border: 1px solid #ccc">
-              <option value="/docs/">Latest - 5.0</option>
-              <option value="/docs/4.3" selected="selected">4.3</option>
+              <option value="/docs/">Latest - 5.1</option>
+              <option value="/docs/5.0/">5 LTS</option>
+              <option value="/docs/4.3/" selected="selected">4.3</option>
               <option value="/docs/4.2/">4.2</option>
               <option value="/docs/4.1/">4.1</option>
               <option value="/docs/4.0/">4 LTS</option>


### PR DESCRIPTION
add release 5 LTS + release 5.1 to release 4.3 version drop downs

Try adding trailing slash to selected 4.3 to see if it fixes broken links

Adding a trailing slash does still not fix the broken links