### PR TITLE
fix weighting so that mcdb 2.3 appears first in list of release notes

### DIFF
--- a/tyk-docs/content/release-notes/mdcb-2.3.md
+++ b/tyk-docs/content/release-notes/mdcb-2.3.md
@@ -3,14 +3,16 @@ title: MDCB v2.3
 menu:
   main:
     parent: "Release Notes"
-weight: 254
+weight: 252
 ---
 
 ## 2.3.0
+
 Release date: 2023-06-28
 
 MDCB 2.3.0 is an update for compatibility for synchronisation with Tyk v5.1 API Definitions.
 
 ### Updated
+
 - Update MDCB to Go 1.19
 - Update for compatibility with API definitions for Tyk v5.1


### PR DESCRIPTION
adjust weighting for mcdb release note 2.3 so that appears first in list of mcdb releases