### PR TITLE
[DX-836]change right nav item to have a font size of 12

### DIFF
--- a/tyk-docs/assets/scss/_table-of-contents.scss
+++ b/tyk-docs/assets/scss/_table-of-contents.scss
@@ -96,7 +96,7 @@
 		&__item {
 			display: block;
 			padding: 0.5rem 0;
-			font-size: 15px;
+			font-size: 12px;
 			color: $brand-black;
 			word-wrap: break-word;
 


### PR DESCRIPTION
[DX-836]

The font size in the right navigation should be slightly smaller than the size in the main content area it should be 12 px
[Preview Link]https://deploy-preview-3675--tyk-docs.netlify.app/docs/nightly/getting-started/)

[DX-836]: https://tyktech.atlassian.net/browse/DX-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ