### PR TITLE
Merging to release-5.1: [DX-460] Fix mongoDB version compatibility with Tyk release 5.0.0 and 5.0.1 (#2881)

### DIFF
--- a/tyk-docs/content/shared/mongodb-versions-include.md
+++ b/tyk-docs/content/shared/mongodb-versions-include.md
@@ -4,7 +4,9 @@
 [MongoDB](https://www.mongodb.com) is our default storage option. We support the following versions:
 
 - MongoDB 4.4.x (with mgo driver)
-- MongoDB 4.4.x, 5.0.x, 6.0.x (with mongo-go driver)
+- MongoDB 4.4.x, 5.0.x, 6.0.x (with mongo-go driver). 
+
+Note: mongo-go driver is available from Tyk 5.0.2.
 
 {{< note success >}}
 **MongoDB 3.x to 4.2.x**


### PR DESCRIPTION
[DX-460] Fix mongoDB version compatibility with Tyk release 5.0.0 and 5.0.1 (#2881)

fix mongoDB version compatibility with Tyk release 5.0.0 and 5.0.1

Co-authored-by: Simon Pears <simon@tyk.io>
Co-authored-by: caroltyk <97617859+caroltyk@users.noreply.github.com>

[DX-460]: https://tyktech.atlassian.net/browse/DX-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ