### PR TITLE
Merging to release-5: [DX-834] Fixing a typo in the docs (#3605)

### DIFF
--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -181,8 +181,8 @@ Then, in the Tyk Classic API definition, you set these names in the listen path 
 ...
 "proxy": {
     "preserve_host_header": false,
-    "listen_path": env://mylistenpath,
-    "target_url": env://myupstream,
+    "listen_path": "env://mylistenpath",
+    "target_url": "env://myupstream",
     ...
 }
 ...


### PR DESCRIPTION
[DX-834] Fixing a typo in the docs (#3605)

Fixing a typo in the docs

the env variables in the JSON need to have quotes

Co-authored-by: dcs3spp <dcs3spp@users.noreply.github.com>

[DX-834]: https://tyktech.atlassian.net/browse/DX-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ