### PR TITLE
[DX-771]fix-issue in 4.3 for youtube videos

### DIFF
--- a/tyk-docs/static/css/bespoke.css
+++ b/tyk-docs/static/css/bespoke.css
@@ -7301,4 +7301,13 @@ body {
   height: auto;
   margin: auto;
 }
-
+.responsive-frame{
+  width: 362px;
+  height: 200px;
+}
+@media only screen and (max-width: 600px) {
+  .responsive-frame{
+    width: 80%!important;
+    height: auto;
+  }
+}

--- a/tyk-docs/themes/tykio/layouts/shortcodes/youtube.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/youtube.html
@@ -1,4 +1,4 @@
 <div class="embed video-player">
-<iframe class="youtube-player" type="text/html" width="870" height="480" src="https://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0">
+<iframe class="responsive-frame youtube-player" type="text/html" width="870" height="480" src="https://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0">
 </iframe>
 </div>


### PR DESCRIPTION
Jira: DX-771
On Mobile the youtube frame go outside the main container . This is fixed by this pull request to make sure in mobile it only occupies 70% of the space.