### PR TITLE
[DX-604] Rename Menu Items for Tyk Helm Charts

### DIFF
--- a/tyk-docs/content/tyk-oss/ce-helm-chart-new.md
+++ b/tyk-docs/content/tyk-oss/ce-helm-chart-new.md
@@ -1,5 +1,5 @@
 ---
-title: "Tyk Helm Chart"
+title: "Tyk OSS Helm Chart"
 date: 2022-05-31
 tags: ["OSS", "Gateways", "Kubernetes"]
 description: "How to deploy Tyk OSS on Kubernetes using new Helm Chart"

--- a/tyk-docs/content/tyk-oss/ce-helm-chart-new.md
+++ b/tyk-docs/content/tyk-oss/ce-helm-chart-new.md
@@ -1,11 +1,11 @@
 ---
-title: "Deploy Tyk OSS using new Helm Chart"
+title: "Tyk Helm Chart"
 date: 2022-05-31
 tags: ["OSS", "Gateways", "Kubernetes"]
 description: "How to deploy Tyk OSS on Kubernetes using new Helm Chart"
 menu:
   main:
-    parent: "Tyk Helm Chart"
+    parent: "Kubernetes"
 weight: 1
 ---
 

--- a/tyk-docs/content/tyk-oss/ce-helm-chart.md
+++ b/tyk-docs/content/tyk-oss/ce-helm-chart.md
@@ -1,11 +1,11 @@
 ---
-title: "Tyk Helm Chart"
+title: "Legacy Tyk Helm Chart"
 date: 2021-07-01
 tags: [""]
 description: ""
 menu:
   main:
-    parent: "Kubernetes"
+    parent: "Tyk Helm Chart"
 weight: 1
 ---
 

--- a/tyk-docs/content/tyk-oss/ce-helm-chart.md
+++ b/tyk-docs/content/tyk-oss/ce-helm-chart.md
@@ -1,5 +1,5 @@
 ---
-title: "Legacy Tyk Helm Chart"
+title: "Legacy Tyk OSS Helm Chart"
 date: 2021-07-01
 tags: [""]
 description: ""

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -41,11 +41,11 @@ menu:
           path: /tyk-oss/ce-docker
           category: Page
           show: True
-        - title: "Tyk Helm Chart"
+        - title: "Tyk OSS Helm Chart"
           path: /tyk-oss/ce-helm-chart-new
           category: Page
           show: True
-        - title: "Legacy Tyk Helm Chart"
+        - title: "Legacy Tyk OSS Helm Chart"
           path: /tyk-oss/ce-helm-chart
           category: Page
           show: True

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -41,11 +41,11 @@ menu:
           path: /tyk-oss/ce-docker
           category: Page
           show: True
-        - title: "Deploy Tyk OSS using new Helm Chart"
+        - title: "Tyk Helm Chart"
           path: /tyk-oss/ce-helm-chart-new
           category: Page
           show: True
-        - title: "Tyk Helm Chart"
+        - title: "Legacy Tyk Helm Chart"
           path: /tyk-oss/ce-helm-chart
           category: Page
           show: True


### PR DESCRIPTION
[DX-604](https://tyktech.atlassian.net/browse/DX-604)

Since the new website release the [new helm chart](https://tyk.io/docs/tyk-oss/ce-helm-chart-new/) deployment sidebar menu item may need consideration. The Tyk OSS charts now considered stable and the length of the menu item may be too long since the release of the new website.

This PR suggests an alternative naming as seen in this [preview](https://deploy-preview-3088--tyk-docs.netlify.app/docs/nightly/tyk-oss/ce-helm-chart-new/)

[DX-604]: https://tyktech.atlassian.net/browse/DX-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ