### PR TITLE
[DX-758] 5.1 GHub Action CI fix

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
+++ b/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
@@ -1,7 +1,7 @@
 {{- range $key, $value := .Site.RegularPages }}
    {{- $title := (replace .Title "\"" "\\\"") }}
    {{- $path := .File.Path }}
-   {{- $url := printf "%s" (replace $value.RelPermalink "/docs/" "/") }}
+   {{- $url := replaceRE "^/docs(/[0-9]+\\.[0-9]+)?(/.*)?$" "$2" $value.RelPermalink }}
    {{- $url = printf "%s" (replace $url "/nightly/" "/") }}
    {{- printf "{\"path\":\"%s\", \"title\":\"%s\", \"file\": \"./content/%s\"}\n" $url $title $path}}
    {{- range $value.Aliases }}


### PR DESCRIPTION
  Similar to how the urls _/docs/nightly_ and _/docs_ are stripped during Hugo build, remove URLs containing _/docs/X.Y/_
  
  This is done before menu.yaml checks CI
  ```console
   {{- $url := replaceRE "^/docs(/[0-9]+\\.[0-9]+)?(/.*)?$" "$2" $value.RelPermalink }}
   ```