### PR TITLE
Merging to release-4.3: [DX-751]Every indexable page under /docs/ should have an absolute canonical URL (#3397)

### DIFF
--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -7,6 +7,14 @@ enableGitInfo = false
 disableKinds = ["taxonomy", "taxonomyTerm"]
 canonifyurls = "false"
 timeout = "60s"
+<<<<<<< HEAD
+=======
+[params]
+GithubEdit = "https://github.com/TykTechnologies/tyk-docs/edit/master/tyk-docs/content/"
+GithubReadOnly = "https://github.com/TykTechnologies/tyk-docs/blob/master/tyk-docs/content/"
+CanonicalBaseUrl = "https://tyk.io/docs/"
+showEmptyPages = false
+>>>>>>> 3a893283... [DX-751]Every indexable page under /docs/ should have an absolute canonical URL (#3397)
 [sitemap]
   changefreq = "daily"
   priority = 0.5

--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="{{ "css/bespoke.css" | relURL }}">
   <link rel="stylesheet" href="{{ "css/docs.css" | relURL }}">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
+<<<<<<< HEAD
   <link rel="stylesheet" href="{{ "css/cookie.css" | relURL }}">
   <link rel="stylesheet" href="{{ "css/custom_search.css" | relURL }}">
   {{ if not (or (findRE `docs/nightly` .Permalink) (findRE `docs/\d\.\d` .Permalink)) }}
@@ -16,6 +17,16 @@
   {{ end }} 
 
 
+=======
+
+  {{ $canonicalLink := replace .Permalink .Site.BaseURL  .Site.Params.CanonicalBaseUrl }}
+  <link rel="canonical" href="{{ $canonicalLink}}" />
+  <!--{{ if not (or (findRE `docs/nightly` .Permalink) (findRE `docs/\d\.\d` .Permalink)) }}
+    <link rel="canonical" href="{{ .Permalink }}" />
+  {{ else }}
+    <meta name="robots" content="noindex" />
+  {{ end }}-->
+>>>>>>> 3a893283... [DX-751]Every indexable page under /docs/ should have an absolute canonical URL (#3397)
 
   <link rel="icon" type="image/png" href="{{ "images/favicon/favicon-32x32.png" | relURL }}" sizes="32x32" />
   <link rel="icon" type="image/png" href="{{ "images/favicon/favicon-16x16.png" | relURL }}" sizes="16x16" />


### PR DESCRIPTION
[DX-751]Every indexable page under /docs/ should have an absolute canonical URL (#3397)

add canonical for all pages

[DX-751]: https://tyktech.atlassian.net/browse/DX-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ