### PR TITLE
Merging to release-5.1: DX-565 document multi_value_headers field (#2913)

### DIFF
--- a/tyk-docs/content/plugins/plugin-types/response-plugins.md
+++ b/tyk-docs/content/plugins/plugin-types/response-plugins.md
@@ -20,7 +20,7 @@ Since Tyk 3.0 we have incorporated response hooks, this type of hook allows you 
 
 This snippet illustrates the hook function signature:
 
-```
+```python
 @Hook
 def ResponseHook(request, response, session, metadata, spec):
     tyk.log("ResponseHook is called", "info")
@@ -47,6 +47,38 @@ The API definition should have this:
     }
 }
 ```
+
+Starting from versions 5.0.4 and 5.1.1+ for our Go, Python and Ruby users we have introduced the `multivalue_headers` field to facilitate more flexible and efficient management of headers, particularly for scenarios involving a single header key associated with multiple values.  The `multivalue_headers` field, similar to its predecessor, the `headers` field, is a key-value store. However, it can accommodate an array or list of string values for each key, instead of a single string value. This feature empowers you to represent multiple values for a single header key. Here's an example of how you might use `multivalue_headers`, using the Set-Cookie header which often has multiple values:
+
+```
+multivalue_headers = {
+    "Set-Cookie": ["sessionToken=abc123; HttpOnly; Secure", "language=en-US; Secure"],
+}
+```
+
+In this example, Set-Cookie header has two associated values: `"sessionToken=abc123; HttpOnly; Secure"` and `"language=en-US; Secure"`.  To help you understand this further, let's see how `multivalue_headers` can be used in a Tyk response plugin written in Python:
+
+```python
+from tyk.decorators import *
+from gateway import TykGateway as tyk
+
+@Hook
+def Del_ResponseHeader_Middleware(request, response, session, metadata, spec):
+    # inject a new header with 2 values
+    new_header = response.multivalue_headers.add()
+    new_header.key = "Set-Cookie"
+    new_header.values.extend("sessionToken=abc123; HttpOnly; Secure")
+    new_header.values.extend("language=en-US; Secure")
+    
+    tyk.log(f"Headers content :\n {response.headers}\n----------", "info")
+    tyk.log(f"Multivalue Headers updated :\n {response.multivalue_headers}\n----------", "info")
+    
+    return response
+```
+
+In this script, we add 2 values for the `Set-Cookie` header and then log both: the traditional `headers` and the new `multivalue_headers`. This is a great way to monitor your transition to `multivalue_headers` and ensure that everything is functioning as expected.
+
+Please note, while the `headers` field will continue to be available and maintained for backward compatibility, we highly encourage the adoption of `multivalue_headers` for the added flexibility in handling multiple header values.
 
 ### Go response plugins
 

--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -19,7 +19,7 @@ This page describes the data structures used by Tyk rich plugins, and is used in
 
 
 We keep our stable Protocol Buffer definitions in the following GitHub repository:
-[https://github.com/TykTechnologies/tyk-protobuf/proto](https://github.com/TykTechnologies/tyk-protobuf/tree/master/proto).
+[https://github.com/TykTechnologies/tyk/tree/master/coprocess/proto](https://github.com/TykTechnologies/tyk/tree/master/coprocess/proto).
 This is intended for users to generate their own bindings using the appropriate gRPC tools for the language used.
 
 ### MiniRequestObject (coprocess_mini_request_object.proto)
@@ -280,6 +280,12 @@ message ResponseObject {
   bytes raw_body = 2;
   string body = 3;
   map<string, string> headers = 4;
+  repeated Header multivalue_headers = 5;
+}
+
+message Header {
+  string key = 1;
+  repeated string values = 2;
 }
 ```
 
@@ -296,3 +302,8 @@ This field contains the HTTP response body in string format. It's not populated 
 
 `headers`
 A map that contains the headers sent by the upstream.
+
+`multivalue_headers`
+A list of headers, each header in this list is a structure that consists of two parts: a key and its corresponding values.
+The key is a string that denotes the name of the header, the values are a list of strings that hold the content of the header, this is useful when the header has multiple associated values.
+This field is available for Go, Python and Ruby since tyk v5.0.4 and  5.1.1+.


### PR DESCRIPTION
DX-565 document multi_value_headers field (#2913)

* document multivalue_headers field
* added text to say that is only available in certain languages
* updated grpc structure of response object
* update link where we store the proto files
---------

Co-authored-by: dcs3spp <dcs3spp@users.noreply.github.com>