### PR TITLE
Merging to release-5.2: [DX-759]fix issue with enableGitInfo enabled in tyk doc when running locally with docker (#3421)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 1313:1313
 
-    entrypoint: ["hugo", "server", "--theme=tykio", "--buildDrafts"]
+    entrypoint: ["make", "run"]
 
     volumes:
-    - ./tyk-docs:/src
+    - .:/src


### PR DESCRIPTION
[DX-759]fix issue with enableGitInfo enabled in tyk doc when running locally with docker (#3421)

fix docker contributr isssue

[DX-759]: https://tyktech.atlassian.net/browse/DX-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ