### PR TITLE
[DX-365] Move GW environment variables out from EDP environment vars section

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -1232,7 +1232,7 @@ menu:
           path: /key-concepts/tcp-proxy
           category: Page
           show: True
-      - title: "Basic Config and Security"
+      - title: "Basic config and security"
         category: Directory
         show: True
         menu:
@@ -1880,8 +1880,12 @@ menu:
         category: Directory
         show: True
         menu:
-        - title: "Tyk Gateway Configuration Options"
+        - title: "Tyk Gateway configuration options"
           path: /tyk-oss-gateway/configuration
+          category: Page
+          show: True
+        - title: "Key value secrets storage for configuration in Tyk"
+          path: /tyk-configuration-reference/kv-store
           category: Page
           show: True
       - title: "Troubleshooting"
@@ -2818,12 +2822,8 @@ menu:
         menu:
       - title: "Environment variables"
         category: Directory
-        show: True
+        show: False
         menu:
-        - title: "Key Value secrets storage for configuration in Tyk"
-          path: /tyk-configuration-reference/kv-store
-          category: Page
-          show: True
       - title: "Troubleshooting"
         category: Directory
         show: False


### PR DESCRIPTION
[DX-365](https://tyktech.atlassian.net/browse/DX-635)

[GW env vars preview](https://deploy-preview-3150--tyk-docs.netlify.app/docs/nightly/tyk-configuration-reference/kv-store/)

[EDP preview](https://deploy-preview-3150--tyk-docs.netlify.app/docs/nightly/tyk-developer-portal/tyk-enterprise-developer-portal/)

[DX-365]: https://tyktech.atlassian.net/browse/DX-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ