### PR TITLE
[DX-771] make youtube iframe  responsive in all screen resolutions

### DIFF
--- a/tyk-docs/assets/scss/_structure.scss
+++ b/tyk-docs/assets/scss/_structure.scss
@@ -173,7 +173,7 @@ body {
 }
 @media only screen and (max-width: 600px) {
     .responsive-frame{
-        width: 70%!important;
+        width: 80%!important;
         height: auto;
     }
 }

--- a/tyk-docs/assets/scss/_structure.scss
+++ b/tyk-docs/assets/scss/_structure.scss
@@ -167,3 +167,13 @@ body {
     display: inline-block;
     background-size: 100%;
   }
+.responsive-frame{
+    width: 362px;
+    height: 200px;
+}
+@media only screen and (max-width: 600px) {
+    .responsive-frame{
+        width: 70%!important;
+        height: auto;
+    }
+}

--- a/tyk-docs/themes/tykio/layouts/shortcodes/youtube.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/youtube.html
@@ -1,4 +1,4 @@
 <div class="embed video-player">
-<iframe class="youtube-player" type="text/html" width="362" height="200" src="https://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0">
+<iframe class="responsive-frame youtube-player" type="text/html" width="362" height="200" src="https://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0">
 </iframe>
 </div>


### PR DESCRIPTION
Jira: DX-771
On Mobile the youtube frame go outside the main container . This is fixed by this pull request to make sure in mobile it only occupies 70% of the space.

[Preview Link](https://deploy-preview-3460--tyk-docs.netlify.app/docs/nightly/advanced-configuration/integrate/sso/)


