### PR TITLE
Merging to release-5.2: [DX-767] Refactor release notes so stored in product stack area of the website (#3435)

### DIFF
--- a/tyk-docs/content/basic-config-and-security/security/owasp-top-ten.md
+++ b/tyk-docs/content/basic-config-and-security/security/owasp-top-ten.md
@@ -56,7 +56,7 @@ Based on [OWASP logging cheatsheet](https://cheatsheetseries.owasp.org/cheatshee
 - [OpenTracing]({{< ref "product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/open-telemetry-overview" >}}) to allow services, which have distributed tracing enabled, for instrumentation to work seamless with Tyk gateway. 
 - [Event handlers]({{< ref "basic-config-and-security/report-monitor-trigger-events" >}}) - Tyk has the ability to configure APIs with event handlers to log data or fire webhooks when an event occurs. [Events]({{< ref "basic-config-and-security/report-monitor-trigger-events/event-types" >}}) could represent an authentication failure, exceeded rate-limit, misuse of api version and more.
 - [Monitors and events]({{< ref "basic-config-and-security/report-monitor-trigger-events/monitors" >}}) - Active monitoring of both user & organisations. Provides simple means of notifying stakeholders in the case of traffic abnormalities.
-- [Audit logs]({{< ref "release-notes/version-2.8.md#dashboard-audit-log-improvements" >}}) for the management layer - to record all activity and changed done by the users of the API Management.
+- [Audit logs]({{< ref "product-stack/tyk-dashboard/release-notes/archived-releases/version-2.8.md#dashboard-audit-log-improvements" >}}) for the management layer - to record all activity and changed done by the users of the API Management.
 
 {{< note success >}}
 **Note**  

--- a/tyk-docs/content/developer-support/tyk-release-summary/overview.md
+++ b/tyk-docs/content/developer-support/tyk-release-summary/overview.md
@@ -1,12 +1,48 @@
 ---
 title: Release Notes
-description: "Explains where to access older supported bundled release notes for Tyk Dashboard and Tyk Gateway"
+description: "Explore Tyk's latest releases and improvements. Here you will find release notes for all Tyk Components and versions. "
 tags: ["Release notes"]
 aliases:
-    - /release-notes
+  - /release-notes
 ---
-Since release 5.2 separate release notes are available for [Tyk Dashboard]({{< ref "product-stack/tyk-dashboard/release-notes/overview" >}}) and [Tyk Gateway]({{< ref "product-stack/tyk-gateway/release-notes/overview" >}}).
 
-Prior to release 5.2 release notes for Tyk Dashboard and Tyk Gateway were bundled into the same release note.This section provides access to these older release notes.
 
-Release notes for our helm charts can be found at our [GitHub repository](https://github.com/TykTechnologies/tyk-charts/releases)
+Tyk is an API Management platform that contains many different components, such as: [Tyk Gateway]({{< ref "tyk-oss-gateway" >}}), [Tyk Dashboard]({{< ref "tyk-dashboard" >}}), [Tyk Enterprise Developer Portal]({{< ref "tyk-developer-portal/tyk-enterprise-developer-portal" >}}), [Tyk Pump]({{< ref "tyk-pump" >}}), [Tyk Multi Data Centre Bridge (MDCB)]({{< ref "tyk-multi-data-centre" >}}), [Tyk Sync]({{< ref "tyk-sync" >}}), [Tyk Operator]({{< ref "tyk-operator" >}}), [Tyk Cloud]({{< ref "tyk-cloud" >}}) and [Tyk Identity Broker]({{< ref "tyk-identity-broker" >}}).
+
+Please find the following links to the release notes per component:
+
+{{< grid >}}
+
+{{< badge href="product-stack/tyk-dashboard/release-notes/overview" image="/img/logos/tyk-logo-selfmanaged.svg" imageStyle="object-fit:contain" alt="Tyk Dashboard Release Notes">}}
+**Tyk Dashboard**
+{{< /badge >}}
+
+{{< badge href="product-stack/tyk-gateway/release-notes/overview" image="/img/logos/tyk-logo-opensource.svg" imageStyle="object-fit:contain" alt="Tyk Gateway Release Notes">}}
+**Tyk Gateway**
+{{< /badge >}}
+
+{{< badge href="release-notes/mdcb-2.4" image="/img/logos/tyk-logo-selfmanaged.svg" imageStyle="object-fit:contain" alt="Tyk Multi Data Centre Bridge Release Notes">}}
+**Tyk MDCB**
+{{< /badge >}}
+
+{{< badge href="release-notes/pump-1.8" image="/img/logos/tyk-logo-opensource.svg" imageStyle="object-fit:contain" alt="Tyk Pump Release Notes">}}
+**Tyk Pump**
+{{< /badge >}}
+
+{{< badge href="https://github.com/TykTechnologies/tyk-charts/releases" image="/img/logos/tyk-logo-opensource.svg" imageStyle="object-fit:contain" alt="Helm Chart Release Notes">}}
+**Helm Charts**
+{{< /badge >}}
+
+{{< badge href="https://github.com/TykTechnologies/tyk-identity-broker/releases" image="/img/logos/tyk-logo-opensource.svg" imageStyle="object-fit:contain" alt="Tyk Identity Broker Release Notes">}}
+**Tyk Identity Broker**
+{{< /badge >}}
+
+{{< badge href="https://github.com/TykTechnologies/tyk-operator/releases" image="/img/logos/tyk-logo-opensource.svg" imageStyle="object-fit:contain" alt="Tyk Operator Release Notes">}}
+**Tyk Operator**
+{{< /badge >}}
+
+{{< badge href="https://github.com/TykTechnologies/tyk-sync/releases" image="/img/logos/tyk-logo-opensource.svg" imageStyle="object-fit:contain" alt="Tyk Sync Release Notes">}}
+**Tyk Sync**
+{{< /badge >}}
+
+{{< /grid >}}

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.4.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.4.md
@@ -1,12 +1,11 @@
 ---
 date: 2017-03-24T09:58:52Z
-title: Tyk Gateway v2.4
-menu:
-  main:
-    parent: "Release Notes"
-weight: 15
+title: Tyk Dashboard v2.4
+tags: ["Tyk", "Release notes", "Dashboard", "v2.4", "2.4"]
+aliases:
+    - /product-stack/tyk-dashboard/release-notes/old-releases/version-2.4/
 ---
-
+ 
 # New in this release:
 
 This release touch all our products and brings you numerous long awaited features and fixes. 

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.5.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.5.md
@@ -1,0 +1,208 @@
+---
+date: 2017-03-24T09:58:52Z
+title: Tyk Dashboard v2.5
+tags: ["Tyk", "Release notes", "Dashboard", "v2.5", "2.5"]
+aliases:
+  - /product-stack/tyk-dashboard/release-notes/old-releases/version-2.5/
+---
+
+# <a name="new"></a>New in this Release:
+
+This release touches all our products and brings you numerous features and fixes. Here are the packages and their versions we are releasing today: Tyk Gateway v2.5.0, Tyk Dashboard v1.5.0, Tyk Pump v0.6.0, MDCB v1.5.0, TIB v0.3.
+
+
+# <a name="major-highlights"></a>Major Highlights
+
+## <a name="dashboard"></a>New Dashboard Look and Feel
+
+Our Dashboard has had a UI overhaul, with the following improvements:
+
+* A more modern, fun look and feel
+* Consistent layouts and action buttons across each section
+* Better feedback on errors and updates
+* Various UX improvements
+
+## <a name="sso"></a>SSO with OpenId Identity Providers
+
+With TIB v0.3 we have made it possible to integrate any OpenID supported Identity provider with Tyk so you can configure Single Sign On (SSO), if the provider supports those.
+
+## <a name="search"></a>Searching API and Policies List
+
+This long awaited feature has been added on the Dashboard UI.
+
+## <a name="versioning"></a>Default API Versioning
+
+You can now specify a default API version when using a versioning strategy.
+
+## <a name="pump"></a>Tyk Pump with MDCB
+
+We've added MDCB support in this release of Tyk Pump
+
+# Moar!
+This release is packed with way more more cool stuff. Here are detailed release notes for each product:
+
+## <a name="gateway"></a>Tyk Gateway v2.5.0
+
+### New Relic Instrumentation Support
+
+We have added support for New Relic Instrumentation using:
+
+`"newrelic": {"app_name": "<app-id>", "license_key": "<key>"}`
+
+[Docs]({{< ref "basic-config-and-security/report-monitor-trigger-events/instrumentation" >}})
+
+### Default API Versioning
+
+You can now specify a default API version, and it will be used if a version is not set via headers, or URL parameters. Use the new option:
+
+`spec.version_data.default_version`
+
+[Docs]({{< ref "getting-started/key-concepts/versioning" >}})
+
+### Disable URL Encoding
+
+You can disable URL encoding using a new boolean `http_server_options` setting:
+ 
+`skip_target_path_escaping`
+
+[Docs]({{< ref "tyk-oss-gateway/configuration#a-name-http-server-options-a-http-server-options" >}})
+
+### Enable Key Logging
+
+By default all key ids in logs are hidden. You can now turn it on if you want to see them for debugging reasons using the `enable_key_logging` option.
+
+[Docs]({{< ref "tyk-oss-gateway/configuration#a-name-enable-key-logging-a-enable-key-logging" >}})
+
+
+### Specify TLS Cipher Suites
+
+We have added support for specifying allowed  SSL ciphers using the following option:
+
+`http_server_options - ssl_ciphers`
+
+[Docs]({{< ref "basic-config-and-security/security/tls-and-ssl" >}})
+
+## <a name="plugins"></a>Plugins Updates
+
+* Coprocess plugins now have access to `config_data`
+* The JSVM `spec` object now has access to `APIID` and `OriginID` to reflect similar functionality of Coprocess plugins.
+* Plugins now have access to Host HTTP Header.
+
+[JSVM Docs]({{< ref "plugins/supported-languages/javascript-middleware/middleware-scripting-guide" >}})
+[Plugin Data Structure Docs]({{< ref "plugins/supported-languages/rich-plugins/rich-plugins-data-structures" >}})
+
+
+## <a name="dashboard"></a>Tyk Dashboard v1.5.0
+
+### A Fresh Look and Feel
+
+With this release we have refreshed the entire Dashboard UI with a new look-and-feel, bringing with it such improvements as:
+
+* A more modern, fun look and feel
+* Consistent layouts and action buttons across each section
+* Better feedback on errors and updates
+* UX improvements
+
+### Search on API and Policy List Pages
+
+We have added API and Policy search functionality, which should help those with long lists.
+
+* [API Docs]({{< ref "tyk-apis/tyk-dashboard-api/api-definitions" >}})
+* [Policy Docs]({{< ref "tyk-apis/tyk-dashboard-api/portal-policies" >}})
+
+### A New, Interactive Getting Started Walkthrough
+
+We have swapped out the old Getting started tutorial and added a new interactive one, which should make it easier for new users to get started with the Dashboard UI.
+
+### Advanced URL Rewrites
+
+We have extended the URL Rewrite plugin functionality by enabling users to create more advanced rewrite rules based on Header matches, Query string variable/value matches, Path part matches, (i.e. components of the path itself), Session metadata values, and Payload matches.
+
+[Docs]({{< ref "transform-traffic/url-rewriting" >}})
+
+### Portal Session Lifetime
+
+You can now control the portal session lifetime using the `portal_session_lifetime` config variable.
+
+[Docs](https://tyk.io/docs/configure/tyk-dashboard-configuration-options/)
+
+### Configure Port for WebSockets
+
+We have added `notifications_listen_port` option to configure the port used by WebSockets for real-time notifications.
+
+[Docs]({{< ref "tyk-oss-gateway/configuration" >}})
+
+### Slug
+
+Once set, the API slug will no longer be overridden when the API title is changed.
+
+### Custom Domain
+
+We have fixed the API URL if a custom domain is set.
+
+
+## <a name="pump"></a> Tyk Pump v0.5.0
+
+### Splunk Support
+
+We added support for forwarding analytics data to Splunk. A sample configuration is:
+
+```
+"pumps": {
+  "splunk": {
+    "name": "splunk",
+    "meta": {
+      "collector_token": "<secret>",
+      "collector_url": "https://<your-id>.cloud.splunk.com:
+                    8088",
+        "ssl_insecure_skip_verify": true
+    }
+  }
+},
+```
+
+### <a name="analytics"></a>Analytics Collection Capping
+
+Detailed analytics collection capping is now enabled by default and configurable via the `collection_cap_enable` and `collection_cap_max_size_bytes` options.
+
+
+
+## <a name="mdcb"></a> MDCB v1.5.0
+
+We've introduced long awaited support for using Tyk Pump in conjunction with MDCB to use any of services supported by Tyk Pump, like ElasticSearch, Splunk and etc. This works by setting `forward_analytics_to_pump` to true, which disables analytics processing by MDCB itself, and enables the forwarding of all data to Tyk Pump running inside your management environment.
+
+
+## <a name="tib"></a>TIB v0.3
+  
+With this release, you now can use any OpenID Connect compatible provider with TIB. This means that you can use almost any Identity management solution, supporting OpenID, like Okta, Ping or Keycloak.
+ 
+Use `SocialProvider` with the following options:
+
+```
+"UseProviders": [{
+  "Name": "openid-connect",
+  "Key": "CLIENT-KEY",
+  "Secret": "CLIENT-SECRET",
+  "DiscoverURL": "https://<oidc-domain>/.well-known/openidconfiguration"
+}]
+```
+
+## Packaging changes across all products
+
+New deb and rpm packages add the "tyk" user and group so that package files and directories would be owned by it and the process run with its effective uid and gid. In addition to this gateway PID now has to reside in its own sub-rundir due to this change, so that's created (and additionally managed by systemd where it's available), default pidfile location changed appropriately so that upgrade wouldn't require any config changes by the users. The gateway config file is now only readable and writable by the "tyk" user and group. This change is applied across all our products except Gateway: its changes scheduled to 2.6. 
+
+The "default" init system files are not removed on upgrade/remove anymore so that it's now a way for users to run the respective process with custom environment variables.
+
+The bug with removal of init system files on upgrade in rpm-based systems is now fixed.
+
+
+## <a name="upgrade"></a>Upgrading all new Components
+
+For details on upgrading all Tyk versions, see [Upgrading Tyk](https://tyk.io/docs/upgrading-tyk/).
+
+## <a name="new"></a>Don't Have Tyk Yet?
+
+Get started now, for free, or contact us with any questions.
+
+* [Get Started](https://tyk.io/pricing/compare-api-management-platforms/#get-started)
+* [Contact Us](https://tyk.io/about/contact/)

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.6.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.6.md
@@ -1,9 +1,8 @@
 ---
-title: Tyk Gateway v2.6
-menu:
-  main:
-    parent: "Release Notes"
-weight: 13
+title: Tyk Dashboard v2.6
+tags: ["Tyk", "Release notes", "Dashboard", "v2.6", "2.6"]
+aliases:
+  - /product-stack/tyk-dashboard/release-notes/old-releases/version-2.6/
 ---
 
 # <a name="new"></a>New in this Release:

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.7.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.7.md
@@ -1,0 +1,77 @@
+---
+title: Tyk Dashboard v2.7
+tags: ["Tyk", "Release notes", "Dashboard", "v2.7", "2.7"]
+aliases:
+  - /product-stack/tyk-dashboard/release-notes/old-releases/version-2.7/
+---
+
+# <a name="new"></a>New in this Release:
+
+## <a name="gateway"></a>Tyk Gateway v2.7.0
+
+### Performance improvements
+
+
+> **TLDR**
+> To get benefit or performance improvements ensure that you have `close_connections` set to `false` and set `max_idle_connections_per_host` according to our [production perfomance guide]({{< ref "planning-for-production" >}})
+
+We have thoroughly analysed every part of our Gateway, and the results are astounding, up to 160% improvement, compared to our 2.6 release.
+
+Such a performance boost comes from various factors, such as optimising our default configs, better HTTP connection re-use, optimisation of the analytics processing pipeline, regexp caching, doing fewer queries to the database, and numerous small changes in each of the  middleware we have.
+
+Our performance testing plan was focused on replicating our customer's setup, and try not to optimise for “benchmarks”: so no supercomputers and no sub-millisecond inner DC latency. Instead, we were testing on average performance 2 CPU Linode machine, with 50ms latency between Tyk and upstream. For testing, we used the Tyk Gateway in Hybrid mode, with a default config, except for a single 2.7 change where `max_idle_connections_per_host ` is set to 500, as apposed to 100 in 2.6. Test runner was using [Locust](https://locust.io/) framework and [Boomer](https://github.com/myzhan/boomer) for load generation.
+
+For a keyless API we were able to achieve 3.7K RPS (requests per second) for 2.7, while 2.6 showed about 2.5K RPS, which is a 47% improvement.
+
+For protected APIs, when Tyk needs to track both rate limits and quotas, 2.7 shows around 3.1K RPS, while 2.6 shows around 1.2K RPS, which is 160% improvement!
+
+In 2.7 we optimised the connection pool between Tyk and upstream, and previously `max_idle_connections_per_host` option was capped to 100. In 2.7 you can set it to any value. `max_idle_connections_per_host` by itself controls an amount of keep-alive connections between clients and Tyk. If you set this value too low, then Tyk will not re-use connections and will have to open a lot of new connections to your upstream. If you set this value too big, you may encounter issues with slow clients occupying your connection and you may reach OS limits. You can calculate the correct value using a straightforward formula: if latency between Tyk and Upstream is around 50ms, then a single connection can handle 1s / 50s = 20 requests. So if you plan to handle 2000 requests per second using Tyk, the size of your connection pool should be at least 2000 / 20 = 100. For example, on low-latency environments (like 5ms), a connection pool of 100 connections will be enough for 20k RPS.
+
+To get the benefit of optimised connection pooling, ensure that `close_connections` is set to `false`, which enables keep-alive between Tyk and Upstream.
+
+### Custom key hashing algorithms
+
+Key hashing is a security technique introduced inside Tyk a long time ago, which allows you to prevent storing your API tokens in database, and instead, only store their hashes. Only API consumers have access to their API tokens, and API owners have access to the hashes, which gives them access to usage and analytics in a secure manner. Time goes on, algorithms age, and to keep up with the latest security trends, we introduce a way to change algorithms used for key hashing.
+
+This new feature is in public beta, and turned off by default, keeping old behavior when Tyk uses `murmur32` algorithm. To set the custom algorithm, you need to set `hash_key_function` to one of the following options:
+- `murmur32`
+- `murmur64`
+- `murmur128`
+- `sha256`
+
+MurMur non-cryptographic hash functions is considered as industry fastest and conflict-prone algorithms up to date, which gives a nice balance between security and performance. With this change you now you may choose the different hash length, depending on your organization security policies. As well, we have introduced a new `sha256` **cryptographic** key hashing algorithm, for cases when you are willing to sacrifice performance with additional security.
+
+Performance wise, setting new key hashing algorithms can increase key hash length, as well as key length itself, so expect that your analytics data size to grow (but not that much, up to 10%). Additionally, if you set the `sha256` algorithm, it will significantly slowdown Tyk, because `cryptographic` functions are slow by design but very secure.
+
+Technically wise, it is implemented by new key generation algorithms, which now embed additional metadata to the key itself, and if you are curious about the actual implementation details, feel free to check the following [pull request](https://github.com/TykTechnologies/tyk/pull/1753).
+
+Changing hashing algorithm is entirely backward compatible. All your existing keys will continue working with the old `murmur32` hashing algorithm, and your new keys will use algorithm specified in Tyk config. Moreover, changing algorithms is also backward compatible, and Tyk will maintain keys multiple hashing algorithms without any issues.
+
+
+## Tyk Dashboard v1.7.0
+
+### User Groups
+
+Instead of setting permissions per user, you can now [create a user group]({{< ref "basic-config-and-security/security/dashboard/create-user-groups" >}}), and assign it to multiple users. It works for Single Sign-On too, just specify group ID during [SSO API]({{< ref "tyk-apis/tyk-dashboard-admin-api/sso" >}}) flow.
+
+This feature is available to all our Cloud and Hybrid users. For Self-Managed installations, this feature is available for customers with an "Unlimited" license.
+
+To manage user groups, ensure that you have either admin or “user groups” permission for your user, which can be enabled by your admin.
+
+From an API standpoint, user groups can be managed by [new Dashboard API]({{< ref "tyk-apis/tyk-dashboard-api/user-groups" >}}). The User object now has a new `group_id` field, and if it is specified, all permissions will be inherited from the specified group. [SSO API]({{< ref "tyk-apis/tyk-dashboard-admin-api/sso" >}}) has been updated to include `group_id` field as well.
+
+### Added SMTP support
+Now you can configure the Dashboard to send transactional emails using your SMTP provider. See [Outbound Email Configuration]({{< ref "configure/outbound-email-configuration" >}}) for details.
+
+## <a name="upgrade"></a>Upgrading all new Components
+
+For details on upgrading all Tyk versions, see [Upgrading Tyk]({{< ref "upgrading-tyk" >}}).
+
+## <a name="new"></a>Don't Have Tyk Yet?
+
+Get started now, for free, or contact us with any questions.
+
+* [Get Started](https://tyk.io/pricing/compare-api-management-platforms/#get-started)
+* [Contact Us](https://tyk.io/about/contact/)
+
+

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.8.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.8.md
@@ -1,9 +1,8 @@
 ---
-title: Tyk Gateway v2.8
-menu:
-  main:
-    parent: "Release Notes"
-weight: 11
+title: Tyk Dashboard v2.8
+tags: ["Tyk", "Release notes", "Dashboard", "v2.8", "2.8"]
+aliases:
+  - /product-stack/tyk-dashboard/release-notes/old-releases/version-2.8/
 ---
 
 ## Looping

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.9.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.9.md
@@ -1,0 +1,155 @@
+---
+title: Tyk Dashboard v2.9
+tags: ["Tyk", "Release notes", "Dashboard", "v2.9", "2.9"]
+aliases:
+  - /product-stack/tyk-dashboard/release-notes/old-releases/version-2.9/
+---
+
+### TCP Proxying
+
+Tyk now can be used as a reverse proxy for your TCP services. It means that you can put Tyk not only on top of your APIs, but on top of **any** network application, like databases, services using custom protocols and etc.
+
+The main benefit of using Tyk as your TCP proxy is that functionality you used to managed your APIs now can be used for your TCP services as well. Features like load balancing, service discovery, Mutual TLS (both authorisation and communication with upstream), certificate pinning: all work exactly the same way as for your HTTP APIs.
+
+See our [TCP Proxy Docs]({{< ref "key-concepts/tcp-proxy" >}}) for more details.
+
+### APIs as Products
+
+With this release we have removed all the barriers on how you can mix and match policies together, providing you with ultimate flexibility for configuring your access rules.
+
+Now a key can have multiple policies, each containing rules for different APIs. In this case each distinct policy will have its own rate limit and quota counters. For example if the first policy gives access to `API1` and second policy to `API2` and `API3`, if you create a key with both policies, your user will have access to all three APIs, where `API1` will have quotas and rate limits defined inside the first policy, and `API2`, `API3` will have shared quotas and rate limits defined inside the second policy.
+
+Additionally you can now mix policies defined for the same API but having different path and methods access rules. For example you can have one policy which allows only access to `/users` and a second policy giving user access to a `/companies` path. If you create a key with both policies, their access rules will be merged, and user will get access to both paths. See [Multiple APIs for single Key Requests]({{< ref "tyk-developer-portal/tyk-portal-classic/portal-concepts#multiple-apis-for-a-single-key-request" >}}).
+
+#### Developer Portal Updates
+
+Developers now can have multiple API keys, and subscribe to multiple catalogues with a single key. Go to the Portal settings and set `Enable subscribing to multiple APIs with single key` option to enable this new flow. When enabled, developers will see the new API generation user interface, which allows users to request access to multiple Catalogues of the **same type** with a single key.
+
+From an implementation point of view, Developer objects now have a `Keys` attribute, which is the map where the key is a `key` and the value is an array of policy IDs. The `Subscriptions` field can be considered as deprecated, with retained backwards compatibility. We have added new set of Developer APIs to manage the keys, similar to the deprecated subscriptions APIs.
+
+Other changes:
+
+- Added two new Portal templates, which are used by a new key request flow `portal/templates/request_multi_key.html`, `portal/templates/request_multi_key_success.html`
+- The Portal Catalogue list page has been updated to show the Catalogue authentication mode
+- The API dashboard screen now show keys instead of subscriptions, and if subscribed to multiple policies, it will show the allowance rules for all catalogues.
+- The Key request API has been updated to accept an `apply_policies` array instead of `for_plan`
+
+### JWT and OpenID scope support
+
+Now you can set granular permissions on per user basis, by injecting permissions to the "scope" claim of a JSON Web Token. To make it work you need to provide mapping between the scope and policy ID, and thanks to enchanced policy merging capabilities mentioned above, Tyk will read the scope value from the JWT and will generate dynamic access rules. Your JWT scopes can look like `"users:read companies:write"` or similar, it is up to your imagination. OpenID supports it as well, but at the moment only if your OIDC provider can generate ID tokens in JWT format (which is very common this days).
+
+See our [JWT Scope docs]({{< ref "advanced-configuration/integrate/api-auth-mode/open-id-connect#jwt-scope-to-policy-mapping-support" >}}) for more details.
+
+### Go plugins
+
+[Go](https://golang.org/) is an open source programming language that makes it easy to build simple, reliable, and efficient software. The whole Tyk stack is written in Go language, and it is one of the reasons of behind our success.
+
+With this release you now can write native Go plugins for Tyk. Which means extreme flexibility and the best performance without any overhead.
+
+Your plugin can be as simple as:
+
+```{.go}
+package main
+import (
+	"net/http"
+)
+// AddFooBarHeader adds custom "Foo: Bar" header to the request
+func AddFooBarHeader(rw http.ResponseWriter, r *http.Request) {
+	r.Header.Add("Foo", "Bar")
+}
+```
+
+See our [Golang plugin documentation]({{< ref "plugins/supported-languages/golang" >}}) for more details.
+
+### Distributed tracing
+
+We have listened to you, and tracing is recently one of your most common requests. Distributed tracing takes your monitoring and profiling experience to the next level, since you can see the whole request flow, even if it has complex route though multiple services. And inside this flow, you can go deep down into the details like individual middleware execution performance.
+At the moment we are offering [OpenTracing](https://opentracing.io/) support, with [Zipkin](https://zipkin.io/) and [Jaeger](https://www.jaegertracing.io/) as supported tracers.
+
+See our [Distributed Tracing documentation]({{< ref "product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/open-telemetry-overview" >}}) for more details.
+
+### HMAC request signing
+
+Now Tyk can sign a request with HMAC, before sending to the upsteam target.
+
+This feature is implemented using [Draft 10](https://tools.ietf.org/html/draft-cavage-http-signatures-10) RFC.
+
+`(request-target)` and all the headers of the request will be used for generating signature string.
+If the request doesn't contain a `Date` header, middleware will add one as it is required according to above draft.
+
+A new config option `request_signing` can be added in an API Definition to enable/disable the request signing. It has following format:
+
+```{.json}
+"request_signing": {
+  "is_enabled": true,
+  "secret": "xxxx",
+  "key_id": "1",
+  "algorithm": "hmac-sha256"
+}
+```
+
+The following algorithms are supported:
+
+1. `hmac-sha1`
+2. `hmac-sha256`
+3. `hmac-sha384`
+4. `hmac-sha512`
+
+### Simplified Dashboard installation experience
+
+We worked a lot with our clients to build a way nicer on-boarding experience for Tyk. Instead of using the command line, you can just run the Dashboard, and complete a form which will configure your Dashboard. However, we did not forget about our experienced users too, and now provide a CLI enchanced tool for bootstrapping Tyk via a command line.
+
+See our updated [Getting Started]({{< ref "tyk-self-managed/install" >}}) section and [new CLI documentation]({{< ref "tyk-on-premises" >}}).
+
+### DNS Caching
+
+Added a global DNS cache in order to reduce the number of request to a Gateway's local DNS server and the appropriate gateway config section. This feature is turned off by default.
+
+```
+"dns_cache": {
+    "enabled": true, //Turned off by default
+    "ttl": 60, //Time in seconds before the record will be removed from cache
+    "multiple_ips_handle_strategy": "pick_first" //A strategy, which will be used when dns query will reply with more than 1 ip address per single host.
+},
+```
+
+### Python Plugin Improvements
+
+We have completed a massive rewrite of our Python scripting engine in order to simplify the installation and usage of Python scripts. From now on, you no longer need to use a separate Tyk binary for Python plugins. Everything is now bundled to the main binary.
+This also means that you can combine JSVM, Python and Coprocess plugins inside the same installation.
+In addition you can now use any Python 3.x version. Tyk will automatically detect a supported version and will load the required libraries. If you have multiple Python versions available, you can specify the exact version using `python_version`.
+
+### Importing Custom Keys using the Dashboard API
+
+Previously if you wanted migrate to Tyk and keep existing API keys, you had to use our low level Tyk Gateway API, which has lot of constraints, especially regarding complex setups with multiple organisations and data centers.
+
+We have introduced a new Dashboard API for importing custom keys, which is as simple as `POST /api/keys/{custom_key} {key-payload}`. This new API ensures that Keys from multiple orgs will not intersect, and it also works for multi-data center setups, and even Tyk SaaS.
+
+### Single sign on for the Tyk SaaS
+
+Before SSO was possible only for Tyk On-Premise, since it required access to low-level Dashboard Admin APIs. With 2.9 we have added new a new Dashboard SSO API, which you can use without having super admin access, and it works at the organisation level. This means that all our Tyk SaaS users can use 3rd party IDPs to manage Dashboard users and Portal developers.
+
+> **NOTE**: This feature is available by request. Please contact our sales team for details.
+
+See our [Dashboard SSO documentation]({{< ref "tyk-apis/tyk-dashboard-api/sso" >}}) for more details.
+
+### Importing WSDL APIs
+
+WSDL now is a first class citizen at Tyk. You can take your WSDL definition and simply import to the Dashboard, creating a nice boilerplate for your service. See [Import APIs]({{< ref "getting-started/import-apis" >}}) for more details.
+
+### Updated Versions
+
+- Tyk Gateway 2.9.0
+- Tyk Dashboard 1.9.0
+- Tyk Pump 0.8.0
+- Tyk MDCB 1.7.0
+
+### Upgrading From Version 2.8
+
+#### Tyk On-Premises
+
+For this release, you should upgrade your Tyk Pump first.
+
+#### Tyk MDCB
+
+For this release, you should upgrade your MDCB component first.

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/overview.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/overview.md
@@ -1,6 +1,54 @@
 ---
 title: Tyk Dashboard Release Notes
-description: "Explains where to access older supported bundled release notes for Tyk Dashboard and Tyk Gateway"
+description: "Links to Tyk major minor releases for Tyk Gateway"
 tags: ["Release notes"]
 ---
-Older release notes of Tyk Dashboard were bundled together with Tyk Gateway. The release notes for these older supported releases are available in the [Developer Support]({{< ref "/developer-support/tyk-release-summary/overview" >}}) section of the website.
+
+This page provides access to release notes for Tyk Dashboard. Links to archived releases are also included.
+
+### Release 5
+- [v5.2]({{< ref "product-stack/tyk-dashboard/release-notes/version-5.2.md" >}})
+- [v5.1]({{< ref "product-stack/tyk-dashboard/release-notes/version-5.1.md" >}})
+- [v5.0]({{< ref "product-stack/tyk-dashboard/release-notes/version-5.0.md" >}})
+
+
+Historic release notes can be previewed by expanding the links in the sections below.
+
+### Release 4
+<details>
+    <summary>
+        Click to expand
+    </summary>
+
+- [v4.3]({{< ref "product-stack/tyk-dashboard/release-notes/version-4.3.md" >}})
+- [v4.2]({{< ref "product-stack/tyk-dashboard/release-notes/version-4.2.md" >}})
+- [v4.1]({{< ref "product-stack/tyk-dashboard/release-notes/version-4.1.md" >}})
+- [v4.0]({{< ref "product-stack/tyk-dashboard/release-notes/version-4.0.md" >}})
+</details>
+
+### Release 3
+<details>
+    <summary>
+        Click to expand
+    </summary>
+
+- [v3.2]({{< ref "product-stack/tyk-dashboard/release-notes/version-3.2.md" >}})
+- [v3.1]({{< ref "product-stack/tyk-dashboard/release-notes/version-3.1.md" >}})
+- [v3.0]({{< ref "product-stack/tyk-dashboard/release-notes/version-3.0.md" >}})
+</details>
+
+## Archived Releases
+
+### Release 2
+<details>
+    <summary>
+        Click to expand
+    </summary>
+
+- [v2.9]({{< ref "product-stack/tyk-dashboard/release-notes/archived-releases/version-2.9.md" >}})
+- [v2.8]({{< ref "product-stack/tyk-dashboard/release-notes/archived-releases/version-2.8.md" >}})
+- [v2.7]({{< ref "product-stack/tyk-dashboard/release-notes/archived-releases/version-2.7.md" >}})
+- [v2.6]({{< ref "product-stack/tyk-dashboard/release-notes/archived-releases/version-2.6.md" >}})
+- [v2.5]({{< ref "product-stack/tyk-dashboard/release-notes/archived-releases/version-2.5.md" >}})
+- [v2.4]({{< ref "product-stack/tyk-dashboard/release-notes/archived-releases/version-2.4.md" >}})
+</details>

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-3.0.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-3.0.md
@@ -1,9 +1,7 @@
 ---
-title: Tyk v3.0
-menu:
-  main:
-    parent: "Release Notes"
-weight: 9
+title: Tyk Dashboard v3.0
+description: "Tyk Dashboard 3.0 release notes"
+tags: ["release notes", "Tyk Dashboard", "v3.0", "3.0"]
 ---
 
 ### Version changes and LTS releases
@@ -117,11 +115,10 @@ The feature can be enabled by setting the config `track_404_logs` to `true` in t
 
 ### Updated Versions
 
-- Tyk Gateway 3.0
 - Tyk Dashboard 3.0
 - Tyk Pump 1.0
 
 ### Upgrading From Version 2.9
 
 No specific actions required.
-If you are upgrading from version 2.8, pls [read this guide]({{< ref "release-notes/version-2.9.md#upgrading-from-version-28" >}})
+If you are upgrading from version 2.8, pls [read this guide]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.9.md#upgrading-from-version-28" >}})

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-3.1.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-3.1.md
@@ -1,9 +1,7 @@
 ---
-title: Tyk v3.1
-menu:
-  main:
-    parent: "Release Notes"
-weight: 8
+title: Tyk Dashboard v3.1
+description: "Tyk Dashboard 3.1 release notes"
+tags: ["release notes", "Tyk Dashboard", "v3.1", "3.1"]
 ---
 
 ## What’s new?
@@ -68,6 +66,5 @@ https://github.com/TykTechnologies/tyk/releases/tag/v3.0.1
 
 ## Updated Versions
 
-- Tyk Gateway 3.1
 - Tyk Dashboard 3.1
 

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-3.2.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-3.2.md
@@ -1,0 +1,48 @@
+---
+title: Tyk Dashboard v3.2
+description: "Tyk Dashboard 3.2 release notes"
+tags: ["release notes", "Tyk Dashboard", "v3.2", "3.2"]
+---
+
+# What’s new?
+
+## Bring your own Identity Provider - Dynamic Client Registration now available!
+
+DCR is a protocol of the Internet Engineering Task Force put in place to set standards in the dynamic registration of clients with authorisation servers. This feature is a way for you to integrate your Tyk Developer Portal with an external identity provider such as Keycloak, Gluu, Auth0 or Okta. 
+The portal developer won't notice a difference. However when they create the app via Tyk Developer portal, Tyk will dynamically register that client on your authorisation server. This means that it is the Authorisation Server that will issue the Client ID and Client Secret for the app.
+
+Check our DCR docs [here]({{< ref "/tyk-developer-portal/tyk-portal-classic/dynamic-client-registration" >}})
+
+We also took this opportunity to give a refresh to the portal settings UI so let us know if you like it! 
+
+## GraphQL and UDG improvements
+
+We've updated the GraphQL functionality of our [Universal Data Graph]({{< ref "universal-data-graph" >}}). You’re now able to deeply nest GraphQL & REST APIs and stitch them together in any possible way.
+
+Queries are now possible via WebSockets and Subscriptions are coming in the next Release (3.3.0).
+
+You're also able to configure [upstream Headers dynamically]({{< ref "universal-data-graph/udg-getting-started/header-forwarding" >}}), that is, you’re able to inject Headers from the client request into UDG upstream requests. For example, it can be used to acccess protected upstreams. 
+
+We've added an easy to use URL-Builder to make it easier for you to inject object fields into REST API URLs when stitching REST APIs within UDG.
+
+Query-depth limits can now be configured on a per-field level.
+
+If you’re using GraphQL upstream services with UDG, you’re now able to forward upstream error objects through UDG so that they can be exposed to the client.
+
+
+## Extendable Tyk Dashboard permissions system
+
+The Tyk Dashboard permission system can now be extended by writing custom rules using an Open Policy Agent (OPA). The rule engine works on top of the Tyk Dashboard API, which means you can control not only access rules, but also the behaviour of all Dashboard APIs (except your public developer portal). You can find more details about OPA [here]({{< ref "/content/tyk-dashboard/open-policy-agent.md" >}}).
+
+In addition, you can now create your own custom permissions using the Additional Permissions API or by updating `security.additional_permissions` map in the Tyk Dashboard config, and writing Opa rule containing logic for the new permission.
+
+# Bug fixes and minor changes
+
+In addition to the above, version 3.2 includes all the fixes that are part of 3.0.5
+https://github.com/TykTechnologies/tyk/releases/tag/v3.0.5
+
+# Updated Versions
+Tyk Dashboard 3.2
+
+# Upgrade process
+If you already have GraphQL or UDG APIs you need to follow this upgrade guide https://tyk.io/docs/graphql/migration-guide/

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.0.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.0.md
@@ -1,9 +1,7 @@
 ---
-title: Tyk v4.0
-menu:
-  main:
-    parent: "Release Notes"
-weight: 6
+title: Tyk Dashboard v4.0
+description: "Tyk Dashboard 4.0 release notes"
+tags: ["release notes", "Tyk Dashboard", "v4.0", "4.0"]
 ---
 
 ## GraphQL federation
@@ -42,7 +40,6 @@ As part of SQL support we are also providing tooling to perform seamless migrati
 - Go plugins can be attached on per-endpoint level, similar to virtual endpoints
 
 # Updated Versions
-Tyk Gateway 4.0
 Tyk Dashboard 4.0
 Tyk Pump 1.5
 

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.1.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.1.md
@@ -1,0 +1,64 @@
+---
+title: Tyk Dashboard v4.1
+description: "Tyk Dashboard 4.1 release notes"
+tags: ["release notes", "Tyk Dashboard", "v4.1", "4.1"]
+---
+
+# Major features
+
+## OpenAPI as a native API definition format
+Tyk has always had a proprietary specification for defining APIs. From Tyk v4.1 we now support defining APIs using the Open API Specification (OAS) as well, which can offer significant time and complexity savings. [This is an early access capability]({{< ref "frequently-asked-questions/using-early-access-features" >}}).
+
+As we extend our OAS support, we would very much like your feedback on how we can extend and update to best meet your needs: .
+
+This capability is available in both the open source and paid versions of Tyk. See our [High Level Concepts]({{< ref "getting-started/key-concepts/high-level-concepts" >}}) for more details, or jump to [OAS Getting Started documentation]({{< ref "getting-started/using-oas-definitions/create-an-oas-api" >}}).
+
+
+## MDCB Synchroniser
+
+Tyk Gateway v4.1 enables an improved synchroniser functionality within Multi Data Centre Bridge (MDCB) v2.0. Prior to this release, the API keys, certificates and OAuth clients required by worker Gateways were synchronised from the controller Gateway on-demand. With Gateway v4.1 and MDCB v2.0 we introduce proactive synchronisation of these resources to the worker Gateways when they start up.
+ 
+This change improves resilience in case the MDCB link or controller Gateway is unavailable, because the worker Gateways can continue to operate independently using the resources stored locally. There is also a performance improvement, with the worker Gateways not having to retrieve resources from the controller Gateway when an API is first called.
+ 
+Changes to keys, certificates and OAuth clients are still synchronised to the worker Gateways from the controller when there are changes and following any failure in the MDCB link.
+
+## Go Plugin Loader
+When upgrading your Tyk Installation you need to re-compile your plugin with the new version. At the moment of loading a plugin, the Gateway will try to find a plugin with the name provided in the API definition. If none is found then it will fallback to search the plugin file with the name: `{plugin-name}_{Gw-version}_{OS}_{arch}.so`
+
+From v4.1.0 the plugin compiler automatically names plugins with the above naming convention. It enables you to have one directory with different versions of the same plugin. For example:
+
+- `plugin_v4.1.0_linux_amd64.so`
+- `plugin_v4.2.0_linux_amd64.so`
+
+So, if you upgrade from Tyk v4.1.0 to v4.2.0 you only need to have the plugins compiled for v4.2.0 before performing the upgrade.
+
+# Changelog
+
+## Tyk Dashboard
+### Added
+- Added support for new OAS api definition format, and new API creation screens
+- Dashboard boostrap instalation script extended to support SQL databases
+- Added `TYK_DB_OMITCONFIGFILE` option for Tyk Dashboard to ignore the values in the config file and load its configuration only from environment variables and default values
+- Added a new config option `identity_broker.ssl_insecure_skip_verify` that will allow customers using the embedded TIB to use IDPs exposed with a self signed certificate. Not intended to be used in production, only for testing and POC purposes.
+- Added option to configure certificates for Tyk Dashboard using [environment variables](https://tyk.io/docs/tyk-dashboard/configuration/#http_server_optionscertificates).
+### Changed
+- Detailed information about certificates can be viewed from certificates listing page
+- Dashboard APIs GQL Playground now shows additional information about certificates
+- Dashboard will now use default version of GraphiQL Playground which can switch between light and dark modes for more accessibility
+- Banner for resyncing GraphQL schema has been given a new, more accessible look in line with the rest of Dashboard design
+### Fixed
+- Fixed an issue with key lookup where keys were not being found when using the search field
+- Fixed an issue with object types dropdown in Universal Data Graph config, where it wasn’t working correctly when object type UNION was chosen
+- Fixed an issue in Universal Data Graph which prevented users from injecting an argument value or parameter value in the domain part of the defined data source upstream URL
+
+
+# Updated Versions
+Tyk Dashboard 4.1
+Tyk MDCB 2.0.1
+
+# Upgrade process
+
+Follow the [standard upgrade guide]({{< ref "/content/upgrading-tyk.md" >}}), there are no breaking changes in this release.
+
+If you want switch from MongoDB to SQL, you can [use our migration tool]({{< ref "/content/planning-for-production/database-settings/postgresql.md#migrating-from-an-existing-mongodb-instance" >}}), but keep in mind that it does not yet support the migration of your analytics data.
+ 

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.2.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.2.md
@@ -1,9 +1,7 @@
 ---
-title: Tyk v4.2
-menu:
-  main:
-    parent: "Release Notes"
-weight: 4
+title: Tyk Dashboard v4.2
+description: "Tyk Dashboard 4.2 release notes"
+tags: ["release notes", "Tyk Dashboard", "v4.2", "4.2"]
 ---
 
 # Major features
@@ -109,23 +107,6 @@ Added support for Kafka as a data source in Universal Data Graph. Configuration 
 
 # Changelog
 
-## Tyk Gateway
-### Added
-- Added support for Kafka as a data source in Universal Data Graph.
-- Adding a way to defining the base GraphQL entity via @key directive
-- It is now possible to define an extension for a type in a subgraph that does not define the base type.
-- Added support for the Request Body Transform middleware, for the new Tyk OAS API Definition
-- Session lifetime now can be controled by Key expiration, e.g. key removed when it is expired. Enabled by setting `session_lifetime_respects_key_expiration` to `true`
-### Changed
-- Generate API ID when API ID is not provided while creating API. 
-- Updated the Go plugin loader to load the most appropriate plugin bundle, honouring the Tyk version, architecture and OS
-- When GraphQL query with a @skip directive is sent to the upstream it will no longer return “null” for the skipped field, but remove the field completely from the response
-- Added validation to Union members - must be both unique and defined.
-### Fixed
-- Fixed an issue where the Gateway would not create the circuit breaker events (BreakerTripped and BreakerReset) for which the Tyk Dashboard offers webhooks.
-- Types of the same name can be defined in more than one subgraph (a shared type). This will no longer produce an error if each definition is exactly identical.
-- Apply Federation Subgraph normalisation do avoid merge errors. Extensions of types whose base type is defined in the same subgraph will be resolved before an attempt at federation.
-
 ## Tyk Dashboard
 ### Added
 - Added support for Kafka as a data source in Universal Data Graph.
@@ -141,7 +122,6 @@ Added support for Kafka as a data source in Universal Data Graph. Configuration 
 
 
 # Updated Versions
-Tyk Gateway 4.2
 Tyk Dashboard 4.2
 
 # Upgrade process

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.3.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.3.md
@@ -1,0 +1,75 @@
+---
+title: Tyk Dashboard v4.3
+description: Tyk Dashboard v4.3 release notes
+tags: ["release notes", "Tyk Dashboard", "v4.3", "4.3"]
+---
+
+## Major features
+
+### Tyk OAS APIs - Versioning via the Dashboard
+
+Tyk v4.3 adds API versioning to the Dashboard UI, including:
+
+- Performing CRUD operations over API versions
+- Navigate seamlessly between versions
+- A dedicated manage versions screen
+- easily identify the default version and the base API.
+
+### Importing OAS v3 via the Dashboard
+
+Importing OpenAPI v3 documents in order to generate Tyk OAS API definition is now fully supported in our Dashboard UI. Our UI automatically detects the version of your OpenAPI Document, and will suggest options that you can pass or allow Tyk to read from the provided document, in order to configure the Tyk OAS API Definition. Such as: 
+
+- custom upstream URL
+- custom listen path
+- authentication mechanism
+- validation request rules and limit access only to the defined paths.
+
+[Importing OAS v3 via the Dashboard]({{< ref "/content/getting-started/using-oas-definitions/import-an-oas-api.md#tutorial-using-the-tyk-dashboard" >}})
+
+### Updated the Tyk Dashboard version of Golang, to 1.16.
+
+**Our Dashboard is using Golang 1.16 version starting with 4.3 release. This version of the Golang release deprecates x509 commonName certificates usage. This will be the last release where it's still possible to use commonName, users need to explicitly re-enable it with an environment variable.**
+
+The deprecated, legacy behavior of treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is now disabled by default. It can be temporarily re-enabled by adding the value x509ignoreCN=0 to the GODEBUG environment variable.
+
+Note that if the CommonName is an invalid host name, it's always ignored, regardless of GODEBUG settings. Invalid names include those with any characters other than letters, digits, hyphens and underscores, and those with empty labels or trailing dots.
+
+
+## Changelog
+
+### Tyk Dashboard
+
+#### Added
+
+- Added an option for using multiple header/value pairs when configuring GraphQL API with a protected upstream and persisting those headers for future use.
+- Added documentation on how edge endpoints Dashboard configuration can be used by users to add tags for their API Gateways.
+- When retrieving the Tyk OAS API Definition of a versioned API, the base API ID is passed on the GET request as a header: `x-tyk-base-api-id`.
+- If Edge Endpoints Dashboard configuration is present, when users add segment/tags to the Tyk OAS API Definition, their corresponding URLs are populated in the servers section of the OAS document.
+- Listen path field is now hidden from the API Designer UI, when the screen presents a versioned or internal API.
+
+#### Changed
+
+- Extended existing `x-tyk-gateway` OAS documentation and improved the markdown generator to produce a better-formatted documentation for `x-tyk-gateway` schema.
+- Complete change of Universal Data Graph configuration UI. New UI is now fully functional and allows configuration of all existing datasources (REST, GraphQL and Kafka).
+- Changed look & feel of request logs for GraphQL Playground. It is now possible to filter the logs and display only the information the user is interested in.
+
+#### Fixed
+
+- Fixed: OAS API definition showing management gateway URL even if segment tags are present in cloud. From now on OAS servers section would be filled with edge endpoint URLs if configured.
+- Adding a path that contains a path parameter, doesn’t throw an error anymore on the Dashboard UI, and creates default path parameter description in the OAS.
+
+## Updated Versions
+
+Tyk Dashboard 4.3 ([docker images](https://hub.docker.com/r/tykio/tyk-dashboard/tags?page=1&name=4.3.0))
+
+## Upgrade process
+
+Follow the [standard upgrade guide]({{< ref "/content/upgrading-tyk.md" >}}), there are no breaking changes in this release.
+
+If you want switch from MongoDB to SQL, you can [use our migration tool]({{< ref "/content/planning-for-production/database-settings/postgresql.md#migrating-from-an-existing-mongodb-instance" >}}), but keep in mind that it does not yet support the migration of your analytics data.
+
+{{< note success >}}
+**Note**  
+
+Note: Upgrading the Golang version implies that all the Golang custom plugins that you are using need to be recompiled before migrating to 4.3 version of the Gateway. Check our docs for more details [Golang Plugins]({{< ref "/content/plugins/supported-languages/golang.md" >}}).
+{{< /note >}}

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.0.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.0.md
@@ -1,30 +1,47 @@
 ---
-title: Tyk v5.0
-menu:
-  main:
-    parent: "Release Notes"
-tags: ["release notes", "Tyk Gateway", "Tyk Dashboard", "v5.0", "5.0", "5.0.0", "5.0.1", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6"]
+title: Tyk Dashboard v5.0
+tags: ["release notes", "Tyk Dashboard", "v5.0", "5.0", "5.0.0", "5.0.1", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6"]
 weight: 2
 ---
 
-## v5.0.7
-Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.7) for Tyk Gateway and Tyk Dashboard.
+**Licensed Protected Product**
 
-## v5.0.6
-Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.6) for Tyk Gateway and Tyk Dashboard.
+**This page contains all release notes for version 5.0.X displayed in reverse chronological order**
 
-## v5.0.5
-Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.5) for Tyk Gateway and Tyk Dashboard.
+--- 
 
-## v5.0.4
-Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.4) for Tyk Gateway and Tyk Dashboard.
+## 5.0.7 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.7).
 
-## v5.0.3
-Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.3) for Tyk Gateway and Tyk Dashboard.
+---
 
-## v5.0.2
+## 5.0.6 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.6). 
 
-### Support for MongoDB 5 and 6
+---
+
+## 5.0.5 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.5).
+
+---
+
+## 5.0.4 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.4).
+
+---
+
+## 5.0.3 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.3).
+
+---
+
+## 5.0.2 Release Notes
+
+##### Release Date 29 May 2023
+
+#### Release Highlights
+
+##### Support for MongoDB 5 and 6
 From Tyk 5.0.2, we added support for MongoDB 5.0.x and 6.0.x. To enable this, you have to set new Dashboard config option driver to *mongo-go*. 
 The driver setting defines the driver type to use for MongoDB. It can be one of the following values:
 - [mgo](https://github.com/go-mgo/mgo) (default): Uses the *mgo* driver. This driver supports MongoDB versions <= v4.x (lower or equal to v4.x). You can get more information about this driver in the [mgo](https://github.com/go-mgo/mgo) GH repository. To allow users more time for migration, we will update our default driver to the new driver, *mongo-go*, in next major release.
@@ -34,48 +51,40 @@ See how to [Choose a MongoDB driver]({{< ref "planning-for-production/database-s
 
 **Note: Tyk Pump 1.8.0 and MDCB 2.2 releases have been updated to support the new driver option**
 
+#### Downloads
 
-### Tyk Dashboard
+[docker image to pull](https://hub.docker.com/layers/tykio/tyk-dashboard/v5.0.2/images/sha256-fe3009c14ff9096771d10995a399a494389321707e951a3c46f944afd28d18cd?context=explore)
 
-#### Fixed
+
+#### Changelog {#Changelog-v5.0.2}
+
+##### Fixed
 - Fixed a bug on migration of a portal catalogue with deleted policy to SQL
 - Fixed: Redirect unregistered user to new page when SSOOnlyForRegisteredUsers is set to true
 
-### Tyk Gateway
+---
 
-#### Updated
-- Internal refactoring to make storage related parts more stable and less affected by potential race issues
+## 5.0.1 Release Notes
 
+##### Release Date 25 Apr 2023
 
-## v5.0.1
+#### Release Highlights
+This release primarily focuses on bug fixes. 
+For a comprehensive list of changes, please refer to the detailed [changelog]({{< ref "#Changelog-v5.0.1">}}) below.
 
-### Tyk Gateway
+#### Downloads
+- [docker image to pull](https://hub.docker.com/layers/tykio/tyk-dashboard/v5.0.1/images/sha256-013d971fc826507702f7226fa3f00e1c7e9d390fc0fb268bed42e410b126e89d?context=explore)
 
-#### Added
-- Added a new `enable_distributed_tracing` option to the NewRelic config to enable support for Distributed Tracer
+#### Changelog {#Changelog-v5.0.1}
 
-#### Fixed
-- Fixed  panic when JWK method was used for JWT authentication and the token didn't include kid
-- Fixed an issue where failure to load GoPlugin middleware didn’t prevent the API from proxying traffic to the upstream: now Gateway logs an error when the plugin fails to load (during API creation/update) and responds with HTTP 500 if the API is called; at the moment this is fixed only for file based plugins
-- Fixed MutualTLS issue causing leak of allowed CAs during TLS handshake when there are multiple mTLS APIs
-- Fixed a bug during hot reload of Tyk Gateway where APIs with JSVM plugins stored in filesystem were not reloaded
-- Fixed a bug where the gateway would remove the trailing `/`at the end of a URL
-- Fixed a bug where nested field-mappings in UDG weren't working as intended
-- Fixed a bug when using Tyk OAuth 2.0 flow on Tyk Cloud where a request for an Authorization Code would fail with a 404 error
-- Fixed a bug where mTLS negotiation could fail when there are a large number of certificates and CAs; added an option (`http_server_options.skip_client_ca_announcement`) to use the alternative method for certificate transfer
-- Fixed CVE issue with go.uuid package
-- Fixed a bug where rate limits were not correctly applied when policies are partitioned to separate access rights and rate limits into different scopes
-
-### Tyk Dashboard
-
-#### Added
+##### Added
 - Improved security for people using the Dashboard by adding the Referrer-Policy header with the value `no-referrer`
 - Added ability to select the plugin driver within the Tyk OAS API Designer
 
-#### Changed
+##### Changed
 - When creating a new API in the Tyk OAS API Designer, caching is now disabled by default
 
-#### Fixed
+##### Fixed
 - Fixed a bug where a call to the `/hello` endpoint would unnecessarily log `http: superfluous response.WriteHeader call`
 - Fixed a bug where the Dashboard was showing *Average usage over time* for all Developers, rather than just those relevant to the logged in developer
 - Fixed a bug where logged in users could see Identity Management pages, even if they didn't have the rights to use these features
@@ -92,17 +101,15 @@ See how to [Choose a MongoDB driver]({{< ref "planning-for-production/database-s
 - Fixed a bug in the default OPA rule that prevented users from resetting their own password
 - Fixed a bug where authToken data was incorrectly stored in the JWT section of the authentication config when a new API was created
 
+---
 
+## v5.0.0 Release Notes
 
+##### Release Date 28 Mar 2023
 
+#### Release Highlights
 
-## v5.0.0 Major features
-
-### Improved OpenAPI support
-
-We have added some great features to the Tyk OAS API definition bringing it closer to parity with our Tyk Classic API and to make it easier to get on board with Tyk using your Open API workflows.
-
-Tyk’s OSS users can now make use of extensive [custom middleware](https://tyk.io/docs/plugins/) options with your OAS APIs, to transform API requests and responses, exposing your upstream services in the way that suits your users and internal API governance rules. We’ve enhanced the Request Validation for Tyk OAS APIs to include parameter validation (path, query, headers, cookie) as well as the body validation that was introduced in Tyk 4.1.
+##### Improved OpenAPI support
 
 Tyk Dashboard has been enhanced with **all the custom middleware options** for Tyk OAS APIs, so **for the first time** you can configure your custom middleware from the Dashboard; this covers the full suite of custom middleware from pre- to post- and response plugins. We’ve got support for middleware bundles, Go plugins and Tyk Virtual Endpoints, all within the new and improved Tyk Dashboard UI.
 
@@ -115,10 +122,7 @@ We’ve improved support for [OAS Mock Responses]({{< ref "getting-started/using
 Another new feature in the Tyk OAS API Designer is that you can now update (PATCH) your existing Tyk OAS APIs through the Dashboard API without having to resort to curl. That should make life just that little bit easier.
 Of course, we’ve also addressed some bugs and usability issues as part of our ongoing ambition to make Tyk OAS API the best way for you to create and manage your APIs.
 
-Thanks to our community contributors [armujahid](https://github.com/armujahid), [JordyBottelier](https://github.com/JordyBottelier) and [ls-michal-dabrowski](https://github.com/ls-michal-dabrowski) for your PRs that further improve the quality of Tyk OSS Gateway!
-
-
-### GraphQL and Universal Data Graph improvements
+##### GraphQL and Universal Data Graph improvements
 
 This release is all about making things easier for our users with GraphQL and Universal Data Graph.
 
@@ -134,30 +138,13 @@ With this release we are also giving our users [improved headers for GQL APIs]({
 
 Additionally we’ve added Dashboard support for introspection control on policy and key level. It is now possible to allow or block certain consumers from being able to introspect any graph while creating a policy or key via Dashboard.
 
-## Changelog
+#### Downloads
 
-### Tyk Gateway
+[docker image to pull](https://hub.docker.com/layers/tykio/tyk-dashboard/v5.0/images/sha256-3d736b06b023e23f406b1591f4915b3cb15a417fcb953d380eb8b4d71829f20f?tab=vulnerabilities)
 
-#### Deprecated
-- Tyk Gateway no longer natively supports **LetsEncrypt** integration. You still can use LetsEncrypt CLI tooling to generate certificates, and use them with Tyk.
+#### Changelog {#Changelog-v5.0.0}
 
-#### Added
-- Support for request validation (including query params, headers and the rest of OAS rules) with Tyk OAS APIs
-- Transform request/response middleware for Tyk OAS APIs
-- Custom middleware for Tyk OAS APIs
-- Added a new API endpoint to manage versions for Tyk OAS APIs
-- Improved Mock API plugin for Tyk OAS APIs
-- Universal Data Graph and GraphQL APIs now support using context variables in request headers, allowing passing information it to your subgraphs
-- Now you can control access to introspection on policy and key level
-
-#### Changed
-
-#### Fixed
-- Fixed potential race when using distributed rate limiter
-
-### Tyk Dashboard
-
-#### Added
+##### Added
 - Numerous UX improvements
 - New UI for custom middleware for Tyk OAS APIs
 - Significantly improved Tyk OAS API versioning user experience
@@ -165,22 +152,20 @@ Additionally we’ve added Dashboard support for introspection control on policy
 - Now you can turn a Kafka topic into a GraphQL subscription by simply [importing your AsyncAPI definition]({{< ref "tyk-apis/tyk-dashboard-api/data-graphs-api" >}})
 - Way to control access to introspection on policy and key level
 
-#### Changed
+##### Changed
 - Universal Data Graph moved to a separate dashboard section
 
-## Updated Versions
-Tyk Gateway 5.0 - [docker](https://hub.docker.com/layers/tykio/tyk-gateway/v5.0.0/images/sha256-196815adff2805ccc14c267b14032f23913321b24ea86c052b62a7b1568b6725?context=repo)
+---
 
-Tyk Dashboard 5.0 - [docker](https://hub.docker.com/layers/tykio/tyk-dashboard/v5.0/images/sha256-3d736b06b023e23f406b1591f4915b3cb15a417fcb953d380eb8b4d71829f20f?tab=vulnerabilities)
+## Further Information
 
-## Upgrade process
+### Upgrading Tyk
+Please refer to the [upgrading Tyk]({{< ref "upgrading-tyk" >}}) page for further guidance with respect to the upgrade strategy.
 
-Follow the [standard upgrade guide]({{< ref "upgrading-tyk.md" >}}), there are no breaking changes in this release.
+### API Documentation
 
-In case you want to switch from MongoDB to SQL, you can [use our migration tool]({{< ref "planning-for-production/database-settings/postgresql.md#migrating-from-an-existing-mongodb-instance" >}}), but keep in mind that it does not yet support the migration of your analytics data.
+- [OpenAPI Document]({{<ref "tyk-dashboard-api">}})
+- [Postman Collection](https://www.postman.com/tyk-technologies/workspace/tyk-public-workspace/collection/27225007-374cc3d0-f16d-4620-a435-68c53553ca40)
 
-{{< note success >}}
-**Note**  
-
-Note: Upgrading the Golang version implies that all the Golang custom plugins that you are using need to be recompiled before migrating to v5.0 of the Gateway. Check our docs for more details [Golang Plugins]({{< ref "plugins/supported-languages/golang#upgrading-tyk" >}}).
-{{< /note >}}
+### FAQ
+Please visit our [Developer Support]({{< ref "frequently-asked-questions/faq" >}}) page for further information relating to reporting bugs, upgrading Tyk, technical support and how to contribute.

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.1.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.1.md
@@ -1,28 +1,31 @@
 ---
-title: Tyk v5.1
-menu:
-  main:
-    parent: "Release Notes"
-weight: 1
+title: Tyk Dashboard v5.1
+description: "Release notes 5.1 for Tyk Dashboard"
+tags: ["Release notes", "Dashboard", "5.1"]
+main: menu
 ---
 
-# What’s Changed?
+**Licensed Protected Product**
 
-### Tyk Gateway and Dashboard updated to Golang version 1.19
+### Support Lifetime
+Minor releases are supported until our next minor comes out in Q3.
 
-Our Dashboard and Gateway are using [Golang 1.19](https://tip.golang.org/doc/go1.19) Programming Language starting with the 5.1 release. This brings improvements to the code base and allows us to benefit from the latest features and security enhancements in Go. Don’t forget that, if you’re using GoPlugins, you'll need to [recompile]({{< ref "plugins/supported-languages/golang#initialise-plugin-for-gateway-51" >}}) these to maintain compatibility with the latest Gateway.
+## 5.1 Release Notes
 
-### Request Body Size Limits
+##### Release Date 23 June 2023
 
-We have introduced a new Gateway-level option to limit the size of requests made
-to your APIs. You can use this as a first line of defence against overly large
-requests that might affect your Tyk Gateways or upstream services. Of course,
-being Tyk, we also provide the flexibility to configure API-level and
-per-endpoint size limits so you can be as granular as you need to protect and
-optimise your services. Check out our improved documentation for full
-description of how to use these powerful [features]({{< ref "basic-config-and-security/control-limit-traffic/request-size-limits" >}}).
+#### Breaking Changes
+Our Dashboard is using [Golang 1.19](https://tip.golang.org/doc/go1.19) programming language starting with the 5.1 release. This brings improvements to the code base and allows us to benefit from the latest features and security enhancements in Go. Don’t forget that, if you’re using GoPlugins, you'll need to [recompile]({{< ref "plugins/supported-languages/golang#initialise-plugin-for-gateway-51" >}}) these to maintain compatibility with the latest Gateway.
 
-### Dashboard Analytics for API Ownership
+#### Deprecation
+There are no deprecations in this release.
+
+#### Upgrade instructions
+If you are on a 5.0 we advise you to upgrade ASAP.
+
+#### Release Highlights
+
+##### Dashboard Analytics for API Ownership
 
 When we implemented Role Based Access Control and API Ownership in Tyk
 Dashboard, we unlocked great flexibility for you to assign different roles to
@@ -35,7 +38,7 @@ the way the analytics data are aggregated (to optimise storage), a user granted
 this role will not have access to the full range of charts. Take a look at the
 documentation for a full description of this new [user role]({{< ref "basic-config-and-security/security/dashboard/user-roles" >}}).
 
-### Import API examples from within the Dashboard
+##### Import API examples from within the Dashboard
 
 In 5.0 we introduced the possibility to import API examples manually or via
 [_Tyk Sync_]({{<ref "tyk-sync" >}}). We have now extended this feature and it is now possible to do this without
@@ -49,7 +52,7 @@ example data graph“ on the next screen. The examples UI will present you with 
 list of available examples. You can navigate to the details page for every
 example and import it as well from the same page.
 
-### Improved nested GraphQL stitching
+##### Improved nested GraphQL stitching
 
 Before this release, it was only possible to implement nested GraphQL stitching
 (GraphQL data source inside another data source) by using a REST data source and
@@ -59,48 +62,27 @@ data from parent data sources.
 
 To use this feature you will only need to check the “Add GraphQL operation“ checkbox when creating a GraphQL data source.
 
-### Import UDG API from OAS 3.0.0
+##### Import UDG API from OAS 3.0.0
 
 We added a [Dashboard API Endpoint]({{< ref "universal-data-graph/datasources/rest#automatically-creating-rest-udg-configuration-based-on-oas-specification" >}}) that is capable of taking an OAS 3.0.0 document and converting it into a UDG API.
 
 This will generate the full schema as well as the data sources that are defined inside the OAS document.
 
-### Changed default RPC pool size for MDCB deployments
+##### Changed default RPC pool size for MDCB deployments
 
 We have reduced the default RPC pool size from 20 to 5. This can reduce the CPU and
 memory footprint in high throughput scenarios. Please monitor the CPU and memory
 allocation of your environment and adjust accordingly. You can change the pool
 size using [slave_options.rpc_pool_size]({{< ref "tyk-oss-gateway/configuration#slave_optionsrpc_pool_size" >}})
 
-## Changelog
+#### Downloads
 
-### Tyk Gateway
+[docker image to pull](https://hub.docker.com/layers/tykio/tyk-dashboard/v5.1/images/sha256-8cde3c6408b9a34daa508a570539ca6cd9fcb8ee5c4790abe907eaecddc1bd9b?context=explore)
 
-#### Added
 
-- Added `HasOperation`, `Operation` and `Variables` to GraphQL data source API definition for easier nesting
-- Added abstractions/interfaces for ExecutionEngineV2 and ExecutionEngine2Executor with respect to graphql-go-tools
-- Added support for the `:authority` header when making GRPC requests. If the `:authority` header is not present then some GRPC servers return PROTOCOL_ERROR which prevents custom GRPC plugins from running. Thanks to [vanhtuan0409](https://github.com/vanhtuan0409) from the Tyk Community for his contribution!
+#### Changelog
 
-#### Changed
-
-- Tyk Gateway updated to use Go 1.19
-- Updated [_kin-openapi_](https://github.com/getkin/kin-openapi) dependency to the version [v0.114.0](https://github.com/getkin/kin-openapi/releases/tag/v0.114.0)
-- Enhanced the UDG parser to comprehensively extract all necessary information for UDG configuration when users import to Tyk their OpenAPI document as an API definition
-- Reduced default CPU and memory footprint by changing the default RPC pool size from 20 to 5 connections.
-
-#### Fixed
-
-- Fixed an issue where invalid IP addresses could be added to the IP allow list
-- Fixed an issue when using custom authentication with multiple authentication methods, custom authentication could not be selected to provide the base identity
-- Fixed an issue where OAuth access keys were physically removed from Redis on expiry. Behaviour for OAuth is now the same as for other authorisation methods
-- Fixed an issue where the `global_size_limit` setting didn't enable request size limit middleware. Thanks to [PatrickTaibel](https://github.com/PatrickTaibel) for the contribution!
-- Fixed minor versioning, URL and field mapping issues when importing OpenAPI document as an API definition to UDG
-- When the control API is not protected with mTLS we now do not ask for a cert, even if all the APIs registered have mTLS as an authorization mechanism
-
-### Tyk Dashboard
-
-#### Added
+##### Added
 
 - Added two endpoints to the dashboard to support the retrieval of example API definitions. One for fetching all examples and another for fetching a single example.
 - Added a way to display UDG examples from the [tyk-examples](https://github.com/TykTechnologies/tyk-examples) repository in the Dashboard UI
@@ -112,13 +94,13 @@ size using [slave_options.rpc_pool_size]({{< ref "tyk-oss-gateway/configuration#
 - Added query param `apidef=true` to example detail endpoint in Dashboard API to retrieve the API definition of an example
 - Added new `owned_analytics` user permission which restricts the user's access only to analytics relating to APIs they own. These are the _API Activity Dashboard Requests_ and _Average Errors Over Time_ charts in the Tyk Dashboard. Note that it is not currently possible to respect API Ownership in other aggregated charts
 
-#### Changed
+##### Changed
 
 - Tyk Dashboard updated to Go 1.19
 - Updated npm package dependencies of Dashboard, to address critical and high CVEs
 - Changed the field mapping tickbox description in GUI to be 'Use default field mapping'
 
-#### Fixed
+##### Fixed
 
 - Fixed an issue when using custom authentication with multiple authentication methods. Custom authentication could not be selected to provide the base identity
 - Fixed an issue where the login URL was displayed as undefined when creating a TIB Profile using LDAP as a provider
@@ -142,34 +124,15 @@ size using [slave_options.rpc_pool_size]({{< ref "tyk-oss-gateway/configuration#
 - Fixed UI bug so that data graphs created with multiple words are [sluggified](https://www.w3schools.com/django/ref_filters_slugify.php#:~:text=Definition%20and%20Usage,ASCII%20characters%20and%20hyphens%20(%2D).), i.e. spaces are replaced with a hyphen `-`
 - Fixed an issue with routing, which was sending the user to a blank screen while creating a new Data Graph or importing an example API
 
-### Tyk Classic Portal
+## Further Information
 
-#### Changed
+### Upgrading Tyk
+Please refer to the [upgrading Tyk]({{< ref "upgrading-tyk" >}}) page for further guidance with respect to the upgrade strategy.
 
-- Improved performance when opening the Portal page by optimising the pre-fetching of required data
+### API Documentation
 
-## Updated Versions
+- [OpenAPI Document]({{<ref "tyk-dashboard-api">}})
+- [Postman Collection](https://www.postman.com/tyk-technologies/workspace/tyk-public-workspace/collection/27225007-374cc3d0-f16d-4620-a435-68c53553ca40)
 
-Tyk Gateway 5.1 - [docker image to pull](https://hub.docker.com/layers/tykio/tyk-gateway/v5.1.0/images/sha256-bde71eeb83aeefce2e711b33a1deb620377728a7b8bde364b5891ea6058c0649?context=repo)
-
-Tyk Dashboard 5.1 - [docker image to pull](https://hub.docker.com/layers/tykio/tyk-dashboard/v5.1.0/images/sha256-075df4d840b452bfe2aa9bad8f1c1b7ad4ee06a7f5b09d3669f866985b8e2600?tab=vulnerabilities)
-
-## Contributors
-
-Special thanks to the following members of the Tyk community for their contributions in this release:
-
-Thanks to [PatrickTaibel](https://github.com/PatrickTaibel) for fixing an issue where `global_size_limit` was not enabling request size limit middleware.
-
-Thanks to [vanhtuan0409](https://github.com/vanhtuan0409) for adding support to the `:authority` header when making gRPC requests.
-
-## Upgrade process
-
-Follow the [standard upgrade guide]({{< ref "upgrading-tyk" >}}), there are no breaking changes in this release.
-
-In case you want to switch from MongoDB to SQL, you can [use our migration tool]({{< ref "planning-for-production/database-settings/postgresql.md#migrating-from-an-existing-mongodb-instance" >}}), but keep in mind that it does not yet support the migration of your analytics data.
-
-{{< note success >}}
-**Note**
-
-Please remember that the upgrade to the Golang version implies that all the Golang custom plugins that you are using need to be recompiled before migrating to v5.1 of the Gateway. Check our docs for more details [Golang Plugins]({{< ref "plugins/supported-languages/golang#upgrading-tyk" >}}).
-{{< /note >}}
+### FAQ
+Please visit our [Developer Support]({{< ref "frequently-asked-questions/faq" >}}) page for further information relating to reporting bugs, upgrading Tyk, technical support and how to contribute.

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.4.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.4.md
@@ -1,0 +1,302 @@
+---
+date: 2017-03-24T09:58:52Z
+title: Tyk Gateway v2.4
+menu:
+  main:
+    parent: "Release Notes"
+weight: 15
+aliases:
+  - /release-notes/version-2.4/ 
+---
+
+# New in this release:
+
+This release touch all our products and brings you numerous long awaited features and fixes. 
+Here are the packages and their versions we are releasing today: Tyk Gateway v2.4.0, Tyk Dashboard v1.4.0, Tyk Pump v0.4.2, MDCB v1.4.0, TIB v0.2.
+
+# <a name="major-highlights"></a>Major highlights
+
+## Mutual TLS
+
+A major feature of this release is the implementation of Mutual TLS. Now you can protect your APIs by white-listing certificates, idenitfy users based on them, and increase security between Tyk and upstream API. For details, see [Mutual TLS]({{< ref "basic-config-and-security/security/mutual-tls" >}}).
+
+
+## Extended use of Multiple Policies
+
+We have extended support for partitioned policies, and you can now mix them up when creating a key. Each policy should have own partition, and will not intersect, to avoid conflicts while merging their rules. 
+
+Using this approach could be useful when you have lot of APIs and multiple subscription options. Before, you had to create a separate policy per API and subscription option. 
+
+Using multiple partitioned policies you can create basic building blocks separately for accessing rules, rate limits and policies, and then mix them for the key, to creating unique combination that fit your needs. 
+
+We have added a new `apply_policies` field to the Key definition, which is an string array of Policy IDs. 
+> **NOTE**: The old key apply_policy_id is supported, but is now deprecated.
+
+We have updated the Dashboard **Apply Policies** section of the **Add Key** section.
+
+{{< img src="/img/release-notes/apply_policy.png" alt="apply-policy" >}}
+
+For this release multiple policies are only supported only via the Add Key section and via the API. Support for OIDC, oAuth, and Portal API Catalogues are planned for subsequent releases.
+
+[Docs]({{< ref "basic-config-and-security/security/security-policies/partitioned-policies" >}})
+
+## <a name="global-api"></a>Global API Rate Limits
+
+We have added a new API definition field `global_rate_limit` which specifies a global API rate limit in the following format: `{"rate": 10, "per": 1}`, similar to policies or keys. 
+
+The API rate limit is an aggregate value across all users, which works in parallel with user rate limits, but has higher priority.
+
+Extended Dashboard API designer Rate Limiting and Quotas section in Core settings:
+
+{{< img src="/img/release-notes/rate_limits.png" alt="rate-limits" >}}
+
+[Docs]({{< ref "basic-config-and-security/security/security-policies/partitioned-policies" >}})
+
+## Specify custom analytics tags using HTTP headers
+
+We have added a new API definition field `tag_headers` which specifies a string array of HTTP headers which can be extracted and turned to tags. 
+
+For example if you include `X-Request-ID` header to tag_headers, for each incoming request it will include a `x-request-id-<header_value>` tag to request an analytic record.
+
+This functionality can be useful if you need to pass additional information from the request to the analytics, without enabling detailed logging, which records the full request and response objects.
+
+We have added a new **Tag headers** section to the Dashboard **API Designer Advanced** tab.
+
+{{< img src="/img/release-notes/tag_headers.png" alt="tag_headers" >}}
+
+[Docs]({{< ref "tyk-stack/tyk-manager/analytics/log-browser" >}})
+
+## <a name="sso"></a>Single-Sign-On (SSO) improvements
+
+More SSO functionality is something that a lot of our customers have been asking for. In this release we've significantly improved our support for SSO, and you can now:
+
+* Enable Tyk Identity Broker to apply LDAP filters to user search [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers/ldap" >}})
+* Set permissions for your users, logged via SSO, via `sso_permission_defaults` in Dashboard config file. [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers" >}})
+* Setup a login page redirect, using `sso_custom_login_url` and `sso_custom_portal_login_url` Dashboard config options to enable users login using a custom SSO login page. [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers" >}})
+* For those who love to build everything in-house, we have added new API for custom dashboard authentication integrations. [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers/custom" >}})
+
+# Moar!
+This release is packed with way more more cool stuff. Here are detailed release notes for each product:
+
+## <a name="gateway"></a>Tyk Gateway v2.4.0
+
+### Mutual TLS support
+[Docs]({{< ref "basic-config-and-security/security/mutual-tls" >}})
+
+### Global API rate limits
+[Docs]({{< ref "basic-config-and-security/control-limit-traffic/rate-limiting" >}})
+
+### Specify custom analytics tags using HTTP headers
+[Docs]({{< ref "tyk-stack/tyk-manager/analytics/log-browser" >}})
+
+### Attaching Multiple Policies to the Keys
+[Docs]({{< ref "basic-config-and-security/security/security-policies/partitioned-policies" >}})
+
+### Default User Agent set to Tyk/$VERSION
+If no user agent is specified in a request, it is now set as `Tyk/$VERSION`.
+
+### Include `x-tyk-api-expires` date header for versioned APIs
+If a request is made for an API which has an expiry date, the response will include the `x-tyk-api-expires` header with expiry date. 
+
+[Docs]({{< ref "getting-started/key-concepts/versioning" >}})
+
+### Run Admin Control API on a separate port
+Using `control_api_port` option in configuration file, you can run the admin control api on a separate port, and hide it behind firewall if needed.
+
+[Docs]({{< ref "tyk-oss-gateway/configuration#control_api_port" >}})
+
+### Added a Configuration Linter
+
+We have added a new `tyk lint ` command which will validate your `tyk.conf` file and validate it for syntax correctness, misspelled attribute names or format of values. The Syntax can be:
+
+`tyk lint` or `tyk --conf=path lint`
+
+If `--conf` is not used, the first of the following paths to exist is used:
+
+`./tyk.conf`
+`/etc/tyk/tyk.conf`
+
+[Docs]({{< ref "tyk-oss-gateway/configuration" >}})
+
+### Set log_level from tyk.conf
+
+We have added a new `log_level` configuration variable to `tyk.conf` to control logging level.
+
+Possible values are: `debug`, `info`, `warn`, `error`
+
+[Docs]({{< ref "tyk-oss-gateway/configuration#a-name-log-level-a-log-level" >}})
+
+### Added jsonMarshal to body transform templates
+
+We have added the `jsonMarshal` helper to the body transform templates. You can apply jsonMarshal on a string in order to perform JSON style character escaping, and on complex objects to serialise them to a JSON string.
+
+Example: `{{ .myField | jsonMarshal }}`
+
+[Docs]({{< ref "transform-traffic/request-body" >}})
+
+### Added a blocking reload endpoint
+
+Now you can add a `?block=true` argument to the `/tyk/reload` API endpoint, which will block a response, until the reload is performed. This can be useful in scripting environments like CI/CD workflows.
+
+[Docs]({{< ref "tyk-gateway-api" >}})
+
+### `tyk_js_path` file now contains only user code
+
+Internal JS API not budled into tyk binary, and `js/tyk.js` file used only for custom user code. It is recommended to delete this file, if you are not using it, or remove Tyk internal code from it. New releases do not ship this file by default.
+
+### Improved Swagger API import defaults
+
+When importing Swagger based APIs they now generate tracked URLs instead of white listed ones.
+
+[More](https://github.com/TykTechnologies/tyk/issues/643)
+
+### Respond with 503 if all hosts are down.
+Previously, the internal load balancer was cycling though hosts even if they were known as down.
+
+### Request with OPTIONS method should not be cached.
+[More](https://github.com/TykTechnologies/tyk/issues/376)
+
+### Health check API is officially deprecated.
+This was very resource consuming and unstable feature. We recommend using load balancers of your choice for this.
+
+### Fixed custom error templates for authentication errors.
+[More](https://github.com/TykTechnologies/tyk/issues/438)
+
+
+## <a name="dashboard"></a>Tyk Dashboard v1.4.0
+
+### Mutual TLS support
+[Docs]({{< ref "basic-config-and-security/security/mutual-tls" >}})
+
+### Global API rate limits
+[Docs]({{< ref "basic-config-and-security/control-limit-traffic/rate-limiting" >}})
+
+### Specify custom analytics tags using HTTP headers
+[Docs]({{< ref "tyk-stack/tyk-manager/analytics/log-browser" >}})
+
+### Attaching Multiple Policies to the Keys
+[Docs]({{< ref "basic-config-and-security/security/security-policies/partitioned-policies" >}})
+
+### Set permissions for users logged via SSO (Tyk Identity Broker)
+Added new option `sso_permission_defaults` in Dashboard config file. 
+Example:
+
+```
+"sso_permission_defaults": {
+  "analytics": "read",
+  "apis": "write",
+  "hooks": "write",
+  "idm": "write",
+  "keys": "write",
+  "policy": "write",
+  "portal": "write",
+  "system": "write",
+  "users": "write"
+},
+```
+[Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers" >}})
+
+### Set custom login pages for portal and dashboard
+If you are using 3-rd party authentification like TIB, you maybe want to redirect from standard login pages to your own using following attributes in dashboard config: `sso_custom_login_url`, `sso_custom_portal_login_url`.
+
+[Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers" >}})
+
+### Added new set of APIs for custom dashboard authentification
+Added new `/admin/sso` endpoint for custom integration. In fact, the same API is used by our own Tyk Identity Broker. 
+
+[Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers/custom" >}})
+
+
+### Service discovery form improved with most common pre-defined templates
+
+Now you can pre-fill the form with most popular templates like consul or etcd.
+
+### RPC credentials renamed to Organization ID
+Yay!
+
+### Replaced text areas with a code editors
+
+All multi-line text fields now replaced with a code editors.
+
+### Replace dropdowns with the live search component
+
+All the dropdown lists now support live search, and work with a large number of elements (especially handy for API or Policiy lists).
+
+### Display user ID and email on when listing users
+
+The **Users list** now displays the **User ID** and **Email**.
+
+### Added search for portal developers
+
+We have added search for the users listed in the developer portal.
+
+### Key request email link to developer details
+
+The email address in a **Key Request** from the **Developer Portal** is now a link to the relevant developer profile.
+
+### Country code in log browser links to geo report
+
+The country code in the log browser has been changed to a link to the geographic report.
+
+### Added support for HEAD methods in the Dashboard API Designer.
+
+### Redirect user to the login page if session is timed out.
+
+### When creating a portal API catalogue, you can now attach documentation without saving the catalogue first.
+
+### Fixed the` proxy.preserve_host_header` field when saved via the UI.
+Previously, the field was available in the API definition, but got removed if the API was saved via the UI.
+
+### Fixed the port removal in service discovery properties.
+https://github.com/TykTechnologies/tyk-analytics-ui/issues/12
+
+### Prevent an admin user revoking their own permissions.
+This is a  UI only fix, it is still allowable via the API (which is OK).
+
+### Other UX Improvements
+
+* Key pieces of data made accessible to quickly copy+paste
+* Improved help tips
+* Get your API URL without having to save and go back
+* Improved pagination
+* Improved feedback messaging
+* Improved charts
+* Improved analytics search
+
+## <a name="pump"></a> Tyk Pump v0.4.2
+
+### Support added for Mongo SSL connections
+
+See https://tyk.io/docs/configure/tyk-pump-configuration/ for a sample pump.conf file.
+
+## <a name="mdcb"></a> MDCB v1.4.0
+Added support for Mutual TLS, mentioned by Gateway and Dashboard above. See [Docs]({{< ref "basic-config-and-security/security/mutual-tls#a-name-mdcb-a-mdcb" >}})
+  
+Also fixed bug when Mongo connections became growing though the roof if client with wrong credentials tries to connect.
+
+
+## <a name="tib"></a>TIB v0.2
+  
+Tyk Identity Broker now fully support LDAP search with complex filters! [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers/ldap" >}})
+
+## <a name="upgrade"></a>Upgrading all new Components
+
+> **NOTE**: This release is fully compatible with the previous version, except that if you want to use new features, like Mutual TLS, you need to upgrade all the related components.
+
+Cloud users will be automatically upgraded to the new release.
+
+Hybrid users should follow the upgrade instructions [here]({{< ref "upgrading-tyk#tyk-multi-cloud-gateway" >}}).
+
+Self-Managed users can download the new release packages from their usual repositories.
+
+
+
+
+
+[3]: /img/release-notes/tag_headers.png
+[4]: /img/release-notes/import_api_definition.png
+[5]: /img/release-notes/live_search.png
+[6]: /img/release-notes/user_list.png
+[7]: /img/release-notes/dev_list.png
+[8]: /img/release-notes/key_request_user.png
+

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.5.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.5.md
@@ -5,6 +5,8 @@ menu:
   main:
     parent: "Release Notes"
 weight: 14
+aliases:
+  - /release-notes/version-2.5/ 
 ---
 
 # <a name="new"></a>New in this Release:

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.6.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.6.md
@@ -1,0 +1,406 @@
+---
+title: Tyk Gateway v2.6
+menu:
+  main:
+    parent: "Release Notes"
+weight: 13
+aliases:
+    - /release-notes/version-2.6/
+---
+
+# <a name="new"></a>New in this Release:
+
+## <a name="gateway"></a>Tyk Gateway v2.6.0
+
+### Organisation Level Rate Limiting
+
+Endpoints Create organisation keys and 
+Add/update organisation keys now allow you to set rate limits at an organisation level. You will need to add the following fields in your create/add/update key request:
+
+* `"allowance"`
+* `"rate"`
+
+These are the number of allowed requests for the specified `per` value, and need to be set to the same value.
+
+* `"per"` is the time period, in seconds.
+
+So, if you want to restrict an organisation rate limit to 100 requests per second you will need to add the following to your request:
+```
+  "allowance": 100,
+  "rate": 100,
+  "per": 5
+```
+
+> **NOTE:** if you don't want to have organisation level rate limiting, set `"rate"` or `"per"` to zero, or don't add them to your request.
+
+See the Keys section of the [Tyk Gateway REST API]({{< ref "tyk-gateway-api" >}}) Swagger doc for more details.
+
+### Keys hashing improvements
+
+Now it is possible to do more operations with key by hash (when we set `"hash_keys":` to `true` in `tyk.conf`):
+
+- endpoints `POST /keys/create`, `POST /keys` and `POST /keys/{keyName}` also return field `"key_hash"` for future use
+- endpoint `GET /keys` get all (or per API) key hashes. You can disable this endpoint by using the new `tyk.conf` setting `enable_hashed_keys_listing` (set to false by default)
+- endpoint `GET /keys/{keyName}` was modified to be able to get a key by hash. You just need provide the key hash as a `keyName` 
+and call it with the new optional query parameter `hashed=true`. So the new format is `GET /keys/{keyName}?hashed=true"`
+- also, we already have the same optional parameter for endpoint `DELETE /keys/{keyName}?hashed=true`
+
+### JSON schema validation
+
+You can now use Tyk to verify user requests against a specified JSON schema and check that the data sent to your API by a consumer is in the right format. This means you can offload data validation from your application to us.
+
+If it's not in the right format, then the request will be rejected. And even better, the response will be a meaningful error rather than just a 'computer says no'.
+
+Schema validation is implemented as for the rest of our plugins, and its configuration should be added to `extended_paths` in the following format:
+```
+"validate_json": [{
+  "method": "POST",
+  "path": "me",
+  "schema": {..schema..}, // JSON object
+  "error_response_code": 422 // 422 default however can override.
+}]
+```
+
+The schema must be a draft v4 JSON Schema spec, see http://json-schema.org/specification-links.html#draft-4 for details. An example schema can look like this:
+```
+{
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string"
+    },
+    "lastName": {
+      "type": "string"
+    },
+    "age": {
+      "description": "Age in years",
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": ["firstName", "lastName"]
+}
+```
+
+
+### New endpoint to get list of tokens generated for provided OAuth-client
+
+`GET /oauth/clients/{apiID}/{oauthClientId}/tokens`
+
+This endpoint allows you to retrieve a list of all current tokens and their expiry date issued for a provided API ID and OAuth-client ID in the following format. New endpoint will work only for newly created tokens:
+```
+[
+  {
+    "code": "5a7d110be6355b0c071cc339327563cb45174ae387f52f87a80d2496",
+    "expires": 1518158407
+  },
+  {
+    "code": "5a7d110be6355b0c071cc33988884222b0cf436eba7979c6c51d6dbd",
+    "expires": 1518158594
+  },
+  {
+    "code": "5a7d110be6355b0c071cc33990bac8b5261041c5a7d585bff291fec4",
+    "expires": 1518158638
+  },
+  {
+    "code": "5a7d110be6355b0c071cc339a66afe75521f49388065a106ef45af54",
+    "expires": 1518159792
+  }
+]
+```
+
+You can control how long you want to store expired tokens in this list using `oauth_token_expired_retain_period ` which specifies the retain period for expired tokens stored in Redis. The value is in seconds, and the default value is `0`. Using the default value means expired tokens are never removed from Redis.
+
+### Creating OAuth clients with access to multiple APIs
+
+When creating a client using `POST /oauth/clients/create`, the `api_id` is now optional - these changes make the endpoint more generic. If you provide the `api_id` it works the same as in previous releases. If you don't provide the `api_id` the request uses policy access rights and enumerates APIs from their setting in the newly created OAuth-client. 
+
+At the moment this changes not reflected on Dashboard UI yet, as we going to do major OAuth improvements in 2.7
+
+### Certificate public key pinning
+
+Certificate pinning is a feature which allows you to allow public keys used to generate certificates, so you will be protected in case an upstream certificate is compromised.
+
+Using Tyk you can allow one or multiple public keys per domain. Wildcard domains are also supported.
+
+Public keys are stored inside the Tyk certificate storage, so you can use Certificate API to manage them.
+
+You can define them globally, from the Tyk Gateway configuration file using the `security.pinned_public_keys` option, or via an API definition `pinned_public_keys` field, using the following format:
+```
+{
+  "example.com": "<key-id>",
+  "foo.com": "/path/to/pub.pem",
+  "*.wild.com": "<key-id>,<key-id-2>"
+}
+```
+
+For `key-id` you should set the ID returned after you upload the public key using the Certificate API. Additionally, you can just set path to public key, located on your server. You can specify multiple public keys by separating their IDs by a comma.
+
+Note that only public keys in PEM format are supported.
+
+If public keys are not provided by your upstream, you can extract them
+by yourself using the following command:
+> openssl s_client -connect the.host.name:443 | openssl x509 -pubkey -noout
+
+If you already have a certificate, and just need to get its public key, you can do it using the following command:
+> openssl x509 -pubkey -noout -in cert.pem
+
+**Note:** Upstream certificates now also have wildcard domain support
+
+### JQ transformations (experimental support)
+
+> This feature is experimental and can be used only if you compile Tyk yourself own using `jq` tag: `go build --tags 'jq'`
+
+If you work with JSON you are probably aware of the popular `jq` command line JSON processor. For more details, see here https://stedolan.github.io/jq/
+
+Now you can use the full power of its queries and transformations to transform requests, responses, headers and even context variables.
+
+We have added two new plugins: 
+
+* `transform_jq` - for request transforms.
+* `transform_jq_response` - for response transforms
+ 
+Both have the same structure, similar to the rest of our plugins: 
+`{ "path": "<path>", "method": "<method>", "filter": "<content>" }`
+
+### Request Transforms
+Inside a request transform you can use following variables: 
+* `.body` - your current request body
+* `._tyk_context` - Tyk context variables. You can use it to access request headers as well.
+
+Your JQ request transform should return an object in the following format: 
+`{ "body": <transformed-body>, "rewrite_headers": <set-or-add-headers>, "tyk_context": <set-or-add-context-vars> }`. 
+
+`body` is required, while `rewrite_headers` and `tyk_context` are optional.
+
+
+### Response Transforms 
+Inside a response transform you can use following variables: 
+* `.body` - your current response body
+* `._tyk_context` - Tyk context variables. You can use it to access request headers as well.
+* `._tyk_response_headers` - Access to response headers
+
+Your JQ response transform should return an object in the following format: 
+`{ "body": <transformed-body>, "rewrite_headers": <set-or-add-headers>}`. 
+
+`body` is required, while `rewrite_headers` is optional.
+
+### Example
+```
+"extended_paths": {
+  "transform_jq": [{
+    "path": "/post",
+    "method": "POST",
+    "filter": "{\"body\": (.body + {\"TRANSFORMED-REQUEST-BY-JQ\": true, path: ._tyk_context.path, user_agent: ._tyk_context.headers_User_Agent}), \"rewrite_headers\": {\"X-added-rewrite-headers\": \"test\"}, \"tyk_context\": {\"m2m_origin\": \"CSE3219/C9886\", \"deviceid\": .body.DEVICEID}}"
+   }],
+  "transform_jq_response": [{
+    "path": "/post",
+    "method": "POST",
+    "filter": "{\"body\": (.body + {\"TRANSFORMED-RESPONSE-BY-JQ\": true, \"HEADERS-OF-RESPONSE\": ._tyk_response_headers}), \"rewrite_headers\": {\"JQ-Response-header\": .body.origin}}"
+  }]
+}
+```
+
+
+## <a name="dashboard"></a>Tyk Dashboard v1.6.0
+
+### API categories
+
+You can apply multiple categories to an API definition, and then filter by these categories on the API list page.
+
+They might refer to the APIs general focus: 'weather', 'share prices'; geographic location 'APAC', 'EMEA'; or technical markers 'Dev', 'Test'. It's completely up to you.
+
+From an API perspective, categories are stored inside API definition `name` field like this: "Api name #category1 #category2", e.g. categories just appended to the end of the name. 
+
+Added new API `/api/apis/categories` to return list of all categories and belonging APIs.
+
+### Raw API Definition mode
+
+Now you can directly edit a raw API definition JSON object directly from the API Designer, by selecting either the **Raw API Definition** or the **API Designer** at the top of the API Designer screen. 
+
+{{< img src="/img/dashboard/system-management/raw_or_designer_mode.png" alt="Raw or Designer" >}}
+
+This feature comes especially handy if you need copy paste parts of one API to another, or if you need to access fields not yet exposed to the Dashboard UI.
+
+### Certificate public key pinning
+
+You can configure certificate pinning on the **Advanced** tab of the API Designer, using a similar method to how you specify upstream client certificates.
+
+{{< img src="/img/release-notes/certificate_pinning.png" alt="Certificate Pinning" >}}
+
+### JSON schema validation
+
+Reflecting the Tyk Gateway changes, on the Dashboard we have added a new **Validate JSON** plugin, which you can specify per URL, and can set both a schema, and custom error code, if needed.
+
+### Improved key hashing support
+
+The Tyk Dashboard API reflects changes made in the v2.6.0 Gateway API, and now supports more operations with key by hash (when we have set `"hash_keys":` to ` true` in `tyk_analytics.conf`):
+
+- endpoint `POST /keys/` also returns a new field `key_hash` per each key in the list
+- endpoint `GET /apis/{apiId}/keys/{keyId}` supports query string parameter `hashed=true` to get the key info via hash
+- endpoint `GET /apis/{apiId}/keys` returns keys hashes
+- endpoint `DELETE /apis/{apiId}/keys?hashed=true` can delete a key by its hash, but its functionality is disabled by default, unless you set `enable_delete_key_by_hash` boolean option inside the Dashboard configuration file. 
+
+
+### Key requests management API now supports OAuth
+
+For this release we've improved our developer portal APIs to fully support an OAuth2.0 based workflow. Developers using your API will now be able to register OAuth clients and manage them.
+
+This change is not yet supported by our built-in portal, but if you are using custom developer portals, you can start using this new functionality right away. Full UI support for built-in portal will be shipped with our next 2.7 release.
+
+Developers can request access to an API protected with OAuth and get OAuth client credentials.
+
+The endpoint `POST /api/portal/requests` now has an optional `"oauth_info"` field which identifies the OAuth key request.
+
+Example of the OAuth key request:  
+```
+{
+  "by_user": "5a3b2e7798b28f03a4b7b3f0",
+  "date_created": "2018-01-15T04:49:20.992-04:00",
+  "for_plan": "5a52dfce1c3b4802c10053c8",
+  "version": "v2",
+  "oauth_info": {
+    "redirect_uri": "http://new1.com,http://new2.com"
+  }
+}
+```
+
+Where:
+
+- `"by_user"` - contains the ID of portal developer who is requesting OAuth access
+- `"for_plan"` - subscription ID
+- `"version"` - is expected to have the value `"v2"`
+- `"oauth_info"` - simple structure which contains a field with comma-separated list of redirect URI for OAuth flow
+
+A new field `"oauth_info"` will be present in replies for endpoints `GET /api/portal/requests/{id}` and `GET /api/portal/requests`
+
+When this kind of OAuth key request gets approved when using endpoint `PUT /api/portal/requests/approve/{id}` 
+a new OAuth-client is generated for a developer specified in the specified `"by_user"` field.
+
+Example of OAuth key request approval reply:
+```
+{
+    "client_id": "203defa5162b42708c6bcafcfa28c9fb",
+    "secret": "YjUxZDJjNmYtMzgwMy00YzllLWI2YzctYTUxODQ4ODYwNWQw",
+    "policy_id": "5a52dfce1c3b4802c10053c8",
+    "redirect_uri": "http://new1.com,http://new2.com"
+}
+```
+
+Where:
+
+- `"client_id"` and `"secret"` are OAuth-client credentials used to request the get token (they are to be kept in secret)
+- `"policy_id"` - the subscription this OAuth-client provides access to
+- `"redirect_uri"` - with comma-separated list of redirect URI for OAuth flow
+
+Also, if you set email notifications in your portal, an email with the  OAuth-client credentials will be sent to the developer 
+who made that OAuth key request.
+
+There is also a change in the reply from the `GET /api/portal/developers` endpoint.The developer object will have new field - 
+`"oauth_clients"` which will contain a mapping of subscription IDs to the list of OAuth clients that the developer requested and
+was approved, i.e.:
+```
+"oauth_clients": {
+  "5a52dfce1c3b4802c10053c8": [
+    {
+      "client_id": "203defa5162b42708c6bcafcfa28c9fb",
+      "redirect_uri": "http://new1.com,http://new2.com",
+      "secret": "YjUxZDJjNmYtMzgwMy00YzllLWI2YzctYTUxODQ4ODYwNWQw"
+    }
+  ]
+},
+```
+
+### New endpoints to get tokens per OAuth client
+
+These endpoints allow you to get a list of all current tokens issued for provided OAuth client ID:
+
+- `GET /apis/oauth/{apiId}/{oauthClientId}/tokens`
+- `GET /apis/oauth/{oauthClientId}/tokens` when the API ID is unknown or OAuth-client provides access to several APIs
+
+
+### Renamed the response `_id` field to `id` in List Key Requests
+
+We have renamed the response `_id` field when retrieving a list of key requests to `id`.
+
+See [List Key Requests]({{< ref "tyk-apis/tyk-dashboard-api/manage-key-requests#list-key-requests" >}}) for more details.
+
+
+### Developers can request a password reset email
+
+If a developer forgets their password, they can now request a password reset email from the Developer Portal Login screen.
+
+{{< img src="/img/dashboard/portal-management/password_request.png" alt="Request email reset" >}}
+
+See [Developer Profiles]({{< ref "tyk-developer-portal/tyk-portal-classic/developer-profiles#reset-developer-password" >}}) for more details.
+
+### SSO API custom email support
+
+Now you can set email address for users logging though the Dashboard SSO API, by adding an "Email" field to the JSON payload which you sent to `/admin/sso` endpoint. For example:
+```
+POST /admin/sso HTTP/1.1
+Host: localhost:3000
+admin-auth: 12345
+    
+{
+  "ForSection": "dashboard",
+  "Email": "user@example.com",
+  "OrgID": "588b4f0bb275ff0001cc7471"
+}
+```
+
+### Set Catalogue settings for each individual API 
+
+Now you can override the global catalogue settings and specify settings per catalogue. 
+The Catalogue object now has `config` field, with exactly same structure as Portal Config, except new `override` boolean field. 
+If set, Catalogue settings will override global ones. 
+
+At the moment the following options can be overriden: `Key request fields`, `Require key approval` and `Redirect on key request` (with `Redirect to` option as well).
+
+### {{<fn>}}Blocklist{{</fn>}} IP Support
+
+Tyk allows you to block IP Addresses, which is located in the **Advanced Options** tab in the **Endpoint Designer**.
+
+{{< img src="/img/release-notes/blacklist_option.png" alt="Blocklist Support" >}}
+
+## <a name="tib"></a>Tyk Identity Broker v0.4.0
+
+With this release TIB joins the Tyk product line as a first class citizen and is now distributed via packages and [Docker image](https://hub.docker.com/r/tykio/tyk-identity-broker/).
+
+### Support for SSO API email field
+If IDP provides a user email, it should be passed to the Dashboard SSO API, and you should see it in the Dashboard UI.
+
+### Improved support for local IDPs
+If you run a local IDP, like Ping, with an untrusted SSL certificate, you can now turn off SSL verification by setting `SSLInsecureSkipVerify` to `true` in the TIB configuration file. 
+
+### Added Redis TLS support
+To enable set `BackEnd.UseSSL` and, optionally, `BackEnd.SSLInsecureSkipVerify`.
+
+## <a name="tib"></a>Tyk Pump v0.5.2
+
+### Redis TLS support
+Added new `redis_use_ssl` and `redis_ssl_insecure_skip_verify` options.
+
+
+## <a name="redis"></a> Redis TLS support
+
+Many Redis hosting providers now support TLS and we're pleased to confirm that we do too.
+
+Whether it's the open source API Gateway, or Dashboard, Pump, Sink and Tyk Identity Broker (TIB): you can now make secure connections to Redis from all Tyk products, as long as your provider allows it.
+
+## <a name="mdcb"></a>MDCB v1.5.3
+
+### Redis TLS support
+Added new `redis_use_ssl` and `redis_ssl_insecure_skip_verify` options.
+
+## <a name="upgrade"></a>Upgrading all new Components
+
+For details on upgrading all Tyk versions, see [Upgrading Tyk](https://tyk.io/docs/upgrading-tyk/).
+
+## <a name="new"></a>Don't Have Tyk Yet?
+
+Get started now, for free, or contact us with any questions.
+
+* [Get Started](https://tyk.io/pricing/compare-api-management-platforms/#get-started)
+* [Contact Us](https://tyk.io/about/contact/)

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.7.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.7.md
@@ -4,6 +4,8 @@ menu:
   main:
     parent: "Release Notes"
 weight: 12
+aliases:
+  - /release-notes/version-2.7/ 
 ---
 
 # <a name="new"></a>New in this Release:

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.8.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.8.md
@@ -1,0 +1,298 @@
+---
+title: Tyk Gateway v2.8
+menu:
+  main:
+    parent: "Release Notes"
+weight: 11
+aliases:
+  - /release-notes/version-2.8/ 
+---
+
+## Looping
+
+You now can configure complex request pipelines, allowing you to specify different actions for the same path, depending 
+on defined conditions.
+
+Visit the [looping section]({{< ref "advanced-configuration/transform-traffic/looping" >}}) for more information.
+
+---
+
+## Debugger
+
+You can now safely test all API changes without publishing them, and visually see the whole request flow, including which plugins are running and even their individual logs.
+
+We have added a new `Debugging` tab in the API designer which provides a "Postman" like HTTP client interface to simulate queries for the current API definition being edited.
+
+You can even debug your virtual endpoints by dynamically modifying the code, sending the request via `Debugger` and watching the virtual endpoint plugin logs.
+
+See [Debugging Tab]({{< ref "advanced-configuration/transform-traffic/endpoint-designer#debugging" >}}) for more information.
+
+---
+
+## Separate rate limits and quotas per API within the same Policy
+
+If you set the `Limits and Quotas per API` flag while configuring a policy, you will be able to configure separate rate limits and quotas per API.  
+
+Note that you can’t mix this functionality with 
+[partitioned policies]({{< ref "basic-config-and-security/security/security-policies/partitioned-policies" >}}).
+
+---
+
+## Developer portal oAuth support
+
+The Developer portal now fully supports exposing oAuth2 APIs:
+
+*  Developers can register their oAuth clients and see analytics
+*  Administrators can see list of oAuth clients from a developer screen
+
+---
+
+## Multi-organisation users
+
+NOTE: Currently only available with >2 node Dashboard licence.
+
+You can now create users with the same email address in different organisations. Users will then be able to select an organisation 
+when logging in, and can easily switch between organisations via the navigation menu. To enable set 
+`"enable_multi_org_users": true`.
+
+---
+
+## Request throttling
+
+When hitting quota or rate limits, the Gateway now can now automatically queue and auto-retry client requests. Throttling can be configured at a key or policy level via two new fields: `throttle_interval` and `throttle_retry_limit`. 
+
+1. `throttle_interval`: Interval(seconds) between each request retry.
+2. `throttle_retry_limit`: Total request retry number.
+
+---
+
+## Password policy improvements
+
+* `security.user_password_max_days` Set the maximum lifetime of a password in days for a user. 
+  They will be prompted to reset their password if the lifetime exceeds the configured expiry value. 
+  e.g. If the value is set to `30` any user password used over 30 days is considered invalid and must be reset.
+* `security.enforce_password_history` Set a maximum number of previous passwords used by a user that cannot be reused. 
+  e.g. If set to `5` the user cannot reuse any of their 5 most recently used passwords.
+* `security.force_first_login_pw_reset` A newly created user will be forced to reset their password on their first login. By default this is set to `false`.
+
+---
+
+## Developer management improvements
+* You can now manually create developer subscriptions from the developer screen.
+* We've added a quick way to change a subscription policy and reset a quota
+* All actions on the developer screen now only require developer permissions 
+
+---
+
+## Key hashing improvements
+
+You can now update keys by only having its hash. This is controlled via the `enable_update_key_by_hash` dashboard configuration variable.
+
+
+## Ability to publish keyless APIs to the developer portal
+
+You can now add open (keyless) APIs to the developer portal. You have the same functionality as for closed APIs, except for key generation, which is disabled.
+
+---
+
+## Dynamic Portal Customisation
+
+Portal templates now have access to the Developer object, its subscriptions, and issued key metadata, providing the ability to conditionally show or hide content inside the Portal based on the attributes below:
+
+The Current logged in Developer can be accessed using the `.Profile` variable with the following fields:
+
+* `Id` - Internal developer ID
+* `Email` - Developer email
+* `OrgID` - Tyk Organisation ID
+* `Subscriptions`  - A map containing subscriptions where the key is a policy ID and the value is an API key
+* `Fields` - A map containing custom developer fields
+* `OauthClients` - A map containing list of registered oAuth clients, where the key is the policy ID.
+
+The Current logged in Developer detailed subscription object can be accessed using the `.APIS` variable, containing a map, where the key is a policy ID and the values are in the following format: 
+
+* `APIDescription` - API definition
+    * `ID` - Internal API id
+    * `Name` - API name
+    * More fields: https://github.com/TykTechnologies/tyk/blob/master/apidef/api_definitions.go#L320
+* `APIKey` - API key
+* `PolicyData` - Policy object
+    * `ID` - Internal Policy ID
+    * `Name` - Policy Name
+    * More fields: https://github.com/TykTechnologies/tyk/blob/master/user/policy.go#L5
+* `KeyMetaData` - Key metadata of the specified map type
+
+### Example
+
+You have different teams of developers, and for each team we want to show them a different list of APIs. 
+In this case, for each developer, we need to set a custom `Team` field, and add it to a template like this:
+
+```
+{{if eq .Profile.Fields.Team `internal`}}
+    … Display internal set of APIs …
+{{end}}
+{{if eq .Profile.Fields.Team `public`}}
+    … Display public set of APIs …
+{{end}}
+```
+
+Similar functionality based on Key metadata can look like this:
+
+```
+{{range $pol, $subscription := .Data.APIS}}}}
+   {{if eq $subscription.APIDescription.Name `test` }}
+     {{if eq $subscription.KeyMetaData.Vip `1`}}
+     …Show extended documentation for users having subscription with `vip` meta tag in token…
+     {{end}}
+   {{end}}
+{{end}}
+```
+
+---
+
+## Custom analytics storage engines for Multi-Cloud & Enterprise MDCB users
+
+Multi-Cloud & Enterprise MDCB installations can now leverage the power of the Tyk Pump and send analytics to custom sources like ElasticSearch or InfluxDB from within their local Data Centers. 
+
+This allows you disable sending the Tyk Gateway analytics to the Multi-Cloud / Master layer from the Gateway itself, allowing the Tyk Pump process to take care of it.
+
+In order to do that, you need to: 
+
+* Install Tyk Pump, with a `hybrid` pump section with the following configuration:
+
+```
+"hybrid": {
+  "name": "hybrid",
+  "meta": {
+    "rpc_key": `<org-id>`,
+    "api_key": `<api-key>`,
+    "connection_string": `hybrid.cloud.tyk.io:9091`,
+    "use_ssl": true,
+    "ssl_insecure_skip_verify": false,
+    "group_id": "",
+    "call_timeout": 30,
+    "ping_timeout": 60,
+    "rpc_pool_size": 30
+  }
+}
+```
+
+* Enable Tyk Pump in the Tyk Gateway configuration, by changing `analytics_config.type` from `rpc` to an empty value.
+
+Now you can add additional pumps to the Tyk Pump config.
+
+---
+
+## Dashboard Audit Log improvements
+
+There is a new section in the Tyk Dashboard config file where you can specify parameters for the audit log (containing audit records for all requests made to all endpoints under the `/api` route).
+
+```
+  ...
+  "audit": {
+    "enabled": true,
+    "format": "json",
+    "path": "/tmp/audit.log",
+    "detailed_recording": false
+  },
+  ...
+```
+
+- `enabled` - enables audit logging, set to `false` by default. NOTE: setting `security.audit_log_path` has the same effect as setting `enabled` to `true`
+- `format` - specifies the format of audit log file. Possible values are `json` and `text` (`text` is default value)
+- `path` - specifies path to the audit log and overwrites `security.audit_log_path` if it was set
+- `detailed_recording` - enables detailed records in the audit log. Set to `false` by default. If set to `true` then audit log records will contain the http-request (without body) and full http-response including the body`
+
+Audit records the following fields for `json` format:
+
+ *   `req_id` - unique request ID
+ *   `org_id` - organisation ID
+ *   `date` - date in `RFC1123` format
+ *   `timestamp` - unix timestamp
+ *   `ip` - IP address the request originated from
+ *   `user` - Dashboard user who performed the request
+ *   `action` - description of the action performed (`i.e. `Update User`)
+ *   `method` - HTTP-method of the request
+ *   `url` - URL of the request
+ *   `status` - HTTP response status of the request
+ *   `diff` - provides a diff of changed fields (available only for PUT requests)
+ *   `request_dump` - HTTP request copy (available if `detailed_recording` is set to `true`)
+ *   `response_dump` - HTTP response copy (available if `detailed_recording` is set to `true`)
+ 
+ If you specify `text` format - all fields are in plain text separated with a new line and provided in the same order as for `json` format.
+
+---
+
+## Plugin bundler CLI tools now built-in to Tyk binary
+
+Previously you had to use a separate `tyk-cli` binary to build bundles. 
+The build command remains the same, but instead of using `tyk-cli bundle` you now use `tyk bundle`.
+
+---
+
+## Basic Auth - Extract Credentials from Body
+
+It is now possible to extract BasicAuth credentials from the request body. This is particularly useful in SOAP requests.
+
+```text
+<soapenv:Envelope
+  ...
+  <soapenv:Header>
+    <aut:AuthenticationHeader>
+      <aut:User>prova1234</aut:User>
+      <aut:Pass>prova1234</aut:Pass>
+    </aut:AuthenticationHeader>
+  ...
+```
+
+You can modify your API definition to let Tyk know how to get the credentials:
+
+```
+...
+"basic_auth": {
+  "extract_from_body": true,
+  "body_user_regexp": "<aut:User>(.*)</aut:User>",
+  "body_password_regexp": "<aut:Pass>(.*)</aut:Pass>"
+},
+...
+```
+
+---
+
+## Insecure Skip Verify on a per API basis
+
+Previously, it was possible to get Tyk Gateway to skip TLS verification globally (for ALL apis), but it was not possible to enable this on a per API basis. This meant that it was not previously possible to use self-signed certificates for some APIs, and actual certs for others.
+  
+It is now possible to control which APIs use skip secure verification as follows within the API Definition object:
+
+`api_definition.proxy.transport.ssl_insecure_skip_verify: bool` - Defaults to `false`.
+
+Tyk's JSVM `TykMakeHttpRequest` function will also respect the above configuration value.
+
+---
+
+## Detailed changelog
+
+### Tyk Gateway 2.8.0
+- URL rewrite advanced rules extended with looping support, allowing you to build complex request pipelines.
+- Added an Admin Debugger API 
+- SSL verification now can be disabled at the API level in addition to the global level, using the new `proxy.transport.ssl_insecure_skip_verify` boolean variable.
+- You can rename the default `/hello` healthcheck endpoint using the new gateway `health_check_endpoint_name` string variable. 
+- Basic auth plugin now can extract credentials from the request body
+- Bundler CLI tools now built in to the Tyk binary
+- Allow updating keys by hash
+
+### Tyk Dashboard 1.8.0
+
+- Added API Debugger tab to the API Designer.
+- Extended the Portal templating functionality.
+- Similar to the Gateway, you now can specify a list of acceptable TLS ciphers using the  
+  `http_server_options.cipher_suites` array option.
+- Audit log improvements
+- Exposing oAuth2 APIs to developer portal
+- Allow for the retrieval of an API via it's external API
+- Allow updating keys by hash
+- Added support for `SMTP` noauth.
+
+### Tyk Pump 0.6
+
+- Added `hybrid` pump configuration, allowing Multi-Cloud users to use custom storage engines for analytics.

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.9.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.9.md
@@ -4,6 +4,8 @@ menu:
   main:
     parent: "Release Notes"
 weight: 10
+aliases:
+  - /release-notes/version-2.9/ 
 ---
 
 ### TCP Proxying

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/overview.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/overview.md
@@ -1,6 +1,54 @@
 ---
 title: Tyk Gateway Release Notes
-description: "Explains where to access older supported bundled release notes for Tyk Dashboard and Tyk Gateway"
-tags: ["Release notes"]
+description: "Links to Tyk major minor releases for Tyk Gateway"
+tags: ["Tyk Gateway Release notes", "Tyk Gateway Releases"]
 ---
-Older release notes of Tyk Gateway were bundled together with Tyk Dashboard. The release notes for these older supported releases are available in the [Developer Support]({{< ref "/developer-support/tyk-release-summary/overview" >}}) section of the website.
+
+This page provides access to release notes for Tyk Gateway. Links to archived releases are also included.
+
+## Release 5
+
+- [v5.2]({{< ref "product-stack/tyk-gateway/release-notes/version-5.2.md" >}})
+- [v5.1]({{< ref "product-stack/tyk-gateway/release-notes/version-5.1.md" >}})
+- [v5.0]({{< ref "product-stack/tyk-gateway/release-notes/version-5.0.md" >}})
+
+Historic release notes can be previewed by expanding the links in the sections below.
+
+## Release 4
+<details>
+    <summary>
+        Click to expand
+    </summary>
+
+- [v4.3]({{< ref "product-stack/tyk-gateway/release-notes/version-4.3.md" >}})
+- [v4.2]({{< ref "product-stack/tyk-gateway/release-notes/version-4.2.md" >}})
+- [v4.1]({{< ref "product-stack/tyk-gateway/release-notes/version-4.1.md" >}})
+- [v4.0]({{< ref "product-stack/tyk-gateway/release-notes/version-4.0.md" >}})
+</details>
+
+## Release 3
+<details>
+    <summary>
+        Click to expand
+    </summary>
+
+- [v3.2]({{< ref "product-stack/tyk-gateway/release-notes/version-3.2.md" >}})
+- [v3.1]({{< ref "product-stack/tyk-gateway/release-notes/version-3.1.md" >}})
+- [v3.0]({{< ref "product-stack/tyk-gateway/release-notes/version-3.0.md" >}})
+</details>
+
+## Archived Releases
+
+### Release 2
+<details>
+    <summary>
+        Click to expand
+    </summary>
+
+- [v2.9]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.9.md" >}})
+- [v2.8]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.8.md" >}})
+- [v2.7]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.7.md"  >}})
+- [v2.6]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.6.md" >}})
+- [v2.5]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.5.md" >}})
+- [v2.4]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.4.md" >}})
+</details>

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.0.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.0.md
@@ -1,0 +1,101 @@
+---
+title: Tyk Gateway v3.0
+description: "Tyk Gateway 3.0 release notes"
+tags: ["release notes", "Tyk Gateway", "v3.0", "3.0"]
+aliases:
+    - /release-notes/version-3.0/
+---
+
+### Version changes and LTS releases
+
+We have bumped our major Tyk Gateway version from 2 to 3, a long overdue change as we’ve been on version 2 for 3 years. We have also changed our Tyk Dashboard major version from 1 to 3, and from now on it will always be aligned with the Tyk Gateway for major and minor releases. The Tyk Pump has also now updated to 1.0, so we can better indicate major changes in future. 
+
+Importantly, such a big change in versions does not mean that we going to break backward compatibility. More-over we are restructuring our internal release strategy to guarantee more stability and to allow us to deliver all Tyk products at a faster pace. We aim to bring more clarity to our users on the stability criteria they can expect, based on the version number.
+Additionally we are introducing Long Term Releases (also known as LTS).
+
+Read more about this changes in our blogpost: https://tyk.io/introducing-long-term-support-some-changes-to-our-release-process-product-versioning/
+
+
+### Universal Data Graph and GraphQL
+
+Tyk now supports GraphQL **natively**. This means Tyk doesn’t have to use any external services or process for any GraphQL middleware. You can securely expose existing GraphQL APIs using our GraphQL core functionality.
+
+In addition to this you can also use Tyk’s integrated GraphQL engine to build a Universal Data Graph. The Universal Data Graph (UDG) lets you expose existing services as one single combined GraphQL API.
+
+All this without even have to build your own GraphQL server. If you have existing REST APIs all you have to do is configure the UDG and Tyk has done the work for you.
+
+With the Universal Data Graph Tyk becomes your central integration point for all your internal as well as external APIs. In addition to this, the UDG benefits from all existing solutions that already come with your Tyk installation. That is, your Data Graph will be secure from the start and there’s a large array of out of the box middlewares you can build on to power your Graph.
+
+Read more about the [GraphQL]({{< ref "graphql" >}}) and [Universal Data Graph]({{< ref "universal-data-graph" >}})
+
+
+
+
+
+
+
+
+### Using external secret management services
+
+Want to reference secrets from a KV store in your API definitions? We now have native Vault & Consul integration. You can even pull from a tyk.conf dictionary or environment variable file.
+
+[Read more]({{< ref "tyk-configuration-reference/kv-store" >}})
+
+
+### Co-Process Response Plugins
+
+We added a new middleware hook allowing middleware to modify the response from the upstream. Using response middleware you can transform, inspect or obfuscate parts of the response body or response headers, or fire an event or webhook based on information received by the upstream service.
+
+At the moment the Response hook is supported for [Python and gRPC plugins]({{< ref "plugins/supported-languages/rich-plugins/rich-plugins-work#overriding-response" >}}).
+
+
+### Enhanced Gateway health check API
+
+Now the standard Health Check API response include information about health of the dashboard, redis and mdcb connections.
+You can configure notifications or load balancer rules, based on new data. For example, you can be notified if your Tyk Gateway can’t connect to the Dashboard (or even if it was working correctly with the last known configuration).
+
+[Read More]({{< ref "planning-for-production/ensure-high-availability/health-check" >}})
+
+### Enhanced Detailed logging
+Detailed logging is used in a lot of the cases for debugging issues. Now as well as enabling detailed logging globally (which can cause a huge overhead with lots of traffic), you can enable it for a single key, or specific APIs. 
+
+New detailed logging changes are available only to our Self-Managed customers currently.
+
+[Read More]({{< ref "tyk-stack/tyk-pump/useful-debug-modes#enabling-detailed-logging" >}})
+
+### Better Redis failover
+
+Now, if Redis is not available, Tyk will be more gracefully handle this scenario, and instead of simply timing out the Redis connection, will dynamically disable functionality which depends on redis, like rate limits or quotas, and will re-enable it back once Redis is available. The Tyk Gateway can even be started without Redis, which makes possible scenarios, such as when the Gateway proxies Redis though itself, like in a Redis Sentinel setup.
+
+### Ability to shard analytics to different data-sinks
+
+In a multi-org deployment, each organisation, team, or environment might have their preferred analytics tooling. At present, when sending analytics to the Tyk Pump, we do not discriminate analytics by org - meaning that we have to send all analytics to the same database - e.g. MongoDB. Now the Tyk Pump can be configured to send analytics for different organisations to different places. E.g. Org A can send their analytics to MongoDB + DataDog. But Org B can send their analytics to DataDog + expose the Prometheus metrics endpoint.
+
+It also becomes possible to put a {{<fn>}}blocklist{{</fn>}} in-place, meaning that some data sinks can receive information for all orgs, whereas others will not receive OrgA’s analytics if blocked.
+
+This change requires updating to new Tyk Pump 1.0
+
+[Read More]({{< ref "tyk-pump/configuration" >}})
+
+### 404 Error logging - unmatched paths
+
+Concerned that client’s are getting a 404 response? Could it be that the API definition or URL rewrites have been misconfigured? Telling Tyk to track 404 logs, will cause the Tyk Gateway to produce error logs showing that a particular resource has not been found. 
+
+The feature can be enabled by setting the config `track_404_logs` to `true` in the gateway's config file.
+
+
+### Fixes
+
+- Fixed the bug when tokens created with non empty quota, and quota expiration set to `Never`, were treated as having unlimited quota. Now such tokens will stop working, once initial quota is reached. 
+
+
+
+### Updated Versions
+
+- Tyk Gateway 3.0
+- Tyk Pump 1.0
+
+### Upgrading From Version 2.9
+
+No specific actions required.
+If you are upgrading from version 2.8, pls [read this guide]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.9.md" >}})

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.1.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.1.md
@@ -1,0 +1,72 @@
+---
+title: Tyk Gateway v3.1
+description: "Tyk Gateway 3.1 release notes"
+tags: ["release notes", "Tyk Gateway", "v3.1", "3.1"]
+aliases:
+    - /release-notes/version-3.1/
+---
+
+## What’s new?
+
+### Identity Management UX and SAML support
+You will notice that the experience for creating a new profile in the Identity management section of the dashboard was changed to a ‘wizard’ approach which reduces the time it takes to get started and configure a profile. 
+In addition, users are now able to use SAML for the dashboard and portal login, whether you use TIB(Tyk Identity Broker) internally or externally of the dashboard.
+
+This follows the recent changes that we have made to embed TIB (Tyk Identity Broker)in the dashboard. See 3.0 [release notes](https://tyk.io/docs/release-notes/version-3.0/) for more information regarding this. 
+
+To learn more [see the documentation](https://tyk.io/docs/getting-started/tyk-components/identity-broker/)
+
+## UDG (Universal Data Graph) & GraphQL
+### Schema Validation
+
+For any GraphQL API that is created via Dashboard or through our API, the GraphQL schema is now validated before saving the definition. Instant feedback is returned in case of error.
+
+### Sync / Update schema with upstream API (Proxy Only Mode)
+
+If you’ve configured just a proxy GraphQL API, you can now keep in sync the upstream schema with the one from the API definition, just by clicking on the `Get latest version` button on the `Schema` tab from API Designer
+
+Docs [here](https://tyk.io/docs/graphql/syncing-schema/)
+
+### Debug logs
+
+You can now see what responses are being returned by the data sources used while configuring a UDG (universal data graph). These can be seen by calling the `/api/debug` API or using the playground tab within API designer.
+
+The data that will be displayed will show information on the query before and after the request to a data source happens, as follows:
+
+Before the request is sent:
+
+Example log message: "Query.countries: preSendHttpHook executed”. Along with this message, the log entry will contain the following set of fields: Typename, Fieldname and Upstream url;
+
+
+After the request is sent:
+
+Example log message: "Query.countries: postReceiveHttpHook executed”. Along with this message, the log entry will contain the following set of fields: Typename, Filename, response body, status code.
+
+Example: 
+
+```{"typename": "Query", "fielname": "countries", "response_body": "{\"data\":{}}", "status_code": 200}```
+
+Docs [here](https://tyk.io/docs/graphql/graphql-playground/)
+
+## Portal
+### GraphQL Documentation
+
+Documentation for the GraphQL APIs that you are exposing to the portal is available now through a GraphQL Playground UI component, same as on the playground tab of API Designer.
+
+Also to overcome the CORS issues that you might encounter while testing documentation pages on the portal, we have pre-filled the CORS settings section in API Designer with explicit values from the start. All you need to do is to check the “Enable CORS” option.
+
+### Portal - API key is hidden in email
+You now have the option to hide the API key in the email generated after you approve the key request for a developer.
+
+[Docs here](https://tyk.io/docs/tyk-developer-portal/key-requests/)
+
+
+## Bug Fixes
+The 3.1 version includes the fixes that are part of 3.0.1. 
+https://github.com/TykTechnologies/tyk/releases/tag/v3.0.1
+
+
+## Updated Versions
+
+- Tyk Gateway 3.1
+

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.2.md
@@ -1,21 +1,12 @@
 ---
-title: Tyk v3.2
-menu:
-  main:
-    parent: "Release Notes"
-weight: 7
+title: Tyk Gateway v3.2
+description: "Tyk Gateway 3.2 release notes"
+tags: ["release notes", "Tyk Gateway", "v3.2", "3.2"]
+aliases:
+    - /release-notes/version-3.2/
 ---
 
 # What’s new?
-
-## Bring your own Identity Provider - Dynamic Client Registration now available!
-
-DCR is a protocol of the Internet Engineering Task Force put in place to set standards in the dynamic registration of clients with authorisation servers. This feature is a way for you to integrate your Tyk Developer Portal with an external identity provider such as Keycloak, Gluu, Auth0 or Okta. 
-The portal developer won't notice a difference. However when they create the app via Tyk Developer portal, Tyk will dynamically register that client on your authorisation server. This means that it is the Authorisation Server that will issue the Client ID and Client Secret for the app.
-
-Check our DCR docs [here]({{< ref "/tyk-developer-portal/tyk-portal-classic/dynamic-client-registration" >}})
-
-We also took this opportunity to give a refresh to the portal settings UI so let us know if you like it! 
 
 ## GraphQL and UDG improvements
 
@@ -31,13 +22,6 @@ Query-depth limits can now be configured on a per-field level.
 
 If you’re using GraphQL upstream services with UDG, you’re now able to forward upstream error objects through UDG so that they can be exposed to the client.
 
-
-## Extendable Tyk Dashboard permissions system
-
-The Tyk Dashboard permission system can now be extended by writing custom rules using an Open Policy Agent (OPA). The rule engine works on top of the Tyk Dashboard API, which means you can control not only access rules, but also the behaviour of all Dashboard APIs (except your public developer portal). You can find more details about OPA [here]({{< ref "/content/tyk-dashboard/open-policy-agent.md" >}}).
-
-In addition, you can now create your own custom permissions using the Additional Permissions API or by updating `security.additional_permissions` map in the Tyk Dashboard config, and writing Opa rule containing logic for the new permission.
-
 ## Go response plugins
 
 With Go response plugins you are now able to modify and create a full request round trip made through the Tyk Gateway. 
@@ -50,7 +34,6 @@ https://github.com/TykTechnologies/tyk/releases/tag/v3.0.5
 
 # Updated Versions
 Tyk Gateway 3.2
-Tyk Dashboard 3.2
 
 # Upgrade process
 If you already have GraphQL or UDG APIs you need to follow this upgrade guide https://tyk.io/docs/graphql/migration-guide/

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.0.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.0.md
@@ -1,0 +1,41 @@
+---
+title: Tyk Gateway v4.0
+description: "Tyk Gateway 4.0 release notes"
+tags: ["release notes", "Tyk Gateway", "v4.0", "4.0"]
+aliases:
+    - /release-notes/version-4.0/
+---
+
+## GraphQL federation
+
+As we know, ease-of-use is an important factor when adopting GraphQL. Modern enterprises have dozens of backend services and need a way to provide a unified interface for querying them. Building a single, monolithic GraphQL server is not the best option. It is hard to maintain and leads to a lot of dependencies and over-complication.
+
+To remedy this, Tyk 4.0 offers GraphQL federation that allows the division of GraphQL implementation across multiple backend services, while still exposing them all as a single graph for the consumers. Subgraphs represent backend services and define a distinct GraphQL schema. A subgraph can be queried directly, as a separate service or federated in the Tyk Gateway into a larger schema of a supergraph – a composition of several subgraphs that allows execution of a query across multiple services in the backend.
+
+[Federation docs]({{< ref "/content/getting-started/key-concepts/graphql-federation.md" >}})
+
+[Subgraphs and Supergraphs docs]({{< ref "/content/getting-started/key-concepts/graphql-federation.md#subgraphs-and-supergraphs" >}})
+
+## GraphQL subscriptions
+
+Subscriptions are a way to push data from the server to the clients that choose to listen to real-time messages from the server, using the WebSocket protocol. There is no need to enable subscriptions separately; Tyk supports them alongside GraphQL as standard.
+
+With release 4.0, users can federate GraphQL APIs that support subscriptions. Federating subscriptions means that events pushed to consumers can be enriched with information from other federated graphs.
+
+[Subscriptions docs]({{< ref "/content/getting-started/key-concepts/graphql-subscriptions.md" >}})
+
+## Other minor changes
+- Now it is possible to configure GraphQL upstream authentification, in order for Tyk to work with its schema
+- JWT scopes now support array and comma delimeters
+- Go plugins can be attached on per-endpoint level, similar to virtual endpoints
+
+# Updated Versions
+Tyk Gateway 4.0
+Tyk Pump 1.5
+
+# Upgrade process
+
+Follow the [standard upgrade guide]({{< ref "/content/upgrading-tyk.md" >}}), there are no breaking changes in this release.
+
+If you want switch from MongoDB to SQL, you can [use our migration tool]({{< ref "/content/planning-for-production/database-settings/postgresql.md#migrating-from-an-existing-mongodb-instance" >}}), but keep in mind that it does not yet support the migration of your analytics data.
+ 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.1.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.1.md
@@ -1,9 +1,9 @@
 ---
-title: Tyk v4.1
-menu:
-  main:
-    parent: "Release Notes"
-weight: 5
+title: Tyk Gateway v4.1
+description: "Tyk Gateway 4.1 release notes"
+tags: ["release notes", "Tyk Gateway", "v4.1", "4.1"]
+aliases:
+    - /release-notes/version-4.1/
 ---
 
 # Major features
@@ -63,27 +63,8 @@ So, if you upgrade from Tyk v4.1.0 to v4.2.0 you only need to have the plugins c
 - Fixed an issue where schema merging in GraphQL federation could fail depending on the order or resolving subgraph schemas and only first instance of a type and its extension would be valid. Subgraphs are now individually normalised before a merge is attempted and all extensions that are possible in the federated schema are applied.
 - Fixed an issue with accessing child properties of an object query variable for GraphQL where query {{.arguments.arg.foo}} would return "{ "foo":"123456" }" instead of "123456"
 
-## Tyk Dashboard
-### Added
-- Added support for new OAS api definition format, and new API creation screens
-- Dashboard boostrap instalation script extended to support SQL databases
-- Added `TYK_DB_OMITCONFIGFILE` option for Tyk Dashboard to ignore the values in the config file and load its configuration only from environment variables and default values
-- Added a new config option `identity_broker.ssl_insecure_skip_verify` that will allow customers using the embedded TIB to use IDPs exposed with a self signed certificate. Not intended to be used in production, only for testing and POC purposes.
-- Added option to configure certificates for Tyk Dashboard using [environment variables](https://tyk.io/docs/tyk-dashboard/configuration/#http_server_optionscertificates).
-### Changed
-- Detailed information about certificates can be viewed from certificates listing page
-- Dashboard APIs GQL Playground now shows additional information about certificates
-- Dashboard will now use default version of GraphiQL Playground which can switch between light and dark modes for more accessibility
-- Banner for resyncing GraphQL schema has been given a new, more accessible look in line with the rest of Dashboard design
-### Fixed
-- Fixed an issue with key lookup where keys were not being found when using the search field
-- Fixed an issue with object types dropdown in Universal Data Graph config, where it wasn’t working correctly when object type UNION was chosen
-- Fixed an issue in Universal Data Graph which prevented users from injecting an argument value or parameter value in the domain part of the defined data source upstream URL
-
-
 # Updated Versions
 Tyk Gateway 4.1
-Tyk Dashboard 4.1
 Tyk MDCB 2.0.1
 
 # Upgrade process

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.2.md
@@ -1,0 +1,136 @@
+---
+title: Tyk Gateway v4.2
+description: "Tyk Gateway 4.2 release notes"
+tags: ["release notes", "Tyk Gateway", "v4.2", "4.2"]
+aliases:
+    - /release-notes/version-4.2/
+---
+
+# Major features
+
+## GraphQL Federation improvements
+
+### Changed GUI in Universal Data Graph configuration section.
+
+A new GUI introduces enhancements to the user experience and more consistent user journey for UDG. 
+This change does not yet cover all possible use cases and is released with a feature flag. To enable the new GUI, analytics.conf needs the following setting:
+
+```
+"ui": {
+  "dev": true
+}
+```
+
+What’s possible with this change:
+- Importing GraphQL schema created outside of Tyk (formats accepted .json, .graphql, .grahqls)
+- Creating GraphQL schema in Tyk using schema editor
+- Hide/Unhide schema editor to focus on graphical representation of the schema
+- Resizing schema editor to adjust workspace look & feel to user preferences
+- Improved search in schema editor (search and search & replace available)
+- Quick link to UDG documentation from schema editor
+
+> Note: Full configuration of new Universal Data Graph is not yet possible in the GUI, however any UDGs created earlier will not be broken and will work as previously. 
+
+## Changes to federation entities
+### Defining the base entity
+Entities must be defined with the `@key` directive. The fields argument must reference a field by which the entity can be uniquely identified. Multiple primary keys are possible. For example:
+
+Subgraph 1 (base entity):
+```
+type MyEntity @key(fields: "id") @key(fields: "name") {
+  id: ID!
+  name: String!
+}
+```
+ Attempting to extend a non-entity with an extension that includes the @key directive or attempting to extend a base entity with an extension that does not include the @key directive will both result in errors.
+
+### Entity stubs
+
+Entities cannot be shared types (be defined in more than one single subgraph).
+If one subgraph references a base entity (an entity defined in another subgraph), that reference must be declared as a stub (stubs look like an extension without any new fields in federation v1). This stub would contain the minimal amount of information to identify the entity (referencing exactly one of the primary keys on the base entity regardless of whether there are multiple primary keys on the base entity). For example, a stub for MyEntity from Subgraph 1 (defined above):
+
+Subgraph 2 (stub)
+```
+extend type MyEntity @key(fields: "id") {
+  id: ID! @external
+}
+```
+
+### Supergraph extension orphans
+It is now possible to define an extension for a type in a subgraph that does not define the base type.
+However, if an extension is unresolved (an extension orphan) after an attempted federation, the federation will fail and produce an error.
+
+### Improved Dashboard UI and error messages
+GraphQL-related (for example when federating subgraphs into a supergraph) errors in the Dashboard UI will show a lean error message with no irrelevant prefixes or suffixes.
+
+Changed the look & feel of request logs in Playground tab for GraphQL APIs. New component presents all logs in a clearer way and is easier to read for the user
+
+### Shared types
+Types of the same name can be defined in more than one subgraph (a shared type). This will no longer produce an error if each definition is identical.
+Shared types cannot be extended outside of the current subgraph, and the resolved extension must be identical to the resolved extension of the shared type in all other subgraphs (see subgraph normalisation notes). Attempting to extend a shared type will result in an error.
+The federated supergraph will include a single definition of a shared type, regardless of how many times it has been identically defined in its subgraphs.
+
+### Subgraph normalisation before federation
+Extensions of types whose base type is defined in the same subgraph will be resolved before an attempt at federation. A valid example involving a shared type:
+
+Subgraph 1:
+```
+enum Example {
+  A,
+  B
+}
+
+extend enum Example {
+  C  
+}
+```
+
+Subgraph 2:
+```
+enum Example {
+  A,
+  B,
+  C
+}
+```
+ 
+The enum named “Example” defined in Subgraph 1 would resolve to be identical to the same-named enum defined in Subgraph 2 before federation takes place. The resulting supergraph would include a single definition of this enum.
+
+### Validation
+Union members must be both unique and defined.
+Types must have bodies, e.g., enums must contain at least one value; inputs, interfaces, or objects must contain at least one field
+
+## OpenAPI 
+Added support for the Request Body Transform middleware, for new Tyk OAS API Definitions.
+
+## Universal Data Graph
+
+Added support for Kafka as a data source in Universal Data Graph. Configuration allows the user to provide multiple topics and broker addresses.
+
+# Changelog
+
+## Tyk Gateway
+### Added
+- Added support for Kafka as a data source in Universal Data Graph.
+- Adding a way to defining the base GraphQL entity via @key directive
+- It is now possible to define an extension for a type in a subgraph that does not define the base type.
+- Added support for the Request Body Transform middleware, for the new Tyk OAS API Definition
+- Session lifetime now can be controled by Key expiration, e.g. key removed when it is expired. Enabled by setting `session_lifetime_respects_key_expiration` to `true`
+### Changed
+- Generate API ID when API ID is not provided while creating API. 
+- Updated the Go plugin loader to load the most appropriate plugin bundle, honouring the Tyk version, architecture and OS
+- When GraphQL query with a @skip directive is sent to the upstream it will no longer return “null” for the skipped field, but remove the field completely from the response
+- Added validation to Union members - must be both unique and defined.
+### Fixed
+- Fixed an issue where the Gateway would not create the circuit breaker events (BreakerTripped and BreakerReset) for which the Tyk Dashboard offers webhooks.
+- Types of the same name can be defined in more than one subgraph (a shared type). This will no longer produce an error if each definition is exactly identical.
+- Apply Federation Subgraph normalisation do avoid merge errors. Extensions of types whose base type is defined in the same subgraph will be resolved before an attempt at federation.
+
+# Updated Versions
+Tyk Gateway 4.2
+
+# Upgrade process
+
+Follow the [standard upgrade guide]({{< ref "/content/upgrading-tyk.md" >}}), there are no breaking changes in this release.
+
+If you want switch from MongoDB to SQL, you can [use our migration tool]({{< ref "/content/planning-for-production/database-settings/postgresql.md#migrating-from-an-existing-mongodb-instance" >}}), but keep in mind that it does not yet support the migration of your analytics data.

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.3.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.3.md
@@ -1,32 +1,12 @@
 ---
-title: Tyk v4.3
-menu:
-  main:
-    parent: "Release Notes"
-weight: 3
+title: Tyk Gateway v4.3
+description: "Tyk Gateway 4.3 release notes"
+tags: ["release notes", "Tyk Gateway", "v4.3"]
+aliases:
+    - /release-notes/version-4.3/
 ---
 
 ## Major features
-
-### Tyk OAS APIs - Versioning via the Dashboard
-
-Tyk v4.3 adds API versioning to the Dashboard UI, including:
-
-- Performing CRUD operations over API versions
-- Navigate seamlessly between versions
-- A dedicated manage versions screen
-- easily identify the default version and the base API.
-
-### Importing OAS v3 via the Dashboard
-
-Importing OpenAPI v3 documents in order to generate Tyk OAS API definition is now fully supported in our Dashboard UI. Our UI automatically detects the version of your OpenAPI Document, and will suggest options that you can pass or allow Tyk to read from the provided document, in order to configure the Tyk OAS API Definition. Such as: 
-
-- custom upstream URL
-- custom listen path
-- authentication mechanism
-- validation request rules and limit access only to the defined paths.
-
-[Importing OAS v3 via the Dashboard]({{< ref "/content/getting-started/using-oas-definitions/import-an-oas-api.md#tutorial-using-the-tyk-dashboard" >}})
 
 ### Mock Responses with Tyk OAS API Definitions
 
@@ -38,9 +18,9 @@ If you’re using a 3rd party IDP to generate tokens for your OAuth applications
 
 This can be achieved by configuring the new External OAuth authentication mechanism. Find out more here [External OAuth Integration]({{< ref "/content/basic-config-and-security/security/authentication-authorization/ext-oauth-middleware.md" >}})
 
-### Updated the Tyk Gateway and Dashboard version of Golang, to 1.16.
+### Updated the Tyk Gateway version of Golang, to 1.16.
 
-**Our Dashboard and Gateway is using Golang 1.16 version starting with 4.3 release. This version of the Golang release deprecates x509 commonName certificates usage. This will be the last release where it's still possible to use commonName, users need to explicitly re-enable it with an environment variable.**
+**Our Gateway is using Golang 1.16 version starting with 4.3 release. This version of the Golang release deprecates x509 commonName certificates usage. This will be the last release where it's still possible to use commonName, users need to explicitly re-enable it with an environment variable.**
 
 The deprecated, legacy behavior of treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is now disabled by default. It can be temporarily re-enabled by adding the value x509ignoreCN=0 to the GODEBUG environment variable.
 
@@ -68,7 +48,7 @@ Note that if the CommonName is an invalid host name, it's always ignored, regard
 
 #### Changed
 
-Updated the Tyk Gateway and Dashboard version of Golang, to 1.16. 
+Updated the Tyk Gateway version of Golang, to 1.16. 
 
 **SECURITY: The release deprecates x509 commonName certificates usage. This will be the last release where it's still possible to use commonName, users need to explicitly re-enable it with an environment variable.**
 
@@ -84,31 +64,10 @@ Note that if the CommonName is an invalid host name, it's always ignored, regard
 - A HTTP OAS API version lifetime respects now the date value of the expiration field from Tyk OAS API Definition.
 - Now it is possible to proxy traffic from a HTTP API (using Tyk Classic API Definition) to a HTTP OAS API (using Tyk OAS API Definition) and vice versa.
 
-### Tyk Dashboard
-
-#### Added
-
-- Added an option for using multiple header/value pairs when configuring GraphQL API with a protected upstream and persisting those headers for future use.
-- Added documentation on how edge endpoints Dashboard configuration can be used by users to add tags for their API Gateways.
-- When retrieving the Tyk OAS API Definition of a versioned API, the base API ID is passed on the GET request as a header: `x-tyk-base-api-id`.
-- If Edge Endpoints Dashboard configuration is present, when users add segment/tags to the Tyk OAS API Definition, their corresponding URLs are populated in the servers section of the OAS document.
-- Listen path field is now hidden from the API Designer UI, when the screen presents a versioned or internal API.
-
-#### Changed
-
-- Extended existing `x-tyk-gateway` OAS documentation and improved the markdown generator to produce a better-formatted documentation for `x-tyk-gateway` schema.
-- Complete change of Universal Data Graph configuration UI. New UI is now fully functional and allows configuration of all existing datasources (REST, GraphQL and Kafka).
-- Changed look & feel of request logs for GraphQL Playground. It is now possible to filter the logs and display only the information the user is interested in.
-
-#### Fixed
-
-- Fixed: OAS API definition showing management gateway URL even if segment tags are present in cloud. From now on OAS servers section would be filled with edge endpoint URLs if configured.
-- Adding a path that contains a path parameter, doesn’t throw an error anymore on the Dashboard UI, and creates default path parameter description in the OAS.
 
 ## Updated Versions
 
 Tyk Gateway 4.3 ([docker images](https://hub.docker.com/r/tykio/tyk-gateway/tags?page=1&name=4.3.0)
-Tyk Dashboard 4.3 ([docker images](https://hub.docker.com/r/tykio/tyk-dashboard/tags?page=1&name=4.3.0))
 
 ## Upgrade process
 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.0.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.0.md
@@ -1,0 +1,142 @@
+---
+title: Tyk Gateway 5.0 Release Notes
+description: Tyk Gateway v5.0 release notes
+tags: ["release notes", "Tyk Gateway", "v5.0", "5.0", "5.0.0", "5.0.1", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6"]
+aliases:
+    - /release-notes/version-5.0/
+---
+
+**Open Source** ([Mozilla Public License](https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md))
+
+**This page contains all release notes for version 5.0.X displayed in reverse chronological order**
+
+---
+
+## 5.0.6 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.6).
+
+---
+
+## 5.0.5 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.5).
+
+---
+
+## 5.0.4 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.4).
+
+---
+
+## 5.0.3 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.3).
+
+---
+
+## 5.0.2 Release Notes
+
+##### Release Date 29 May 2023
+
+#### Release Highlights
+
+This release primarily focuses on bug fixes. 
+For a comprehensive list of changes, please refer to the detailed [changelog]({{< ref "#Changelog-v5.0.2">}}) below.
+
+#### Downloads
+
+- [docker image to pull](https://hub.docker.com/layers/tykio/tyk-gateway/v5.0.2/images/sha256-5e126d64571989f9e4b746544cf7a4a53add036a68fe0df4502f1e62f29627a7?context=explore) 
+- [source code](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.2)
+
+#### Changelog {#Changelog-v5.0.2}
+
+##### Updated
+- Internal refactoring to make storage related parts more stable and less affected by potential race issues
+
+---
+
+## 5.0.1 Release Notes
+
+##### Release Date 25 Apr 2023
+
+#### Release Highlights
+This release primarily focuses on bug fixes. 
+For a comprehensive list of changes, please refer to the detailed [changelog]({{< ref "#Changelog-v5.0.1">}}) below.
+
+#### Downloads
+- [docker image to pull](https://hub.docker.com/layers/tykio/tyk-gateway/v5.0.1/images/sha256-5fa7aa910d62a7ed2c1cfbc68c69a988b4b0e9420d7a52018f80f9a45cadb083?context=explore
+- [source code](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.1)
+
+#### Changelog {#Changelog-v5.0.1}
+
+##### Added
+- Added a new `enable_distributed_tracing` option to the NewRelic config to enable support for Distributed Tracer
+
+##### Fixed
+- Fixed  panic when JWK method was used for JWT authentication and the token didn't include kid
+- Fixed an issue where failure to load GoPlugin middleware didn’t prevent the API from proxying traffic to the upstream: now Gateway logs an error when the plugin fails to load (during API creation/update) and responds with HTTP 500 if the API is called; at the moment this is fixed only for file based plugins
+- Fixed MutualTLS issue causing leak of allowed CAs during TLS handshake when there are multiple mTLS APIs
+- Fixed a bug during hot reload of Tyk Gateway where APIs with JSVM plugins stored in filesystem were not reloaded
+- Fixed a bug where the gateway would remove the trailing `/`at the end of a URL
+- Fixed a bug where nested field-mappings in UDG weren't working as intended
+- Fixed a bug when using Tyk OAuth 2.0 flow on Tyk Cloud where a request for an Authorization Code would fail with a 404 error
+- Fixed a bug where mTLS negotiation could fail when there are a large number of certificates and CAs; added an option (`http_server_options.skip_client_ca_announcement`) to use the alternative method for certificate transfer
+- Fixed CVE issue with go.uuid package
+- Fixed a bug where rate limits were not correctly applied when policies are partitioned to separate access rights and rate limits into different scopes
+
+---
+
+## 5.0.0 Release Notes
+
+##### Release Date 28 Mar 2023
+
+#### Deprecations
+- Tyk Gateway no longer natively supports **LetsEncrypt** integration. You still can use LetsEncrypt CLI tooling to generate certificates and use them with Tyk.
+
+#### Release Highlights
+
+##### Improved OpenAPI support
+
+We have added some great features to the Tyk OAS API definition bringing it closer to parity with our Tyk Classic API and to make it easier to get on board with Tyk using your Open API workflows.
+
+Tyk’s OSS users can now make use of extensive [custom middleware](https://tyk.io/docs/plugins/) options with your OAS APIs, to transform API requests and responses, exposing your upstream services in the way that suits your users and internal API governance rules. We’ve enhanced the Request Validation for Tyk OAS APIs to include parameter validation (path, query, headers, cookie) as well as the body validation that was introduced in Tyk 4.1.
+
+[Versioning your Tyk OAS APIs]({{< ref "getting-started/key-concepts/oas-versioning" >}}) is easier than ever, with the Tyk OSS Gateway now looking after the maintenance of the list of versions associated with the base API for you; we’ve also added a new endpoint on the Tyk API that will return details of the versions for a given API.
+
+We’ve improved support for [OAS Mock Responses]({{< ref "getting-started/using-oas-definitions/mock-response" >}}), with the Tyk OAS API definition now allowing you to register multiple Mock Responses in a single API, providing you with increased testing flexibility.
+
+Of course, we’ve also addressed some bugs and usability issues as part of our ongoing ambition to make Tyk OAS API the best way for you to create and manage your APIs.
+
+Thanks to our community contributors [armujahid](https://github.com/armujahid), [JordyBottelier](https://github.com/JordyBottelier) and [ls-michal-dabrowski](https://github.com/ls-michal-dabrowski) for your PRs that further improve the quality of Tyk OSS Gateway!
+
+#### Downloads
+
+- [docker image to pull](https://hub.docker.com/layers/tykio/tyk-gateway/v5.0.0/images/sha256-196815adff2805ccc14c267b14032f23913321b24ea86c052b62a7b1568b6725?context=explore)
+- [source code](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.0)
+
+#### Changelog {#Changelog-v5.0.0}
+
+##### Added
+- Support for request validation (including query params, headers and the rest of OAS rules) with Tyk OAS APIs
+- Transform request/response middleware for Tyk OAS APIs
+- Custom middleware for Tyk OAS APIs
+- Added a new API endpoint to manage versions for Tyk OAS APIs
+- Improved Mock API plugin for Tyk OAS APIs
+- Universal Data Graph and GraphQL APIs now support using context variables in request headers, allowing passing information it to your subgraphs
+- Now you can control access to introspection on policy and key level
+
+#### Fixed
+- Fixed potential race condition when using distributed rate limiter
+
+---
+
+## Further Information
+
+### Upgrading Tyk
+Please refer to the [upgrading Tyk]({{< ref "upgrading-tyk" >}}) page for further guidance with respect to the upgrade strategy.
+
+### API Documentation
+
+- [OpenAPI Document]({{<ref "tyk-dashboard-api">}})
+- [Postman Collection](https://www.postman.com/tyk-technologies/workspace/tyk-public-workspace/collection/27225007-374cc3d0-f16d-4620-a435-68c53553ca40)
+
+### FAQ
+Please visit our [Developer Support]({{< ref "frequently-asked-questions/faq" >}}) page for further information relating to reporting bugs, upgrading Tyk, technical support and how to contribute.

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.1.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.1.md
@@ -1,0 +1,106 @@
+---
+title: Tyk Gateway 5.1 Release Notes
+description: "Release notes 5.1 for Tyk Gateway"
+tags: ["Release notes", "Gateway", "5.1"]
+aliases:
+  -  /release-notes/version-5.1/
+---
+
+**Open Source** ([Mozilla Public License](https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md))
+
+### Support Lifetime
+Minor releases are supported until our next minor comes out in Q3.
+
+---
+
+## 5.1 Release Notes
+
+##### Release Date 23 June 2023
+
+#### Breaking Changes
+Our Gateway is using [Golang 1.19](https://tip.golang.org/doc/go1.19) Programming Language starting with the 5.1 release. This brings improvements to the code base and allows us to benefit from the latest features and security enhancements in Go. Don’t forget that, if you’re using GoPlugins, you'll need to [recompile]({{< ref "plugins/supported-languages/golang#initialise-plugin-for-gateway-51" >}}) these to maintain compatibility with the latest Gateway.
+
+#### Deprecations
+There are no deprecations in this release.
+
+#### Upgrade instructions
+If you are on a 5.0 we advise you to upgrade ASAP.
+
+#### Release Highlights
+ 
+##### Request Body Size Limits
+
+We have introduced a new Gateway-level option to limit the size of requests made
+to your APIs. You can use this as a first line of defence against overly large
+requests that might affect your Tyk Gateways or upstream services. Of course,
+being Tyk, we also provide the flexibility to configure API-level and
+per-endpoint size limits so you can be as granular as you need to protect and
+optimise your services. Check out our improved documentation for full
+description of how to use these powerful [features]({{< ref "basic-config-and-security/control-limit-traffic/request-size-limits" >}}).
+
+##### Changed default RPC pool size for MDCB deployments
+
+We have reduced the default RPC pool size from 20 to 5. This can reduce the CPU and
+memory footprint in high throughput scenarios. Please monitor the CPU and memory
+allocation of your environment and adjust accordingly. You can change the pool
+size using [slave_options.rpc_pool_size]({{< ref "tyk-oss-gateway/configuration#slave_optionsrpc_pool_size" >}})
+
+#### Downloads
+
+- [docker image to pull](https://hub.docker.com/layers/tykio/tyk-gateway/v5.1/images/sha256-3d1e64722be1a983d4bc4be9321ca1cdad10af9bb3662fd6824901d5f22820f1?context=explore)
+- [source code](https://github.com/TykTechnologies/tyk/releases/tag/v5.1.0)
+
+
+#### Changelog
+
+##### Added
+
+- Added `HasOperation`, `Operation` and `Variables` to GraphQL data source API definition for easier nesting
+- Added abstractions/interfaces for ExecutionEngineV2 and ExecutionEngine2Executor with respect to graphql-go-tools
+- Added support for the `:authority` header when making GRPC requests. If the `:authority` header is not present then some GRPC servers return PROTOCOL_ERROR which prevents custom GRPC plugins from running. Thanks to [vanhtuan0409](https://github.com/vanhtuan0409) from the Tyk Community for his contribution!
+
+##### Changed
+
+- Tyk Gateway updated to use Go 1.19
+- Updated [_kin-openapi_](https://github.com/getkin/kin-openapi) dependency to the version [v0.114.0](https://github.com/getkin/kin-openapi/releases/tag/v0.114.0)
+- Enhanced the UDG parser to comprehensively extract all necessary information for UDG configuration when users import to Tyk their OpenAPI document as an API definition
+- Reduced default CPU and memory footprint by changing the default RPC pool size from 20 to 5 connections.
+
+##### Fixed
+
+- Fixed an issue where invalid IP addresses could be added to the IP allow list
+- Fixed an issue when using custom authentication with multiple authentication methods, custom authentication could not be selected to provide the base identity
+- Fixed an issue where OAuth access keys were physically removed from Redis on expiry. Behaviour for OAuth is now the same as for other authorisation methods
+- Fixed an issue where the `global_size_limit` setting didn't enable request size limit middleware. Thanks to [PatrickTaibel](https://github.com/PatrickTaibel) for the contribution!
+- Fixed minor versioning, URL and field mapping issues when importing OpenAPI document as an API definition to UDG
+- When the control API is not protected with mTLS we now do not ask for a cert, even if all the APIs registered have mTLS as an authorization mechanism
+
+#### Tyk Classic Portal Changelog
+
+##### Changed
+
+- Improved performance when opening the Portal page by optimising the pre-fetching of required data
+
+
+## Community Contributions
+
+Special thanks to the following members of the Tyk community for their contributions in this release:
+
+- Thanks to [PatrickTaibel](https://github.com/PatrickTaibel) for fixing an issue where `global_size_limit` was not enabling request size limit middleware.
+
+- Thanks to [vanhtuan0409](https://github.com/vanhtuan0409) for adding support to the `:authority` header when making gRPC requests.
+
+---
+
+## Further Information
+
+### Upgrading Tyk
+Please refer to the [upgrading Tyk]({{< ref "upgrading-tyk" >}}) page for further guidance with respect to the upgrade strategy.
+
+### API Documentation
+
+- [OpenAPI Document]({{<ref "tyk-gateway-api">}})
+- [Postman Collection](https://www.postman.com/tyk-technologies/workspace/tyk-public-workspace/collection/27225007-c23829a5-7b3c-454f-8dcb-a1c67249032b)
+
+### FAQ
+Please visit our [Developer Support]({{< ref "frequently-asked-questions/faq" >}}) page for further information relating to reporting bugs, upgrading Tyk, technical support and how to contribute.

--- a/tyk-docs/content/tyk-cloud/securing-your-apis.md
+++ b/tyk-docs/content/tyk-cloud/securing-your-apis.md
@@ -27,7 +27,7 @@ Here are the most popular ways to secure your APIs.
 
 ## 2. Request Signing
 
-Tyk can [sign the request with HMAC or RSA]({{< ref "/release-notes/version-2.9.md#hmac-request-signing" >}}), before sending it to the API target. This is an implementation of an [RFC Signing HTTP Messages(draft 10)](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-10). This RFC was designed to provide authenticity of the digital signature of the client. In our flow, the Tyk Cloud Data Planes, as the client, using a certificate private key, will add a header signature to the request. The API, using a pre-agreed public key (based on a meaningful keyId identifier) will verify the authenticity of the request coming from your Tyk Cloud Data Plane.
+Tyk can [sign the request with HMAC or RSA]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.9.md#hmac-request-signing" >}}), before sending it to the API target. This is an implementation of an [RFC Signing HTTP Messages(draft 10)](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-10). This RFC was designed to provide authenticity of the digital signature of the client. In our flow, the Tyk Cloud Data Planes, as the client, using a certificate private key, will add a header signature to the request. The API, using a pre-agreed public key (based on a meaningful keyId identifier) will verify the authenticity of the request coming from your Tyk Cloud Data Plane.
  A limitation is that the APIs or LB need to implement this signature verification and be able to update the certificates as mentioned in [Mutual TLS or Client authorisation](#1-mutual-tls-or-client-authorisation).
 
  ## 3. IP Whitelisting

--- a/tyk-docs/content/tyk-multi-data-centre/mdcb-components.md
+++ b/tyk-docs/content/tyk-multi-data-centre/mdcb-components.md
@@ -63,7 +63,7 @@ To provide resilience and availability, multiple Gateways should be deployed and
 If you want this Data Plane deployment to be resilient, available, and independent from the Control Plane during a disconnection event, it is advised to make the Redis data store persistent.
   
 ### Optional Components
-- A **Tyk Pump** specifically configured as a [Hybrid Pump]({{< ref "/release-notes/version-2.8.md#custom-analytics-storage-engines-for-multi-cloud--enterprise-mdcb-users" >}}) can be deployed with the Data Plane gateways to export analytics data (request/response logs) to your [data sink of choice]({{< ref "/tyk-stack/tyk-pump/other-data-stores.md" >}}) for further analytics and visualisation.
+- A **Tyk Pump** specifically configured as a [Hybrid Pump]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.8.md#custom-analytics-storage-engines-for-multi-cloud--enterprise-mdcb-users" >}}) can be deployed with the Data Plane gateways to export analytics data (request/response logs) to your [data sink of choice]({{< ref "/tyk-stack/tyk-pump/other-data-stores.md" >}}) for further analytics and visualisation.
   
 ## Next Steps
  - [Run an MDCB Proof of Concept]({{< ref "/tyk-multi-data-centre/mdcb-example-minimising-latency.md" >}})

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -2072,32 +2072,68 @@ menu:
           path: /product-stack/tyk-gateway/release-notes/version-5.2
           category: Page
           show: True
-        - title: "Old releases"
+        - title: "Tyk Gateway v5.1"
+          category: Page
+          path: /product-stack/tyk-gateway/release-notes/version-5.1
+          show: True
+        - title: "Tyk Gateway v5.0"
+          path: /product-stack/tyk-gateway/release-notes/version-5.0
+          category: Page
+          show: True
+        - title: "Tyk Gateway v4.3"
+          path: /product-stack/tyk-gateway/release-notes/version-4.3
+          category: Page
+          show: True
+        - title: "Tyk Gateway v4.2"
+          path: /product-stack/tyk-gateway/release-notes/version-4.2
+          category: Page
+          show: True
+        - title: "Tyk Gateway v4.1"
+          path: /product-stack/tyk-gateway/release-notes/version-4.1
+          category: Page
+          show: True
+        - title: "Tyk Gateway v4.0"
+          path: /product-stack/tyk-gateway/release-notes/version-4.0
+          category: Page
+          show: True
+        - title: "Tyk Gateway v3.2"
+          path: /product-stack/tyk-gateway/release-notes/version-3.2
+          category: Page
+          show: True
+        - title: "Tyk Gateway v3.1"
+          path: /product-stack/tyk-gateway/release-notes/version-3.1
+          category: Page
+          show: True
+        - title: "Tyk Gateway v3.0"
+          path: /product-stack/tyk-gateway/release-notes/version-3.0
+          category: Page
+          show: True
+        - title: "Archived releases"
           category: Directory
           show: True
           menu:
           - title: "Tyk Gateway v2.9"
-            path: /release-notes/version-2.9
+            path: /product-stack/tyk-gateway/release-notes/archived-releases/version-2.9
             category: Page
             show: True
           - title: "Tyk Gateway v2.8"
-            path: /release-notes/version-2.8
+            path: /product-stack/tyk-gateway/release-notes/archived-releases/version-2.8
             category: Page
             show: True
           - title: "Tyk Gateway v2.7"
-            path: /release-notes/version-2.7
+            path: /product-stack/tyk-gateway/release-notes/archived-releases/version-2.7
             category: Page
             show: True
           - title: "Tyk Gateway v2.6"
-            path: /release-notes/version-2.6
+            path: /product-stack/tyk-gateway/release-notes/archived-releases/version-2.6
             category: Page
             show: True
           - title: "Tyk Gateway v2.5"
-            path: /release-notes/version-2.5
+            path: /product-stack/tyk-gateway/release-notes/archived-releases/version-2.5
             category: Page
             show: True
           - title: "Tyk Gateway v2.4"
-            path: /release-notes/version-2.4
+            path: /product-stack/tyk-gateway/release-notes/archived-releases/version-2.4
             category: Page
             show: True
         - title: "Release highlights and upgrades"
@@ -2487,13 +2523,73 @@ menu:
           category: Page
           path: /product-stack/tyk-dashboard/release-notes/version-5.2
           show: True
+        - title: "Tyk Dashboard v5.1"
+          category: Page
+          path: /product-stack/tyk-dashboard/release-notes/version-5.1
+          show: True
+        - title: "Tyk Dashboard v5.0"
+          category: Page
+          path: /product-stack/tyk-dashboard/release-notes/version-5.0
+          show: True
+        - title: "Tyk Dashboard v4.3"
+          category: Page
+          path: /product-stack/tyk-dashboard/release-notes/version-4.3
+          show: True
+        - title: "Tyk Dashboard v4.2"
+          category: Page
+          path: /product-stack/tyk-dashboard/release-notes/version-4.2
+          show: True
+        - title: "Tyk Dashboard v4.1"
+          category: Page
+          path: /product-stack/tyk-dashboard/release-notes/version-4.1
+          show: True
+        - title: "Tyk Dashboard v4.0"
+          category: Page
+          path: /product-stack/tyk-dashboard/release-notes/version-4.0
+          show: True
+        - title: "Tyk Dashboard v3.2"
+          category: Page
+          path: /product-stack/tyk-dashboard/release-notes/version-3.2
+          show: True
+        - title: "Tyk Dashboard v3.1"
+          category: Page
+          path: /product-stack/tyk-dashboard/release-notes/version-3.1
+          show: True
+        - title: "Tyk Dashboard v3.0"
+          category: Page
+          path: /product-stack/tyk-dashboard/release-notes/version-3.0
+          show: True
         - title: "Changelog"
           category: Page
           show: False
-        - title: "Old releases"
+        - title: "Archived releases"
           category: Directory
-          show: False
+          show: True
           menu:
+          - title: "Tyk Dashboard v2.9"
+            path: "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.9"
+            category: Page
+            show: true
+          - title: "Tyk Dashboard v2.8"
+            path: "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.8"
+            category: Page
+            show: true
+          - title: "Tyk Dashboard v2.7"
+            path: "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.7"
+            category: Page
+            show: true
+          - title: "Tyk Dashboard v2.6"
+            path: "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.6"
+            category: Page
+            show: true
+          - title: "Tyk Dashboard v2.5"
+            path: "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.5"
+            category: Page
+            show: true
+          - title: "Tyk Dashboard v2.4"
+            path: "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.4"
+            category: Page
+            show: true
         - title: "Release highlights and upgrades"
           category: Directory
           show: False
@@ -3036,24 +3132,24 @@ menu:
           - title: "[version]"
             category: Page
             show: False
-        - title: "MDCB v2.0"
-          path: /release-notes/mdcb-2.0
-          category: Page
-          show: True
-        - title: "MDCB v2.1"
-          path: /release-notes/mdcb-2.1
-          category: Page
-          show: True
-        - title: "MDCB v2.2"
-          path: /release-notes/mdcb-2.2/
+        - title: "MDCB v2.4"
+          path: /release-notes/mdcb-2.4
           category: Page
           show: True
         - title: "MDCB v2.3"
           path: /release-notes/mdcb-2.3
           category: Page
           show: True
-        - title: "MDCB v2.4"
-          path: /release-notes/mdcb-2.4
+        - title: "MDCB v2.2"
+          path: /release-notes/mdcb-2.2/
+          category: Page
+          show: True
+        - title: "MDCB v2.1"
+          path: /release-notes/mdcb-2.1
+          category: Page
+          show: True
+        - title: "MDCB v2.0"
+          path: /release-notes/mdcb-2.0
           category: Page
           show: True
     - title: "Tyk Pump (Open Source)"
@@ -3423,50 +3519,46 @@ menu:
     - title: "Plug-in Hub"
       category: Page
       show: False
-    - title: "Tyk Release Summary"
+    - title: "Tyk Releases"
       category: Directory
-      show: True
+      show: False
       menu:
-      - title: "Overview"
-        path: /developer-support/tyk-release-summary/overview
-        category: Page
-        show: True
       - title: "Tyk v5.1"
         path: /release-notes/version-5.1
         category: Page
-        show: True
+        show: False
       - title: "Tyk v5.0"
         path: /release-notes/version-5.0
         category: Page
-        show: True
+        show: False
       - title: "Tyk v4.3"
         path: /release-notes/version-4.3
         category: Page
-        show: True
+        show: False
       - title: "Tyk v4.2"
         path: /release-notes/version-4.2
         category: Page
-        show: True
+        show: False
       - title: "Tyk v4.1"
         path: /release-notes/version-4.1
         category: Page
-        show: True
+        show: False
       - title: "Tyk v4.0"
         path: /release-notes/version-4.0
         category: Page
-        show: True
+        show: False
       - title: "Tyk v3.2"
         path: /release-notes/version-3.2
         category: Page
-        show: True
+        show: False
       - title: "Tyk v3.1"
         path: /release-notes/version-3.1
         category: Page
-        show: True
+        show: False
       - title: "Tyk v3.0"
         path: /release-notes/version-3.0
         category: Page
-        show: True
+        show: False
     - title: "How to Upgrade Tyk"
       category: Directory
       show: True
@@ -3479,6 +3571,10 @@ menu:
         path: /upgrading-v2-3-v2-2
         category: Page
         show: True
+    - title: "Tyk Release Notes"
+      path: /developer-support/tyk-release-summary/overview
+      category: Page
+      show: True
     - title: "Contribute to Tyk Docs"
       path: /contribute
       category: Page


### PR DESCRIPTION
[DX-767] Refactor release notes so stored in product stack area of the website (#3435)

Update release notes structure in product stack area of website and add landing page to release notes in developer support section.

Co-authored-by: Simon Pears <simon@tyk.io>
Co-authored-by: itachi sasuke <8012032+Keithwachira@users.noreply.github.com>
Co-authored-by: Yaara <yaara@tyk.io>

[DX-767]: https://tyktech.atlassian.net/browse/DX-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ