### PR TITLE
[DX-886] remove hotjar as we no longer use it

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/head_tracking.html
+++ b/tyk-docs/themes/tykio/layouts/partials/head_tracking.html
@@ -14,24 +14,6 @@
   }
 </script>
 <!-- End Google Tag Manager -->
-<!-- Hotjar Tracking Code for https://tyk.io/ -->
-<script>
-  if (!localStorage.getItem("cookieDisabled")) {
-    (function (h, o, t, j, a, r) {
-      h.hj =
-        h.hj ||
-        function () {
-          (h.hj.q = h.hj.q || []).push(arguments);
-        };
-      h._hjSettings = { hjid: 1216213, hjsv: 6 };
-      a = o.getElementsByTagName("head")[0];
-      r = o.createElement("script");
-      r.async = 1;
-      r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
-      a.appendChild(r);
-    })(window, document, "https://static.hotjar.com/c/hotjar-", ".js?sv=");
-  }
-</script>
 
 <!-- Fullstory script -->
 <script>


### PR DESCRIPTION
[DX-886]
Remove hotjar as we no longer use it. We use full story instead. This is as an effort to remove all javascript that we do not use as they slow down our website

[DX-886]: https://tyktech.atlassian.net/browse/DX-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ