### PR TITLE
Merging to release-5.2: [DX-653] Rename integration menu item as overview in Integration options section (#3386)

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -1588,6 +1588,10 @@ menu:
           category: Directory
           show: True
           menu:
+          - title: "Overview"
+            path: /advanced-configuration/integrate
+            category: Page
+            show: True
           - title: "3rd Party identity providers"
             category: Directory
             show: True
@@ -1640,10 +1644,6 @@ menu:
               path: /advanced-configuration/integrate/api-auth-mode/open-id-connect
               category: Page
               show: True
-          - title: "Integration Options"
-            path: /advanced-configuration/integrate
-            category: Page
-            show: True
         - title: "Distributed Tracing"
           category: Directory
           show: True


### PR DESCRIPTION
[DX-653] Rename integration menu item as overview in Integration options section (#3386)

rename integration menu item as overview in Integration options section

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-653]: https://tyktech.atlassian.net/browse/DX-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ