### PR TITLE
[DX-791]add support for oas 3.1.0 in the docs

### DIFF
--- a/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
+++ b/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
@@ -84,7 +84,7 @@ var ui = SwaggerUIBundle({
   margin-top: 3em;
 }
 
-.swagger-ui h4.opblock-tag {
+.swagger-ui h3.opblock-tag {
   flex-direction: column;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -95,7 +95,7 @@ var ui = SwaggerUIBundle({
   position: relative;
 }
 
-.swagger-ui h4 > a:last-child  {
+.swagger-ui h3 > a:last-child  {
   position: absolute;
   top: 10px;
   right: 10px;

--- a/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
+++ b/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
@@ -71,7 +71,7 @@ var ui = SwaggerUIBundle({
 }
 
 .swagger-ui * {
-  font-family: 'Inter', sans-serif !important;
+  font-family: 'Roboto', sans-serif !important;
   line-height: 1.5;
   letter-spacing: 0.015em;
 }
@@ -123,7 +123,7 @@ var ui = SwaggerUIBundle({
 .swagger-ui .info .title {
     margin-bottom: 26px;
     font-size: 48px;
-    font-family: "Inter", sans-serif !important;
+    font-family: "smoolthan", sans-serif !important;
     font-weight: bold;
     color: #000;
 }

--- a/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
+++ b/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
@@ -1,9 +1,9 @@
 {{ define "content" }}
 <a href="https://www.postman.com/tyk-technologies/workspace/379673ec-4cc5-4b8e-bef5-8a6a988071cb/overview" target="_blank">Visit our Postman Collections</a>
 <div id="swagger-ui">Loading...</div>
-<link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.20.3/swagger-ui.css">
-<script src="https://unpkg.com/swagger-ui-dist@3.20.3/swagger-ui-standalone-preset.js"></script>
-<script src="https://unpkg.com/swagger-ui-dist@3.20.3/swagger-ui-bundle.js"></script>
+<link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.9.2/swagger-ui.css">
+<script src="https://unpkg.com/swagger-ui-dist@5.9.2/swagger-ui-standalone-preset.js"></script>
+<script src="https://unpkg.com/swagger-ui-dist@5.9.2/swagger-ui-bundle.js"></script>
 <script>
 setTimeout(function(){
 const DisableTryItOutPlugin = function() {

--- a/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
+++ b/tyk-docs/themes/tykio/layouts/swagger-ui/single.html
@@ -71,7 +71,7 @@ var ui = SwaggerUIBundle({
 }
 
 .swagger-ui * {
-  font-family: 'Roboto', sans-serif !important;
+  font-family: 'Inter', sans-serif !important;
   line-height: 1.5;
   letter-spacing: 0.015em;
 }
@@ -123,10 +123,16 @@ var ui = SwaggerUIBundle({
 .swagger-ui .info .title {
     margin-bottom: 26px;
     font-size: 48px;
-    font-family: 'smoolthan' !important;
+    font-family: "Inter", sans-serif !important;
     font-weight: bold;
     color: #000;
 }
+
+.swagger-ui .renderedMarkdown code {
+    color: #d63384;
+
+}
+
 
 /* Disable Try it Now button */
 


### PR DESCRIPTION
DX-791

Currently a user cannot add OAS 3.1.0 in the docs because we use a old version of swagger ui. This changes the version of swagger ui add also updates the Css 

[Preview Link](https://deploy-preview-3524--tyk-docs.netlify.app/docs/nightly/tyk-gateway-api/)