### PR TITLE
[DX-464] Fix broken button links on homepage

### DIFF
--- a/tyk-docs/content/content.md
+++ b/tyk-docs/content/content.md
@@ -30,7 +30,7 @@ url: /
 
 {{< /grid >}}
 
-{{< button href="/apim" color="green" content="Compare" >}}
+{{< button href="apim" color="green" content="Compare" >}}
 
 ## The Tyk Stack
 

--- a/tyk-docs/content/content.md
+++ b/tyk-docs/content/content.md
@@ -74,7 +74,7 @@ The Tyk Identity Broker (TIB) is a microservice portal that provides a bridge be
 
 {{< /grid >}}
 
-{{< button href="/getting-started/key-concepts/" color="red" content="Tyk Concepts" >}}
+{{< button href="getting-started/key-concepts/" color="red" content="Tyk Concepts" >}}
 
 ## Feature Setups
 
@@ -106,6 +106,6 @@ Log into your Tyk Dashboard and Portal with your existing IDP.
 
 {{< /grid >}}
 
-{{< button href="/basic-config-and-security/" color="black" content="More Tyk Configuration" >}}
+{{< button href="basic-config-and-security/" color="black" content="More Tyk Configuration" >}}
 
 </div>


### PR DESCRIPTION
Remove / from href in the Compare button link

[DX-464](https://tyktech.atlassian.net/browse/DX-464)

[Preview](https://deploy-preview-2884--tyk-docs.netlify.app/docs/nightly)

[DX-464]: https://tyktech.atlassian.net/browse/DX-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ