### PR TITLE
python no longer needs alternative binary

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/python/tutorial-add-demo-plugin-api.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/python/tutorial-add-demo-plugin-api.md
@@ -74,25 +74,3 @@ To enable Python plugins you need to add the following block to `tyk.conf`:
 `bundle_base_url`: is a base URL that will be used to download the bundle, in this example we have `test-bundle` specified in the API settings, Tyk will fetch the URL for your specified bundle server (in the above example): `dummy-bundle-server.com/bundles/test-bundle`. You need to create and then specify your own bundle server URL.
 
 `public_key_path`: sets a public key, this is used for verifying signed bundles, you may omit this if unsigned bundles are used. 
-
-## Running the Tyk Python Gateway build
-
-To use Tyk with Python support you will need to use an alternative binary, it is provided in the standard Tyk package but it has a different service name.
-
-Firstly stop the standard Tyk version:
-
-```{.copyWrapper}
-service tyk-gateway stop
-```
-
-and then start the Python build:
-
-```{.copyWrapper}
-service tyk-gateway-python start
-```
-
-To restart Tyk use:
-
-```{.copyWrapper}
-service tyk-gateway-python restart
-```


### PR DESCRIPTION


## Related Issue (if applicable)
<!-- If applicable, please reference to a related issue in this repository. -->

## Description
<!-- Describe your changes in detail.
     Please explain the change to the reviewer. For example, if it's a change in the file name or directory 
     name please flag it out since it’s hard to compare text after such a change -->

Deleted the Running the Tyk Python Gateway build section 
https://community.tyk.io/t/python-middleware-error-when-trying-example-from-documentation/4700/7 
"I’m afraid that is out of date. Python support has been in the default binary since the release of 2.9. There is no extra service that needs to be started."

<!-- Provide a summary of your changes in the title above 
     Please remember to add the following: 
     - A description of the changes proposed in the pull request. 
       Please explain the change to the reviewer. Pay special attention for changes that are hard to spot, 
       for example, if it's a change in the file name or directory name please flag it out since it’s hard 
       to compare text after such a change 
     - @mentions of the person or team responsible for reviewing proposed changes. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
service tyk-gateway-python start returns unrecognized service

## Preview Link
<!-- Add a preview link to make it easier for reviewer to review. -->
## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fixing typo (please merge to production)
- [ ] Documenting a new feature (please merge to production)
- [ ] Documentation for future release (please do not merge to production)
- [x ] Something else (please add if needs merging to production or not)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ x] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [x ] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x ] Make sure you have started *your change* off *our latest `master`*.
- [x ] I have added a preview link.
