### PR TITLE
Merging to release-5.2: [DX-714]Add missing link to OAS glossary (#3293)

### DIFF
--- a/tyk-docs/content/getting-started/using-oas-definitions/create-an-oas-api.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/create-an-oas-api.md
@@ -30,7 +30,7 @@ Your Tyk Gateway API secret is stored in your `tyk.conf` file, the property is c
 
 #### Create an API
 
-To create the API, send a Tyk OAS API Definition [link to glossary] to the `apis` endpoint (http://{your-tyk-host}:{port}/tyk/apis/oas), which will return the status and version of your Tyk Gateway. Change the `x-tyk-authorization` value and curl the domain name and port to be the correct values for your environment.
+To create the API, send a [Tyk OAS API Definition]({{< ref "getting-started/using-oas-definitions/oas-glossary" >}}) to the `apis` endpoint (http://{your-tyk-host}:{port}/tyk/apis/oas), which will return the status and version of your Tyk Gateway. Change the `x-tyk-authorization` value and curl the domain name and port to be the correct values for your environment.
 
 {{< note success >}}
 **Note**  
@@ -388,7 +388,7 @@ This example Tyk OAS API definition configures the Tyk Gateway to forward reques
 
 To view the raw API definition object, visit: https://bit.ly/39jUnuq
 
-To create the API, send a Tyk OAS API Definition [link to glossary] to the Dashboard `apis` endpoint (http://{your-tyk-host}:{port}/api/apis/oas), which will return the status and the API ID of your just created API.
+To create the API, send a [Tyk OAS API Definition]({{< ref "getting-started/using-oas-definitions/oas-glossary" >}}) to the Dashboard `apis` endpoint (http://{your-tyk-host}:{port}/api/apis/oas), which will return the status and the API ID of your just created API.
 
 | Property     | Description            |
 |--------------|------------------------|

--- a/tyk-docs/content/getting-started/using-oas-definitions/update-an-oas-api.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/update-an-oas-api.md
@@ -48,7 +48,7 @@ Your Tyk Gateway API secret is stored in your `tyk.conf` file, the property is c
 
 #### Create an API
 
-To [create the API]({{< ref "/content/getting-started/using-oas-definitions/create-an-oas-api.md" >}}), send a Tyk OAS API Definition [link to glossary] to the `apis` endpoint (http://{your-tyk-host}:{port}/tyk/apis/oas), which will return the status and version of your Tyk Gateway. Change the `x-tyk-authorization` value and curl the domain name and port to be the correct values for your environment.
+To [create the API]({{< ref "getting-started/using-oas-definitions/create-an-oas-api.md" >}}), send a [Tyk OAS API Definition] ({{< ref "getting-started/using-oas-definitions/oas-glossary" >}}) to the `apis` endpoint (http://{your-tyk-host}:{port}/tyk/apis/oas), which will return the status and version of your Tyk Gateway. Change the `x-tyk-authorization` value and curl the domain name and port to be the correct values for your environment.
 
 | Property     | Description            |
 |--------------|------------------------|


### PR DESCRIPTION
[DX-714]Add missing link to OAS glossary (#3293)

* fix issue with linking to oas

[DX-714]: https://tyktech.atlassian.net/browse/DX-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ