### PR TITLE
[DX-581] Update secret docs for passing target url from env

### DIFF
--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -99,6 +99,15 @@ TYK_GW_USEDBAPPCONFIGS
 TYK_GW_POLICIES_POLICYSOURCE
 ```
 
+Additionally if you with to override either the listen path or target URL in an API definition you can store a number of secrets in this format:
+
+```
+TYK_SECRET_FOO
+TYK_SECRET_BAR
+```
+
+where foo is stored in your API Definition as `env://foo` or `env://bar`
+
 Example:  
 IF one enables the `kv` secrets engine under the path `secret` within Vault using:  
 `vault secrets enable -version=2 -path=secret kv`  

--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -99,7 +99,7 @@ TYK_GW_USEDBAPPCONFIGS
 TYK_GW_POLICIES_POLICYSOURCE
 ```
 
-Additionally if you with to override either the listen path or target URL in an API definition you can store a number of secrets in this format:
+Additionally if you wish to override either the listen path or target URL in an API definition you can store a number of secrets in this format:
 
 ```
 TYK_SECRET_FOO


### PR DESCRIPTION
It was undocumented that you can pass target url or listen path with the env var TYK_SECRET_{some string} and have that picked up in API definitions with env://{some string}

This is important functionality for users with shared api definitions that land on multiple clusters of gateways for example