### PR TITLE
Added link to 5.0.7 release notes

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.0.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.0.md
@@ -1,7 +1,7 @@
 ---
 title: Tyk Gateway 5.0 Release Notes
 description: Tyk Gateway v5.0 release notes
-tags: ["release notes", "Tyk Gateway", "v5.0", "5.0", "5.0.0", "5.0.1", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6"]
+tags: ["release notes", "Tyk Gateway", "v5.0", "5.0", "5.0.0", "5.0.1", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6", "5.0.7"]
 aliases:
     - /release-notes/version-5.0/
 ---
@@ -12,6 +12,10 @@ aliases:
 
 ---
 
+## 5.0.7 Release Notes
+Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.7).
+
+---
 ## 5.0.6 Release Notes
 Please refer to our GitHub [release notes](https://github.com/TykTechnologies/tyk/releases/tag/v5.0.6).
 


### PR DESCRIPTION
The link to 5.0.7 release notes (October LTS release) was missing.
