### PR TITLE
Merging to release-5.2: [DX-754] add fix to data to remove comma at the end (#3539)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/site_schema.html
+++ b/tyk-docs/themes/tykio/layouts/partials/site_schema.html
@@ -1,7 +1,7 @@
 <script type="application/ld+json">
 {
     "@context" : "http://schema.org",
-    "@type" : "Tyk Documentation",
+    "@type": "WebPage",
     "mainEntityOfPage": {
          "@type": "WebPage",
          "@id": "{{ .Site.BaseURL }}"
@@ -13,6 +13,7 @@
     "author" : "tyk ",
     "copyrightHolder" : "Tyk",
     "url" : "{{ .Permalink }}",
-    "keywords" : [ {{ if isset .Params "tags" }}{{ range .Params.tags }}"{{ . }}",{{ end }}{{ end }} ]
+    "keywords" : [{{ if isset .Params "tags" }}{{ range $index, $tag := .Params.tags }}"{{ $tag }}"{{ if ne $index (sub (len $.Params.tags) 1) }},{{ end }}{{ end }}{{ end }}]
+
 }
 </script>


### PR DESCRIPTION
[DX-754] add fix to data to remove comma at the end (#3539)

Fixes issues based schema.org validator - Removes comma from the end of the tags list and changes the "@type" from "Tyk Documentation" to the known type "Webpage".

[DX-754]: https://tyktech.atlassian.net/browse/DX-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ