### PR TITLE
[DX-741] Correcting docs for field-based permissions

### DIFF
--- a/tyk-docs/content/graphql/field-based-permissions.md
+++ b/tyk-docs/content/graphql/field-based-permissions.md
@@ -157,6 +157,6 @@ Currently only restricted types and fields can be set up via Tyk Dashboard. Supp
 2. From **System Management > Keys > Add Key** select a policy or configure directly for the key.
 3. Select your GraphQL API (marked as *GraphQL*).
 4. Enable **Field-Based Permissions** for the selected API.
-5. By default all *Types* and *Fields* will be checked. By unchecking a *Type* or *Field* you will disallow to use it for any GraphQL operation associated with the key.
+5. By default all *Types* and *Fields* will be unchecked. By checking a *Type* or *Field* you will disallow to use it for any GraphQL operation associated with the key.
 
 {{< img src="/img/dashboard/system-management/field_based_permissions.png" alt="field-based-permissions" >}}


### PR DESCRIPTION
### Preview Link
https://deploy-preview-3356--tyk-docs.netlify.app/docs/nightly/graphql/field-based-permissions/

### Description
Corrected single line regarding field-based permissions. The default state of the screen in Dashboard is different than described.

https://tyktech.atlassian.net/browse/DX-741
<br>

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have added a **preview link** to the PR description.
- [x] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [x] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x] Make sure you have started *your change* off *our latest `master`*.
- [x] I **labelled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->
