### PR TITLE
[DX-436] Skip empty Path Type column values in data-bank spreadsheet

### DIFF
--- a/scripts/menu_generator.py
+++ b/scripts/menu_generator.py
@@ -52,6 +52,7 @@ fileDoesntExists = outputFileName + "-doesntExists.txt"
 fileUrlCheckNoTitle = outputFileName + "-urlcheck-noTitle.txt"
 fileUrlCheckAliases = outputFileName + "-urlcheck-aliases.txt"
 fileCaseInsensitiveMatches = outputFileName + "-caseInsensitiveMappings.txt"
+fileBlankPagePathInDataBank = outputFileName + "-blankFilePaths.txt"
 fileMenu = "./tyk-docs/data/menu.yaml"
 
 # Open the output files
@@ -63,6 +64,7 @@ openFileMenu = open(fileMenu, "w")
 openUrlCheckNoTitle = open(fileUrlCheckNoTitle, "w")
 openUrlCheckAliases = open(fileUrlCheckAliases, "w")
 openCaseInsensitiveMatches = open(fileCaseInsensitiveMatches, "w")
+openBlankPagePathInDataBank=open(fileBlankPagePathInDataBank, "w")
 
 #
 # Mapping of paths in urlcheck to title
@@ -127,7 +129,7 @@ with open(categories_path, "r") as file:
 
     # Iterate over rows in the CSV file
     counter = 0
-    for row in reader:
+    for row_index, row in enumerate(reader):
         if counter < 5:
             counter += 1
             continue
@@ -135,6 +137,11 @@ with open(categories_path, "r") as file:
         # ignore the first 2 columns in data-bank.csv
         # continue until reach end of the list marker
         data = row[3:]
+
+        if data[1] == "":
+            print(f"Blank Path Type at row {row_index+1} of data-bank spreadsheet : skipping", file=openBlankPagePathInDataBank)
+            continue
+
         if "End of the list" in data[0]:
             break
 
@@ -393,3 +400,4 @@ openOrphanFile.close()
 openFileMenu.close()
 openUrlCheckNoTitle.close()
 openCaseInsensitiveMatches.close()
+openBlankPagePathInDataBank.close()

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -559,9 +559,6 @@ menu:
             path: /tyk-stack/tyk-operator/tyk-operator-reconciliation
             category: Page
             show: True
-  - title: ""
-    category: 
-    menu:
   - title: "Managing APIs"
     path: /getting-started
     category: Tab


### PR DESCRIPTION
Please note that this PR needs merging after https://github.com/TykTechnologies/tyk-docs/pull/2849. That contains the fixes for broken nav links, fixed by updating hugo version to 0.111.3.

In the data-bank spreadsheet sometimes the _Page Path_ column has a blank path. Update the Python script to skip these, otherwise we get menu items with blank title and category appear in menu.yaml.

Log to file the instances where these occur and skip to the next row when reading the data-bank.csv file.

[preview](https://deploy-preview-2853--tyk-docs.netlify.app/docs/nightly)
[DX-436](https://tyktech.atlassian.net/browse/DX-436)

This fixes red bars `|` appearing in the menu tabs

[DX-436]: https://tyktech.atlassian.net/browse/DX-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ