### PR TITLE
[DX-553] Remove troubleshooting link from FAQ page

### DIFF
--- a/tyk-docs/content/frequently-asked-questions/faq.md
+++ b/tyk-docs/content/frequently-asked-questions/faq.md
@@ -7,8 +7,7 @@ menu: main
 weight: 21
 ---
 
-As well as [FAQs]({{< ref "frequently-asked-questions/faq" >}}), this section contains the following references:
+Check this section for troubleshooting common issues, in addition to details relating to release notes and upgrading.
 
-* [Troubleshooting]({{< ref "troubleshooting" >}}) of common issues
 * [Release Notes]({{< ref "release-notes" >}})
 * [Upgrading]({{< ref "upgrading-tyk" >}}) information


### PR DESCRIPTION
[DX-553](https://tyktech.atlassian.net/browse/DX-553) Remove troubleshooting link from FAQ page

[Preview](https://deploy-preview-2970--tyk-docs.netlify.app/docs/nightly/frequently-asked-questions/faq)

[DX-553]: https://tyktech.atlassian.net/browse/DX-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ