### PR TITLE
[DX-677]change to nearest when scrolling

### DIFF
--- a/tyk-docs/static/js/scroll_to_active_tab.js
+++ b/tyk-docs/static/js/scroll_to_active_tab.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const activeItem = document.querySelector('.st-treed li.active');
     if (activeItem) {
         activeItem.scrollIntoView({
-            behavior: 'auto',
+            behavior: 'instant',
             block: 'nearest',
         });
     }

--- a/tyk-docs/static/js/scroll_to_active_tab.js
+++ b/tyk-docs/static/js/scroll_to_active_tab.js
@@ -2,8 +2,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const activeItem = document.querySelector('.st-treed li.active');
     if (activeItem) {
         activeItem.scrollIntoView({
-            behavior: 'smooth',
-            block: 'start',
+            behavior: 'auto',
+            block: 'nearest',
         });
     }
 });

--- a/tyk-docs/static/js/scroll_to_active_tab.js
+++ b/tyk-docs/static/js/scroll_to_active_tab.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (activeItem) {
         activeItem.scrollIntoView({
             behavior: 'instant',
-            block: 'nearest',
+            block: 'center',
         });
     }
 });


### PR DESCRIPTION
### Ticket
DX-677
### Description
- currently When scrolling the focus item move up to the beginning of the page. This pull request change that and now the item move to the nearest which means that if an item is invisible the browser will choose the alignment that brings the most of the element into view while keeping it fully visible
### Preview Link

https://deploy-preview-3236--tyk-docs.netlify.app/docs/nightly/planning-for-production/database-settings/mongodb-sizing/


#### Screenshots (if appropriate)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have added a **preview link** to the PR description.
- [ ] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [ ] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [ ] Make sure you have started *your change* off *our latest `master`*.
- [ ] I **labelled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->
