### PR TITLE
[DX-436] Add safety check when generating yaml in menu generator script to avoid printing empty titles

### DIFF
--- a/scripts/menu_generator.py
+++ b/scripts/menu_generator.py
@@ -320,6 +320,9 @@ def print_tree_as_yaml(tree, level=1):
     for node in tree:
         title = node["name"]
         
+        if title == "" and "url" not in node and "category" in node:
+           continue
+
         if "url" in node and node["category"] != "Tab":
             try:
                 title = title_map[node["url"].replace("/", "")]


### PR DESCRIPTION
Update Python script when generating yaml to ignore nodes generated with the following properties:

- title with empty string
- a category has been assigned
- a url path has not been assigned

[DX-436](https://tyktech.atlassian.net/browse/DX-436)

[Preview](https://deploy-preview-2896--tyk-docs.netlify.app/docs/nightly)

[DX-436]: https://tyktech.atlassian.net/browse/DX-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ