### PR TITLE
[DX-798] - Update CTA links on home page badges to refer to docs pages

### DIFF
--- a/tyk-docs/data/tyk_components.json
+++ b/tyk-docs/data/tyk_components.json
@@ -5,7 +5,7 @@
       "image": "img/tyk_self_managed.svg",
       "steps": "Only 4 steps",
       "button_text": "Free trial",
-      "path": "tyk-self-managed/install/",
+      "path": "getting-started/quick-start/",
       "description":"Easily install our Full Lifecycle API Management solution in your own infrastructure. There is no calling home and there are no usage limits. You have full control.",
       "includes": "Includes: Tyk API Gateway, Tyk Dashboard, Tyk Portal, Tyk UDG"
     },{
@@ -13,7 +13,7 @@
       "image": "img/tyk_cloud.svg",
       "steps": "Only 2 steps",
       "button_text": "Free trial",
-      "path": "tyk-cloud/",
+      "path": "deployment-and-operations/tyk-cloud-platform/quick-start/",
       "description":"A fully managed service that makes it easy for API teams to create, secure, publish and maintain APIs at any scale, anywhere in the world.",
       "includes": "Includes: Tyk API Gateway, Tyk Dashboard, Tyk Portal, Tyk UDG"
     },{
@@ -21,7 +21,7 @@
       "image": "img/tyk_open_source.svg",
       "steps": "Only 4 steps",
       "button_text": "Get started",
-      "path": "apim/open-source/",
+      "path": "deployment-and-operations/tyk-open-source-api-gateway/quick-start/",
       "description":"The heart of what we do. Anything that is API Gateway-related, lives in the Gateway, or is critical for the Gateway to work is open and freely available.",
       "includes":"Includes: Tyk OSS Gateway"
     }

--- a/tyk-docs/data/tyk_components.json
+++ b/tyk-docs/data/tyk_components.json
@@ -19,7 +19,7 @@
     },{
       "title": "Tyk Open Source",
       "image": "img/tyk_open_source.svg",
-      "steps": "Only 4 steps",
+      "steps": "Only 3 steps",
       "button_text": "Get started",
       "path": "deployment-and-operations/tyk-open-source-api-gateway/quick-start/",
       "description":"The heart of what we do. Anything that is API Gateway-related, lives in the Gateway, or is critical for the Gateway to work is open and freely available.",


### PR DESCRIPTION
Update CTA links on home page badges to refer to docs pages

[DX-798](https://tyktech.atlassian.net/browse/DX-798)

[preview](https://deploy-preview-3542--tyk-docs.netlify.app/docs/nightly/)

[DX-798]: https://tyktech.atlassian.net/browse/DX-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ