### PR TITLE
[DX-608] Update release 5.1 versions list to include release 5.2 and update base URL in config.toml to be tyk.io/docs/5.1/

### DIFF
--- a/.github/workflows/stable-updater.yaml
+++ b/.github/workflows/stable-updater.yaml
@@ -2,12 +2,12 @@ name: Stable branch update
 on:
   push:
     branches:
-      - release-5.1
+      - release-5.2
 
 jobs:
   stable:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/release-5.1'
+    if: github.ref == 'refs/heads/release-5.2'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "//tyk.io/docs/"
+baseURL = "//tyk.io/docs/5.1/"
 languageCode = "en-gb"
 title = "Tyk Documentation"
 theme = "tykio"

--- a/tyk-docs/themes/tykio/layouts/partials/version_selector.html
+++ b/tyk-docs/themes/tykio/layouts/partials/version_selector.html
@@ -1,7 +1,7 @@
 <label for="version-selector">Version: </label>
 <select onchange="var path = location.pathname.match('\/docs\/(?:nightly|[1-9][^\/]*\)?(.*)')[1].replace(/^\//,''); window.location = this.options[this.selectedIndex].value + path" id="version-selector">
-    <option value="/docs/" selected="selected">Latest - 5.2</option>
-    <option value="/docs/5.1/">5.1</option>
+    <option value="/docs/">Latest - 5.2</option>
+    <option value="/docs/5.1/" selected="selected">5.1</option>
     <option value="/docs/5.0/">5 LTS</option>
     <option value="/docs/4.3/">4.3</option>
     <option value="/docs/4.2/">4.2</option>

--- a/tyk-docs/themes/tykio/layouts/partials/version_selector.html
+++ b/tyk-docs/themes/tykio/layouts/partials/version_selector.html
@@ -1,6 +1,7 @@
 <label for="version-selector">Version: </label>
 <select onchange="var path = location.pathname.match('\/docs\/(?:nightly|[1-9][^\/]*\)?(.*)')[1].replace(/^\//,''); window.location = this.options[this.selectedIndex].value + path" id="version-selector">
-    <option value="/docs/" selected="selected">Latest - 5.1</option>
+    <option value="/docs/" selected="selected">Latest - 5.2</option>
+    <option value="/docs/5.1/">5.1</option>
     <option value="/docs/5.0/">5 LTS</option>
     <option value="/docs/4.3/">4.3</option>
     <option value="/docs/4.2/">4.2</option>


### PR DESCRIPTION
DX-608

The config.toml on release 5.1 will have to be updated so that the BaseURL is //tyk.io/docs/5.1/ in addition to adding release 5.2 to the versions dropdown.

The release 5.2 branch will have the BaseURL of //tyk.io/docs/
The config.toml of release 5.1 will have the BaseURL of //tyk.io/docs/5.1/