### PR TITLE
[TT-9854] Fix x-tyk-gateway.md destination path

### DIFF
--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -218,7 +218,8 @@ jobs:
 
       - name: Write out docs
         run: |
-             [ -d "gateway-docs" ]   && cp gateway-docs/{x-tyk-gateway.md,*.yml} ./tyk-docs/tyk-docs/assets/others/
+             [ -d "gateway-docs" ]   && cp gateway-docs/*.yml ./tyk-docs/tyk-docs/assets/others/
+             [ -d "gateway-docs" ]   && cp gateway-docs/x-tyk-gateway.md ./tyk-docs/tyk-docs/content/shared/
              [ -d "dashboard-docs" ] && cp dashboard-docs/*.yml ./tyk-docs/tyk-docs/assets/others/
              [ -d "config-docs" ]    && cp config-docs/* ./tyk-docs/tyk-docs/content/shared/
 


### PR DESCRIPTION
This PR updates the tyk-docs github action to latest, fixing the destination of `x-tyk-gateway.md` output. It has been tested via #3160 and is ready to merge.

https://tyktech.atlassian.net/browse/TT-9854