### PR TITLE
 [Don't merge it I am testing it]remove sections from the sitemap as they return 404

### DIFF
--- a/tyk-docs/themes/tykio/layouts/sitemap.xml
+++ b/tyk-docs/themes/tykio/layouts/sitemap.xml
@@ -1,5 +1,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range .Data.Pages }}
+  {{- if .IsPage -}}
   <url>
     <loc>https:{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -11,5 +12,6 @@
     </image:image>
     {{ end }}
   </url>
+  {{ end }}
   {{ end }}
 </urlset>


### PR DESCRIPTION
We have pages in the docs sitemap that return 404. This is because hugo adds sections in the sitemap. This pr is to remove them.

**Need testing before merging**