### PR TITLE
[DX-753]remove sections from the sitemap as they return 404

### DIFF
--- a/tyk-docs/themes/tykio/layouts/sitemap.xml
+++ b/tyk-docs/themes/tykio/layouts/sitemap.xml
@@ -1,5 +1,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range .Data.Pages }}
+  {{- if .IsPage -}}
   <url>
     <loc>https:{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -11,5 +12,6 @@
     </image:image>
     {{ end }}
   </url>
+  {{ end }}
   {{ end }}
 </urlset>


### PR DESCRIPTION
We have pages in the docs sitemap that return 404. This is because hugo adds sections in the sitemap. This pr is to remove them.
**How I solved the issue**
In hugo you can check if a page is a regular page using .IsPage so i used this variable to only include urls that are pages to the sitemap and remove sections.  **Reference :** https://gohugo.io/variables/page/
 Jira ticket :DX-753

[Preview link to new sitemap](https://deploy-preview-3566--tyk-docs.netlify.app/docs/nightly/sitemap.xml)

Sections removed from site map
https://tyk.io/docs/nightly/api-management/
https://tyk.io/docs/nightly/apim-best-practice/
https://tyk.io/docs/nightly/concepts/
https://tyk.io/docs/nightly/configure/
https://tyk.io/docs/nightly/deployment-and-operations/
https://tyk.io/docs/nightly/developer-support/
https://tyk.io/docs/nightly/key-concepts/
https://tyk.io/docs/nightly/product-stack/
https://tyk.io/docs/nightly/transform-traffic/
https://tyk.io/docs/nightly/tyk-on-prem/
https://tyk.io/docs/nightly/tyk-self-managed/