### PR TITLE
[DX-548] Deprecate Dashboard getting start page currently In Product Stack -> Tyk Dashboard

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -2002,10 +2002,6 @@ menu:
         path: /tyk-dashboard
         category: Page
         show: True
-      - title: "Get started"
-        path: /tyk-dashboard/getting-started
-        category: Page
-        show: True
       - title: "Advanced configurations"
         category: Directory
         show: True
@@ -3321,6 +3317,10 @@ menu:
       category: Directory
       show: False
       menu:
+      - title: "Get started"
+        path: /tyk-dashboard/getting-started
+        category: Page
+        show: True
       - title: "Tyk Cloud Classic"
         path: /advanced-configuration/manage-multiple-environments/with-tyk-cloud-classic
         category: Page


### PR DESCRIPTION
[DX-548](https://tyktech.atlassian.net/browse/DX-548) It moves _tyk-dashboard/getting-started/_ into deprecated pages from _Product Stack -> Tyk Dashboard -> Getting Started_

[Preview](https://deploy-preview-2996--tyk-docs.netlify.app/docs/nightly/tyk-dashboard/)

[DX-548]: https://tyktech.atlassian.net/browse/DX-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ