### PR TITLE
Merging to release-5.1: [DX-865] remove pages that were moved to product stack before (#3672)

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -3433,46 +3433,6 @@ menu:
     - title: "Plug-in Hub"
       category: Page
       show: False
-    - title: "Tyk Releases"
-      category: Directory
-      show: False
-      menu:
-      - title: "Tyk v5.1"
-        path: /release-notes/version-5.1
-        category: Page
-        show: False
-      - title: "Tyk v5.0"
-        path: /release-notes/version-5.0
-        category: Page
-        show: False
-      - title: "Tyk v4.3"
-        path: /release-notes/version-4.3
-        category: Page
-        show: False
-      - title: "Tyk v4.2"
-        path: /release-notes/version-4.2
-        category: Page
-        show: False
-      - title: "Tyk v4.1"
-        path: /release-notes/version-4.1
-        category: Page
-        show: False
-      - title: "Tyk v4.0"
-        path: /release-notes/version-4.0
-        category: Page
-        show: False
-      - title: "Tyk v3.2"
-        path: /release-notes/version-3.2
-        category: Page
-        show: False
-      - title: "Tyk v3.1"
-        path: /release-notes/version-3.1
-        category: Page
-        show: False
-      - title: "Tyk v3.0"
-        path: /release-notes/version-3.0
-        category: Page
-        show: False
     - title: "How to Upgrade Tyk"
       category: Directory
       show: True


### PR DESCRIPTION
[DX-865] remove pages that were moved to product stack before (#3672)

remove pages that were moved to product stack before

Co-authored-by: dcs3spp <dcs3spp@users.noreply.github.com>

[DX-865]: https://tyktech.atlassian.net/browse/DX-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ