### PR TITLE
[DX-523] Remove toc from pages

### DIFF
--- a/tyk-docs/content/getting-started/key-concepts/authentication.md
+++ b/tyk-docs/content/getting-started/key-concepts/authentication.md
@@ -9,8 +9,6 @@ menu:
 weight: 2
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 OAS has the concept of `securitySchemes` which describes one way in which an API may be accessed, e.g. with a token. You can have multiple securitySchemes defined for an API. You decide which is actually active by declaring that in the security section. When hosting an API with Tyk, the only remaining question is which part of the flow does this security validation? If you do nothing more, then Tyk will pass the authentication to the upstream. However if you do want Tyk to handle the authentication, then it is as simple as setting an authentication field in the `x-tyk-api-gateway` section of the Tyk OAS API Definition. 

--- a/tyk-docs/content/getting-started/key-concepts/high-level-concepts.md
+++ b/tyk-docs/content/getting-started/key-concepts/high-level-concepts.md
@@ -9,8 +9,6 @@ menu:
 weight: 1
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 OAS is a ‘vendor neutral’ specification for APIs. The great thing about this is that it means there are already a large number of tools that will help you design and create APIs in OAS, or even generate them from your source code. Tyk supports defining APIs in OAS, making it even easier to get your API up and running. 

--- a/tyk-docs/content/getting-started/key-concepts/oas-versioning.md
+++ b/tyk-docs/content/getting-started/key-concepts/oas-versioning.md
@@ -9,8 +9,6 @@ menu:
 weight: 5
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 Tyk considers API versioning a highly important topic when it comes to adopting an API Gateway solution for your APIs. Whether it's about transparently changing/improving your API (while offering backwards compatibility or graceful degradation), or maybe using versioning as environments for your APIs, Tyk has buit the new versioning system with your developer experience in mind, taking into consideration the way different teams are setup and how they collaborate over designing APIs.

--- a/tyk-docs/content/getting-started/key-concepts/paths.md
+++ b/tyk-docs/content/getting-started/key-concepts/paths.md
@@ -9,8 +9,6 @@ menu:
 weight: 4
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 The OAS API Definition represents the source of truth for the Tyk APIs, therefore, the configuration of the `paths` section within that will tell Tyk which endpoints are available to configure.

--- a/tyk-docs/content/getting-started/key-concepts/request-validation.md
+++ b/tyk-docs/content/getting-started/key-concepts/request-validation.md
@@ -9,8 +9,6 @@ menu:
 weight: 3
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 Tyk can protect any Gateway incoming request by validating the request

--- a/tyk-docs/content/getting-started/key-concepts/servers.md
+++ b/tyk-docs/content/getting-started/key-concepts/servers.md
@@ -9,8 +9,6 @@ menu:
 weight: 1
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 These are the URLs you would use to access an API. Once an API is added to Tyk, you will be using a URL that points at the Tyk Gateway itself, plus optionally, an additional listen path on the end of the URL. As part of an import, where possible, Tyk will aim to take the current server in the OAS API Specification provided and make that the Upstream in the Tyk OAS API Specification that is created. That way, Tyk will forward requests to the same place a user would have sent requests to before a gateway was in place. At the same time, the Tyk Gateway will be made the Server. This has the effect of automatically inserting Tyk into your API flow.

--- a/tyk-docs/content/getting-started/using-oas-definitions.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions.md
@@ -9,7 +9,6 @@ menu:
 weight: 7
 ---
 
-{{< toc >}}
 
 ### Introduction
 

--- a/tyk-docs/content/getting-started/using-oas-definitions/create-an-oas-api.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/create-an-oas-api.md
@@ -9,8 +9,6 @@ menu:
 weight: 2
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 This section will walk you through creating an OAS API. We will cover the following methods:

--- a/tyk-docs/content/getting-started/using-oas-definitions/export-an-oas-api.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/export-an-oas-api.md
@@ -9,8 +9,6 @@ menu:
 weight: 5
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 Tyk supports exporting the Tyk OAS API Definitions or just the extracted OAS API Definition using either the Gateway or Dashboard APIs. Below are the commands you can use to get Tyk to export the required format.

--- a/tyk-docs/content/getting-started/using-oas-definitions/get-started-oas.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/get-started-oas.md
@@ -9,8 +9,6 @@ menu:
 weight: 1
 ---
 
-{{< toc >}}
-
 ### Introduction
 It is easy to get going with Tyk in your favourite editors. We will take you through the steps to get going with Visual Studio Code. This will include installing a plugin, importing an API and sending a request to that API. It should take about ten minutes, if that.
 

--- a/tyk-docs/content/getting-started/using-oas-definitions/import-an-oas-api.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/import-an-oas-api.md
@@ -9,8 +9,6 @@ menu:
 weight: 4
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 Tyk supports importing OAS API Definitions (In JSON format, version 3.0.x) from either the Tyk Gateway or the Dashboard. Below are the commands you can use to get Tyk to generate the respective Tyk OAS API definitions for OAS API Defintions.

--- a/tyk-docs/content/getting-started/using-oas-definitions/mock-response.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/mock-response.md
@@ -9,8 +9,6 @@ menu:
 weight: 6
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 The mock response middleware allows you to return mock responses for an API endpoint without requiring an upstream service. This can be useful when creating a new API or making a development API available to an external team. Tyk has mock response middleware before we implemented OAS. However, the previous one wasn’t respecting any authentication or any other middleware configured for the endpoint. The new mock response has extended OAS capabilities that respect authentication and other middleware. In this new implementation, there are two ways of adding a mock response to an endpoint.

--- a/tyk-docs/content/getting-started/using-oas-definitions/oas-glossary.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/oas-glossary.md
@@ -9,8 +9,6 @@ menu:
 weight: 7
 ---
 
-{{< toc >}}
-
 ### Tyk classic API definition
 
 An API definition written in Tyk’s proprietary API Specification format.

--- a/tyk-docs/content/getting-started/using-oas-definitions/oas-reference.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/oas-reference.md
@@ -9,7 +9,6 @@ menu:
 weight: 8
 ---
 
-{{< toc >}}
 ### Introduction
 
 The tables below list the status of the Tyk Gateway API features, that will be available in the early access phase of the new Tyk OAS API Definition format.

--- a/tyk-docs/content/getting-started/using-oas-definitions/update-an-oas-api.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/update-an-oas-api.md
@@ -9,8 +9,6 @@ menu:
 weight: 3
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 This section will walk you through updating an OAS API. We will cover the following methods:

--- a/tyk-docs/content/getting-started/using-oas-definitions/update-api-with-oas.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/update-api-with-oas.md
@@ -9,8 +9,6 @@ menu:
 weight: 6
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 As developers working on API development, it is necessary for us to constantly update the OpenAPI definition. This definition is normally generated either from our codebase or created using API design tools (such as [Swagger Editor]({{< ref "https://editor.swagger.io/" >}}), [Postman]({{< ref "https://www.postman.com/" >}}) and [Stoplight]({{< ref "https://stoplight.io/" >}}))

--- a/tyk-docs/content/getting-started/using-oas-definitions/versioning-an-oas-api.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/versioning-an-oas-api.md
@@ -9,8 +9,6 @@ menu:
 weight: 7
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 Tyk allows you to create versions of your APIs. This tutorial shows you how to do this with our Open Source Gateway.

--- a/tyk-docs/content/graphql-proxy-only.md
+++ b/tyk-docs/content/graphql-proxy-only.md
@@ -11,8 +11,6 @@ aliases:
 - /getting-started/key-concepts/graphql-proxy-only/
 ---
 
-{{< toc >}}
-
 ### What is GraphQL Proxy Only
 
 GraphQL Proxy Only is just a GraphQL API with a single datasource and read-only schema.

--- a/tyk-docs/content/tyk-stack/tyk-pump/other-data-stores/monitor-apis-prometheus.md
+++ b/tyk-docs/content/tyk-stack/tyk-pump/other-data-stores/monitor-apis-prometheus.md
@@ -9,8 +9,6 @@ menu:
 weight: 1
 ---
 
-{{< toc >}}
-
 ### Introduction
 
 Your Tyk Pump can expose Prometheus metrics for the requests served by your Tyk Gateway. This is helpful if you want to track how often your APIs are being called and how they are performing. Tyk collects latency data of how long your services take to respond to requests, how often your services are being called and what status code they return.


### PR DESCRIPTION
[DX-523](https://tyktech.atlassian.net/browse/DX-523) Remove table of contents from pages. This has been done since the website restructure has occurred and the new right side navigation menu included.

[preview](https://deploy-preview-3086--tyk-docs.netlify.app/docs/nightly)

For the path of pages that have been affected please refer to the checklist in the ticket above.

This PR will be released for release-5.1. The new right side navigation is not included for releases < 5.1

[DX-523]: https://tyktech.atlassian.net/browse/DX-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ