### PR TITLE
Merging to release-5: [DX-477] Fix old helm chart docs (#2901)

### DIFF
--- a/tyk-docs/content/tyk-on-premises/kubernetes.md
+++ b/tyk-docs/content/tyk-on-premises/kubernetes.md
@@ -12,16 +12,13 @@ aliases:
   - /tyk-on-premises/kubernetes
 ---
 
-## Installing Tyk
-
-The main ways to install *Tyk Self-Managed* in a Kubernetes cluster are via Helm charts or via Kubernetes manifest files.
-
 ### Tyk Helm Charts
-This is the preferred way to install Tyk Self-Managed Pro on Kubernetes. 
+The main way to install *Tyk Self-Managed* in a Kubernetes cluster is via Helm charts. 
 We are actively working to add flexibility and more user flows to our chart. Please reach out
 to our teams on support or the cummunity forum if you have questions, requests or suggestions for improvements.
 Go to [Tyk Helm Charts]({{< ref "/content/tyk-self-managed/tyk-helm-chart.md" >}}) for detailed installation instructions.
 
 ## Tyk Operator and Ingress 
 For a GitOps workflow used with a **Tyk Self-Managed** installation or setting the Tyk Gateway as a Kubernetes ingress controller, Tyk Operator enables you to manage API definitions, security policies and other Tyk features using Kubernetes manifest files.
+To get started go to [Tyk Operator]({{< ref "tyk-stack/tyk-operator/getting-started-tyk-operator.md" >}}).
 

--- a/tyk-docs/content/tyk-oss/ce-kubernetes.md
+++ b/tyk-docs/content/tyk-oss/ce-kubernetes.md
@@ -9,20 +9,11 @@ menu:
 weight: 2
 ---
 
-## Installing Tyk
-The main ways to install the Open Source *Tyk Gateway* in a Kubernetes cluster are via Helm charts or via Kubernetes manifest files. 
-
 ### Tyk Helm Charts
-This is the preferred way to install Tyk Self-Managed Pro on Kubernetes. 
+The main way to install the Open Source *Tyk Gateway* in a Kubernetes cluster is via Helm charts. 
 We are actively working to add flexibility and more user flows to our chart. Please reach out
 to our teams on support or the cummunity forum if you have questions, requests or suggestions for improvements.
 Go to [Tyk OSS Helm Charts]({{< ref "tyk-oss/ce-helm-chart" >}}) for detailed installation instructions.
 
-### Kubernetes manifest files
-
-This is not the main support way to install Tyk but we do offer instruction on this installation choice in the repo
- [tyk-oss-k8s-deployment GitHub repo](https://github.com/TykTechnologies/tyk-oss-k8s-deployment).  
-For advice and help, reach out via the usual channels, our support team or the [Tyk community forum](https://community.tyk.io/).
-
 ### Tyk Operator and Ingress
-For GitOps workflow used with the *Tyk Gateway* or setting it as a Kubernetes ingress controller, Tyk Operator enables you to manage API definitions, security policies and other Tyk features using Kubernetes manifest files. 
+For GitOps workflow used with the *Tyk Gateway* or setting it as a Kubernetes ingress controller, Tyk Operator enables you to manage API definitions, security policies and other Tyk features using Kubernetes manifest files. To get started go to [Tyk Operator]({{< ref "tyk-stack/tyk-operator/getting-started-tyk-operator.md" >}}).


### PR DESCRIPTION
[DX-477] Fix old helm chart docs (#2901)

* Fix helm installation steps for OSS
* Fix helm installation instruction for tyk-pro
* Add link to operator in the docs
* Fix docs of on prem
* Update tyk-docs/content/tyk-on-premises/kubernetes.md

---------

Co-authored-by: dcs3spp <dcs3spp@users.noreply.github.com>

[DX-477]: https://tyktech.atlassian.net/browse/DX-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ