### PR TITLE
[DX-759]fix issue with enableGitInfo enabled in tyk doc when running locally with docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 1313:1313
 
-    entrypoint: ["hugo", "server", "--theme=tykio", "--buildDrafts"]
+    entrypoint: ["make", "run"]
 
     volumes:
-    - ./tyk-docs:/src
+    - .:/src


### PR DESCRIPTION
DX-759

### How i solved it

1.   **Context** - We enabled the enableGitInfo parameter in the config so that we can get the date when an article was last updated and this parameter requires that the repo be a git repo.
2. **The problem** was we were mounting only the tyk-docs/tyk-docs folder to the docker volume and this folder is not a git repo since it did not have the .git folder.

3. **Solution** - I have made it so that we mount the parent folder instead (tyk-docs) which has the .git folder thus is a git folder.