### PR TITLE
[DX-751]Every indexable page under /docs/ should have an absolute canonical URL

### DIFF
--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -10,6 +10,7 @@ timeout = "60s"
 [params]
 GithubEdit = "https://github.com/TykTechnologies/tyk-docs/edit/master/tyk-docs/content/"
 GithubReadOnly = "https://github.com/TykTechnologies/tyk-docs/blob/master/tyk-docs/content/"
+CanonicalBaseUrl = "https://tyk.io/docs/"
 showEmptyPages = false
 [sitemap]
   changefreq = "daily"

--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -13,11 +13,14 @@
   <link href='https://fonts.googleapis.com/css?family=Inter' rel='stylesheet'>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
-  {{ if not (or (findRE `docs/nightly` .Permalink) (findRE `docs/\d\.\d` .Permalink)) }}
+
+  {{ $canonicalLink := replace .Permalink .Site.BaseURL  .Site.Params.CanonicalBaseUrl }}
+  <link rel="canonical" href="{{ $canonicalLink}}" />
+  <!--{{ if not (or (findRE `docs/nightly` .Permalink) (findRE `docs/\d\.\d` .Permalink)) }}
     <link rel="canonical" href="{{ .Permalink }}" />
   {{ else }}
     <meta name="robots" content="noindex" />
-  {{ end }}
+  {{ end }}-->
 
   <link rel="icon" type="image/png" href="{{ "images/favicon/favicon-32x32.png" | relURL }}" sizes="32x32" />
   <link rel="icon" type="image/png" href="{{ "images/favicon/favicon-16x16.png" | relURL }}" sizes="16x16" />


### PR DESCRIPTION
[Jira Ticket](https://tyktech.atlassian.net/browse/DX-751)
[
Preview Link](https://deploy-preview-3397--tyk-docs.netlify.app/docs/nightly)

## ScreenShot
<img width="1053" alt="Screenshot 2023-10-18 at 14 35 03" src="https://github.com/TykTechnologies/tyk-docs/assets/8012032/7c5e0d1f-d72f-4800-b147-958a997f46a6">
