### PR TITLE
Merging to release-5.2: Update version-5.2.md GW to fix grammar error (#3267)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
@@ -101,7 +101,7 @@ Please refer to the [upgrading Tyk]({{< ref "/upgrading-tyk" >}}) page for furth
 #### Fixed:
 - Fixed an issue with querying a *UDG* API containing a query parameter of array type in a REST data source. The *UDG* was dropping the array type parameter from the final request URL sent upstream.
 
-- Fixed an issue with introspecting GraphQL schemas that previously raised an error when dealing with custom root types other than *Query*, *Mutation*, or *Subscription*.
+- Fixed an issue with introspecting GraphQL schemas that previously raised an error when dealing with custom root types other than *Query*, *Mutation* or *Subscription*.
 
 - Fixed an issue where the *enforced timeout* configuration parameter of an API endpoint accepted negative values, without displaying validation errors. With this fix, users receive clear feedback and prevent unintended configurations.
 


### PR DESCRIPTION
Update version-5.2.md GW to fix grammar error (#3267)

Update version-5.2.md

Update grammar to trigger _redirects correction on release-5.2 url in _redirects file