### PR TITLE
[DX-552] Move /basic-config-and-security/security/dashboard to deprecated pages

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -2018,10 +2018,6 @@ menu:
           category: Directory
           show: True
           menu:
-          - title: "Dashboard"
-            path: /basic-config-and-security/security/dashboard
-            category: Page
-            show: True
           - title: "Create User Groups"
             path: /basic-config-and-security/security/dashboard/create-user-groups
             category: Page
@@ -3325,6 +3321,10 @@ menu:
       category: Directory
       show: False
       menu:
+      - title: "Dashboard"
+        path: /basic-config-and-security/security/dashboard
+        category: Page
+        show: True
       - title: "Tyk Cloud Classic"
         path: /advanced-configuration/manage-multiple-environments/with-tyk-cloud-classic
         category: Page


### PR DESCRIPTION
[DX-552](https://tyktech.atlassian.net/browse/DX-552) Move _/basic-config-and-security/security/dashboard_ to deprecated pages. It has been moved out from _Product Stack -> Tyk Dashboard -> Advanced Configurations -> User management -> Dashboard _ into hidden deprecated pages section in _Developer Support_

[Preview](https://deploy-preview-2995--tyk-docs.netlify.app/docs/nightly/basic-config-and-security/security/dashboard/create-user-groups/)


[DX-552]: https://tyktech.atlassian.net/browse/DX-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ