### PR TITLE
Merging to release-5.2: [DX-799]: Remove CTA button in deployment & ops -> GW -> overview, replacing with links (#3541)

### DIFF
--- a/tyk-docs/content/apim/open-source.md
+++ b/tyk-docs/content/apim/open-source.md
@@ -17,9 +17,7 @@ Open source is at the heart of what we do. Anything that is API Gateway-related,
 
 Our commitment to open source also delivers a host of benefits for our users: signup for free with Tyk, receive securely packaged open source packages, getting started guides, access to our community and all of the latest open source information.
 
-To get started and test it out:
-
-{{< button_left href="https://tyk.io/docs/apim/open-source/installation/" color="green" content="Discover Open Source" >}}
+If you are new to Tyk API Gateway or just want to quickly take it for a spin in just 3 steps, head over to our [quick start guide]({{< ref "deployment-and-operations/tyk-open-source-api-gateway/quick-start" >}}). If you want to deploy it in a specific platform check our [installation options]({{< ref "apim/open-source/installation" >}}) page.
 
 
 Please show your support for the Gateway by clicking the GitHub link, then adding your star.


### PR DESCRIPTION
[DX-799]: Remove CTA button in deployment & ops -> GW -> overview, replacing with links (#3541)

remove CTA button on GW overview, replacing with links
Update tyk-docs/content/apim/open-source.md

Co-authored-by: Yaara <yaara@tyk.io>

---------

Co-authored-by: Simon Pears <simon@tyk.io>
Co-authored-by: Yaara <yaara@tyk.io>

[DX-799]: https://tyktech.atlassian.net/browse/DX-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ