### PR TITLE
[DX-460] Fix mongoDB version compatibility with Tyk release 5.0.0 and 5.0.1

### DIFF
--- a/tyk-docs/content/shared/mongodb-versions-include.md
+++ b/tyk-docs/content/shared/mongodb-versions-include.md
@@ -4,7 +4,7 @@
 [MongoDB](https://www.mongodb.com) is our default storage option. We support the following versions:
 
 - MongoDB 4.4.x (with mgo driver)
-- MongoDB 4.4.x, 5.0.x, 6.0.x (with mongo-go driver)
+- MongoDB 4.4.x, 5.0.2+, 6.0.x (with mongo-go driver). Tyk 5.0.0 and 5.0.1 does not support mongoDB versions 5 or 6.
 
 {{< note success >}}
 **MongoDB 3.x to 4.2.x**

--- a/tyk-docs/content/shared/mongodb-versions-include.md
+++ b/tyk-docs/content/shared/mongodb-versions-include.md
@@ -4,7 +4,9 @@
 [MongoDB](https://www.mongodb.com) is our default storage option. We support the following versions:
 
 - MongoDB 4.4.x (with mgo driver)
-- MongoDB 4.4.x, 5.0.2+, 6.0.x (with mongo-go driver). Tyk 5.0.0 and 5.0.1 does not support mongoDB versions 5 or 6.
+- MongoDB 4.4.x, 5.0.x, 6.0.x (with mongo-go driver). 
+
+Note: mongo-go driver is available from Tyk 5.0.2.
 
 {{< note success >}}
 **MongoDB 3.x to 4.2.x**


### PR DESCRIPTION
Fix MongoDB version compatibility with Tyk release 5.0.0 and 5.0.1. Thanks for reporting, Asha Parulkar

https://tyktech.slack.com/archives/C51P42LLT/p1689153190425159

[DX-460](https://tyktech.atlassian.net/browse/DX-460)

[Preview](https://deploy-preview-2881--tyk-docs.netlify.app/docs/nightly/planning-for-production/database-settings/mongodb/#supported-versions)

[DX-460]: https://tyktech.atlassian.net/browse/DX-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ