### PR TITLE
[DX-510] Update APIM Publish APIs with content detailed in DX-510

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -722,6 +722,22 @@ menu:
         category: Directory
         show: False
         menu:
+      - title: "Connect to a Provider"
+        path: "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/with-tyk-self-managed-as-provider/"
+        category: Page
+        show: True
+      - title: "Create and import API Products and Plans"
+        path: "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/create-api-product-and-plan/"
+        category: Page
+        show: True
+      - title: "Publish API Products and Plans to the Developer portal so that API consumers can access them"
+        path: "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/publish-api-products-and-plans/"
+        category: Page
+        show: True
+      - title: "Customise the navigation menu in the Developer portal for your specific API consumer audience."
+        path: "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/customise-menus/"
+        category: Page
+        show: True
       - title: "API Publishing"
         category: Directory
         show: False

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -716,7 +716,7 @@ menu:
           show: False
     - title: "Publish APIs"
       category: Directory
-      show: False
+      show: True
       menu:
       - title: "Overview"
         category: Directory


### PR DESCRIPTION
[DX-510](https://tyktech.atlassian.net/browse/DX-510)

[Preview](https://deploy-preview-2941--tyk-docs.netlify.app/docs/nightly/getting-started)

Add the 4 links outlined in this [page](https://tyk.io/docs/nightly/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/getting-started-with-enterprise-portal/) to APIM->Publish APIs
Should there be any other content?

The 4 pages are currently used in another menu, for example [Create Product Plans](https://deploy-preview-2941--tyk-docs.netlify.app/docs/nightly/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/create-api-product-and-plan/) in Product Stack->Tk Enterprise Portal

[DX-510]: https://tyktech.atlassian.net/browse/DX-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ