### PR TITLE
add fixxing for list element to add padding

### DIFF
--- a/tyk-docs/assets/scss/home.scss
+++ b/tyk-docs/assets/scss/home.scss
@@ -135,7 +135,7 @@ a {
 }
 
 ol, ul {
-  padding-left: 0 !important;
+  padding-left: 0;
 }
 
 

--- a/tyk-docs/assets/scss/home.scss
+++ b/tyk-docs/assets/scss/home.scss
@@ -236,9 +236,9 @@ ol, ul {
 
 @media only screen and (max-width: 1024px) {
   .home-mobile-padding {
-    padding-top: 0 !important;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
+    padding-top: 0;
+    padding-left: 0 ;
+    padding-right: 0 ;
 
   }
 }


### PR DESCRIPTION
Add padding to li element as reported by andy

>. I have removed important to make sure it does not override the already exiting css . This make sure that Li in content have a padding of 15px

[Preview link](https://deploy-preview-3517--tyk-docs.netlify.app/docs/nightly/getting-started/key-concepts/high-level-concepts/)
