### PR TITLE
[DX-435] Update hugo version in htmltest ghub action

### DIFF
--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.92.1'
+          hugo-version: '0.111.3'
           extended: true
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Update hugo version in htmltest ghub action to test if this resolves the broken nav links reported by htmltest ghub action??

[DX-435](https://tyktech.atlassian.net/browse/DX-435)

[DX-435]: https://tyktech.atlassian.net/browse/DX-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ