### PR TITLE
Merging to release-5.1: fix release note weighting for mcdb 2.3 (#2826)

### DIFF
--- a/tyk-docs/content/release-notes/mdcb-2.3.md
+++ b/tyk-docs/content/release-notes/mdcb-2.3.md
@@ -3,14 +3,16 @@ title: MDCB v2.3
 menu:
   main:
     parent: "Release Notes"
-weight: 254
+weight: 252
 ---
 
 ## 2.3.0
+
 Release date: 2023-06-28
 
 MDCB 2.3.0 is an update for compatibility for synchronisation with Tyk v5.1 API Definitions.
 
 ### Updated
+
 - Update MDCB to Go 1.19
 - Update for compatibility with API definitions for Tyk v5.1


### PR DESCRIPTION
fix release note weighting for mcdb 2.3 (#2826)

fix release note weighting for mcdb 2.3

Co-authored-by: Simon Pears <simon@tyk.io>