### PR TITLE
[DX-640] Fix ordering of overview section for reduce latency section in Product Stack

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -1444,6 +1444,10 @@ menu:
           category: Directory
           show: True
           menu:
+          - title: "Overview"
+            path: /basic-config-and-security/reduce-latency
+            category: Page
+            show: True
           - title: "Caching"
             category: Directory
             show: True
@@ -1472,10 +1476,6 @@ menu:
               path: /basic-config-and-security/reduce-latency/caching/optimise-cache/
               category: Page
               show: True
-          - title: "Reduce Latency"
-            path: /basic-config-and-security/reduce-latency
-            category: Page
-            show: True
         - title: "Report, monitor and trigger events"
           category: Directory
           show: True


### PR DESCRIPTION
[DX-640](https://tyktech.atlassian.net/browse/DX-640)

[preview](https://deploy-preview-3168--tyk-docs.netlify.app/docs/nightly/basic-config-and-security/reduce-latency)

Update ordering of [reduce latency](https://tyk.io/docs/5.0/basic-config-and-security/reduce-latency/) menu item so that this overview page is displayed first in the Product Stack section of the new website.

[DX-640]: https://tyktech.atlassian.net/browse/DX-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ