### PR TITLE
[DX-552] Deprecate dashboard getting started from Product Stack -> Advanced Configuration -> Managing Users

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -2022,10 +2022,6 @@ menu:
           category: Directory
           show: True
           menu:
-          - title: "Dashboard"
-            path: /basic-config-and-security/security/dashboard
-            category: Page
-            show: True
           - title: "Create User Groups"
             path: /basic-config-and-security/security/dashboard/create-user-groups
             category: Page
@@ -3329,6 +3325,10 @@ menu:
       category: Directory
       show: False
       menu:
+      - title: "Dashboard"
+        path: /basic-config-and-security/security/dashboard
+        category: Page
+        show: True
       - title: "Get started"
         path: /tyk-dashboard/getting-started
         category: Page


### PR DESCRIPTION
Re-opened a new PR due to merge conflicts for DX-552

[Preview](https://deploy-preview-3001--tyk-docs.netlify.app/docs/nightly/basic-config-and-security/security/dashboard/create-user-groups/)