### PR TITLE
Move tyk-helm-chart-tyk-stack to new location as requested

### DIFF
--- a/tyk-docs/content/deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-chart-tyk-stack
+++ b/tyk-docs/content/deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-chart-tyk-stack
@@ -3,10 +3,10 @@ title: "Deploy Tyk Self Managed using new Helm Chart"
 date: 2022-07-10
 tags: ["Tyk Self Managed", "Single Data Center", "Kubernetes"]
 description: "How to deploy Tyk Self Managed on Kubernetes using new Helm Chart"
-menu:
-  main:
-    parent: "Tyk Helm Chart "
+menu: main
 weight: 1
+aliases:
+    - /tyk-self-managed/tyk-helm-chart-single-dc
 ---
 
 ## New Tyk Helm Charts (Beta)

--- a/tyk-docs/content/deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-chart-tyk-stack.md
+++ b/tyk-docs/content/deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-chart-tyk-stack.md
@@ -3,7 +3,6 @@ title: "Deploy Tyk Self Managed using new Helm Chart"
 date: 2022-07-10
 tags: ["Tyk Self Managed", "Single Data Center", "Kubernetes"]
 description: "How to deploy Tyk Self Managed on Kubernetes using new Helm Chart"
-menu: main
 weight: 1
 aliases:
     - /tyk-self-managed/tyk-helm-chart-single-dc

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -440,10 +440,10 @@ menu:
               path: /tyk-self-managed/tyk-helm-chart
               category: Page
               show: True
-            - title: "Tyk new Helm chart"
-              path: /tyk-self-managed/tyk-helm-chart-tyk-stack/
-              category: Page
-              show: True
+            # - title: "Tyk new Helm chart"
+            #   path: /deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-chart-tyk-stack
+            #   category: Page
+            #   show: True
           - title: "Red Hat (RHEL / CentOS)"
             category: Directory
             show: True

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -440,10 +440,10 @@ menu:
               path: /tyk-self-managed/tyk-helm-chart
               category: Page
               show: True
-            # - title: "Tyk new Helm chart"
-            #   path: /deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-chart-tyk-stack
-            #   category: Page
-            #   show: True
+            - title: "Tyk new Helm chart"
+              path: /deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-chart-tyk-stack
+              category: Page
+              show: True
           - title: "Red Hat (RHEL / CentOS)"
             category: Directory
             show: True


### PR DESCRIPTION
In this PR https://github.com/TykTechnologies/tyk-docs/pull/3183:

tyk-self-managed/tyk-helm-chart-single-dc.md was renamed to tyk-self-managed/tyk-helm-chart-tyk-stack.md

As requested this PR moves the content to new location.
https://github.com/TykTechnologies/tyk-docs/pull/3183#issuecomment-1770592978

The original file has been removed and an alias setup in the new file.

Can this PR be reviewed and suggestions made for required titles? (https://github.com/TykTechnologies/tyk-docs/pull/3183#discussion_r1344281377)
