### PR TITLE
Merging to release-5.2: Typo on OAS Import page (#3367)

### DIFF
--- a/tyk-docs/content/getting-started/using-oas-definitions/import-an-oas-api.md
+++ b/tyk-docs/content/getting-started/using-oas-definitions/import-an-oas-api.md
@@ -30,7 +30,7 @@ You can also run these steps using the Tyk Dashboard API, noting the differences
 | Interface             | Port     | Endpoint        | Authorization Header  | Authorization credentials        |
 |-----------------------|----------|-----------------|-----------------------|----------------------------------|
 | Tyk Gateway API       | 8080     | `tyk/apis/oas`  | `x-tyk-authorization` | `secret` value set in `tyk.conf` |
-| Tyk Dashboard API     | 3000     | `api/apis/oas`  | `authorization`       | From Dashboard User Profile      |
+| Tyk Dashboard API     | 3000     | `api/apis/oas`  | `Authorization`       | From Dashboard User Profile      |
 
 As explained in the section on [Creating an OAS API]({{< ref "/getting-started/using-oas-definitions/create-an-oas-api" >}}) remember that when using the Tyk Dashboard API you only need to issue one command to create the API and load it onto the Gateway; when using the Tyk Gateway API you must remember to restart or hot reload the Gateway after creating the API.
 


### PR DESCRIPTION
Typo on OAS Import page (#3367)

Missed capitalisation of `Authorization` parameter

Co-authored-by: dcs3spp <dcs3spp@users.noreply.github.com>