### PR TITLE
hide getting started for tyk cloud

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -109,7 +109,7 @@ menu:
           menu:
           - title: "Getting started"
             category: Directory
-            show: True
+            show: False
             menu:
             - title: "Getting started with Tyk Cloud"
               path: /tyk-cloud/getting-started


### PR DESCRIPTION
hide getting started for tyk cloud - based on this pr https://github.com/TykTechnologies/tyk-docs/pull/2963

The page to remove - https://deploy-preview-3218--tyk-docs.netlify.app/docs/nightly/tyk-cloud/getting-started/