### PR TITLE
Merging to release-5.2: [Dx 902] Remove H1 headings from GW Release Notes < 5.x (#3740)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.4.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.4.md
@@ -9,19 +9,19 @@ aliases:
   - /release-notes/version-2.4/ 
 ---
 
-# New in this release:
+## New in this release:
 
 This release touch all our products and brings you numerous long awaited features and fixes. 
 Here are the packages and their versions we are releasing today: Tyk Gateway v2.4.0, Tyk Dashboard v1.4.0, Tyk Pump v0.4.2, MDCB v1.4.0, TIB v0.2.
 
-# <a name="major-highlights"></a>Major highlights
+## <a name="major-highlights"></a>Major highlights
 
-## Mutual TLS
+### Mutual TLS
 
 A major feature of this release is the implementation of Mutual TLS. Now you can protect your APIs by white-listing certificates, idenitfy users based on them, and increase security between Tyk and upstream API. For details, see [Mutual TLS]({{< ref "basic-config-and-security/security/mutual-tls" >}}).
 
 
-## Extended use of Multiple Policies
+### Extended use of Multiple Policies
 
 We have extended support for partitioned policies, and you can now mix them up when creating a key. Each policy should have own partition, and will not intersect, to avoid conflicts while merging their rules. 
 
@@ -40,7 +40,7 @@ For this release multiple policies are only supported only via the Add Key secti
 
 [Docs]({{< ref "basic-config-and-security/security/security-policies/partitioned-policies" >}})
 
-## <a name="global-api"></a>Global API Rate Limits
+### <a name="global-api"></a>Global API Rate Limits
 
 We have added a new API definition field `global_rate_limit` which specifies a global API rate limit in the following format: `{"rate": 10, "per": 1}`, similar to policies or keys. 
 
@@ -52,7 +52,7 @@ Extended Dashboard API designer Rate Limiting and Quotas section in Core setting
 
 [Docs]({{< ref "basic-config-and-security/security/security-policies/partitioned-policies" >}})
 
-## Specify custom analytics tags using HTTP headers
+### Specify custom analytics tags using HTTP headers
 
 We have added a new API definition field `tag_headers` which specifies a string array of HTTP headers which can be extracted and turned to tags. 
 
@@ -66,7 +66,7 @@ We have added a new **Tag headers** section to the Dashboard **API Designer Adva
 
 [Docs]({{< ref "tyk-stack/tyk-manager/analytics/log-browser" >}})
 
-## <a name="sso"></a>Single-Sign-On (SSO) improvements
+### <a name="sso"></a>Single-Sign-On (SSO) improvements
 
 More SSO functionality is something that a lot of our customers have been asking for. In this release we've significantly improved our support for SSO, and you can now:
 
@@ -75,37 +75,37 @@ More SSO functionality is something that a lot of our customers have been asking
 * Setup a login page redirect, using `sso_custom_login_url` and `sso_custom_portal_login_url` Dashboard config options to enable users login using a custom SSO login page. [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers" >}})
 * For those who love to build everything in-house, we have added new API for custom dashboard authentication integrations. [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers/custom" >}})
 
-# Moar!
+## Moar!
 This release is packed with way more more cool stuff. Here are detailed release notes for each product:
 
-## <a name="gateway"></a>Tyk Gateway v2.4.0
+### <a name="gateway"></a>Tyk Gateway v2.4.0
 
-### Mutual TLS support
+#### Mutual TLS support
 [Docs]({{< ref "basic-config-and-security/security/mutual-tls" >}})
 
-### Global API rate limits
+#### Global API rate limits
 [Docs]({{< ref "basic-config-and-security/control-limit-traffic/rate-limiting" >}})
 
-### Specify custom analytics tags using HTTP headers
+#### Specify custom analytics tags using HTTP headers
 [Docs]({{< ref "tyk-stack/tyk-manager/analytics/log-browser" >}})
 
-### Attaching Multiple Policies to the Keys
+#### Attaching Multiple Policies to the Keys
 [Docs]({{< ref "basic-config-and-security/security/security-policies/partitioned-policies" >}})
 
-### Default User Agent set to Tyk/$VERSION
+#### Default User Agent set to Tyk/$VERSION
 If no user agent is specified in a request, it is now set as `Tyk/$VERSION`.
 
-### Include `x-tyk-api-expires` date header for versioned APIs
+#### Include `x-tyk-api-expires` date header for versioned APIs
 If a request is made for an API which has an expiry date, the response will include the `x-tyk-api-expires` header with expiry date. 
 
 [Docs]({{< ref "getting-started/key-concepts/versioning" >}})
 
-### Run Admin Control API on a separate port
+#### Run Admin Control API on a separate port
 Using `control_api_port` option in configuration file, you can run the admin control api on a separate port, and hide it behind firewall if needed.
 
 [Docs]({{< ref "tyk-oss-gateway/configuration#control_api_port" >}})
 
-### Added a Configuration Linter
+#### Added a Configuration Linter
 
 We have added a new `tyk lint ` command which will validate your `tyk.conf` file and validate it for syntax correctness, misspelled attribute names or format of values. The Syntax can be:
 
@@ -118,7 +118,7 @@ If `--conf` is not used, the first of the following paths to exist is used:
 
 [Docs]({{< ref "tyk-oss-gateway/configuration" >}})
 
-### Set log_level from tyk.conf
+#### Set log_level from tyk.conf
 
 We have added a new `log_level` configuration variable to `tyk.conf` to control logging level.
 
@@ -126,7 +126,7 @@ Possible values are: `debug`, `info`, `warn`, `error`
 
 [Docs]({{< ref "tyk-oss-gateway/configuration#a-name-log-level-a-log-level" >}})
 
-### Added jsonMarshal to body transform templates
+#### Added jsonMarshal to body transform templates
 
 We have added the `jsonMarshal` helper to the body transform templates. You can apply jsonMarshal on a string in order to perform JSON style character escaping, and on complex objects to serialise them to a JSON string.
 
@@ -134,50 +134,50 @@ Example: `{{ .myField | jsonMarshal }}`
 
 [Docs]({{< ref "transform-traffic/request-body" >}})
 
-### Added a blocking reload endpoint
+#### Added a blocking reload endpoint
 
 Now you can add a `?block=true` argument to the `/tyk/reload` API endpoint, which will block a response, until the reload is performed. This can be useful in scripting environments like CI/CD workflows.
 
 [Docs]({{< ref "tyk-gateway-api" >}})
 
-### `tyk_js_path` file now contains only user code
+#### `tyk_js_path` file now contains only user code
 
 Internal JS API not budled into tyk binary, and `js/tyk.js` file used only for custom user code. It is recommended to delete this file, if you are not using it, or remove Tyk internal code from it. New releases do not ship this file by default.
 
-### Improved Swagger API import defaults
+#### Improved Swagger API import defaults
 
 When importing Swagger based APIs they now generate tracked URLs instead of white listed ones.
 
 [More](https://github.com/TykTechnologies/tyk/issues/643)
 
-### Respond with 503 if all hosts are down.
+#### Respond with 503 if all hosts are down.
 Previously, the internal load balancer was cycling though hosts even if they were known as down.
 
-### Request with OPTIONS method should not be cached.
+#### Request with OPTIONS method should not be cached.
 [More](https://github.com/TykTechnologies/tyk/issues/376)
 
-### Health check API is officially deprecated.
+#### Health check API is officially deprecated.
 This was very resource consuming and unstable feature. We recommend using load balancers of your choice for this.
 
-### Fixed custom error templates for authentication errors.
+#### Fixed custom error templates for authentication errors.
 [More](https://github.com/TykTechnologies/tyk/issues/438)
 
 
-## <a name="dashboard"></a>Tyk Dashboard v1.4.0
+### <a name="dashboard"></a>Tyk Dashboard v1.4.0
 
-### Mutual TLS support
+#### Mutual TLS support
 [Docs]({{< ref "basic-config-and-security/security/mutual-tls" >}})
 
-### Global API rate limits
+#### Global API rate limits
 [Docs]({{< ref "basic-config-and-security/control-limit-traffic/rate-limiting" >}})
 
-### Specify custom analytics tags using HTTP headers
+#### Specify custom analytics tags using HTTP headers
 [Docs]({{< ref "tyk-stack/tyk-manager/analytics/log-browser" >}})
 
-### Attaching Multiple Policies to the Keys
+#### Attaching Multiple Policies to the Keys
 [Docs]({{< ref "basic-config-and-security/security/security-policies/partitioned-policies" >}})
 
-### Set permissions for users logged via SSO (Tyk Identity Broker)
+#### Set permissions for users logged via SSO (Tyk Identity Broker)
 Added new option `sso_permission_defaults` in Dashboard config file. 
 Example:
 
@@ -196,64 +196,64 @@ Example:
 ```
 [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers" >}})
 
-### Set custom login pages for portal and dashboard
+#### Set custom login pages for portal and dashboard
 If you are using 3-rd party authentification like TIB, you maybe want to redirect from standard login pages to your own using following attributes in dashboard config: `sso_custom_login_url`, `sso_custom_portal_login_url`.
 
 [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers" >}})
 
-### Added new set of APIs for custom dashboard authentification
+#### Added new set of APIs for custom dashboard authentification
 Added new `/admin/sso` endpoint for custom integration. In fact, the same API is used by our own Tyk Identity Broker. 
 
 [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers/custom" >}})
 
 
-### Service discovery form improved with most common pre-defined templates
+#### Service discovery form improved with most common pre-defined templates
 
 Now you can pre-fill the form with most popular templates like consul or etcd.
 
-### RPC credentials renamed to Organization ID
+#### RPC credentials renamed to Organization ID
 Yay!
 
-### Replaced text areas with a code editors
+#### Replaced text areas with a code editors
 
 All multi-line text fields now replaced with a code editors.
 
-### Replace dropdowns with the live search component
+#### Replace dropdowns with the live search component
 
 All the dropdown lists now support live search, and work with a large number of elements (especially handy for API or Policiy lists).
 
-### Display user ID and email on when listing users
+#### Display user ID and email on when listing users
 
 The **Users list** now displays the **User ID** and **Email**.
 
-### Added search for portal developers
+#### Added search for portal developers
 
 We have added search for the users listed in the developer portal.
 
-### Key request email link to developer details
+#### Key request email link to developer details
 
 The email address in a **Key Request** from the **Developer Portal** is now a link to the relevant developer profile.
 
-### Country code in log browser links to geo report
+#### Country code in log browser links to geo report
 
 The country code in the log browser has been changed to a link to the geographic report.
 
-### Added support for HEAD methods in the Dashboard API Designer.
+#### Added support for HEAD methods in the Dashboard API Designer.
 
-### Redirect user to the login page if session is timed out.
+#### Redirect user to the login page if session is timed out.
 
-### When creating a portal API catalogue, you can now attach documentation without saving the catalogue first.
+#### When creating a portal API catalogue, you can now attach documentation without saving the catalogue first.
 
-### Fixed the` proxy.preserve_host_header` field when saved via the UI.
+#### Fixed the` proxy.preserve_host_header` field when saved via the UI.
 Previously, the field was available in the API definition, but got removed if the API was saved via the UI.
 
-### Fixed the port removal in service discovery properties.
+#### Fixed the port removal in service discovery properties.
 https://github.com/TykTechnologies/tyk-analytics-ui/issues/12
 
-### Prevent an admin user revoking their own permissions.
+#### Prevent an admin user revoking their own permissions.
 This is a  UI only fix, it is still allowable via the API (which is OK).
 
-### Other UX Improvements
+#### Other UX Improvements
 
 * Key pieces of data made accessible to quickly copy+paste
 * Improved help tips
@@ -263,23 +263,23 @@ This is a  UI only fix, it is still allowable via the API (which is OK).
 * Improved charts
 * Improved analytics search
 
-## <a name="pump"></a> Tyk Pump v0.4.2
+### <a name="pump"></a> Tyk Pump v0.4.2
 
-### Support added for Mongo SSL connections
+#### Support added for Mongo SSL connections
 
 See https://tyk.io/docs/configure/tyk-pump-configuration/ for a sample pump.conf file.
 
-## <a name="mdcb"></a> MDCB v1.4.0
+### <a name="mdcb"></a> MDCB v1.4.0
 Added support for Mutual TLS, mentioned by Gateway and Dashboard above. See [Docs]({{< ref "basic-config-and-security/security/mutual-tls#a-name-mdcb-a-mdcb" >}})
   
 Also fixed bug when Mongo connections became growing though the roof if client with wrong credentials tries to connect.
 
 
-## <a name="tib"></a>TIB v0.2
+### <a name="tib"></a>TIB v0.2
   
 Tyk Identity Broker now fully support LDAP search with complex filters! [Docs]({{< ref "advanced-configuration/integrate/3rd-party-identity-providers/ldap" >}})
 
-## <a name="upgrade"></a>Upgrading all new Components
+### <a name="upgrade"></a>Upgrading all new Components
 
 > **NOTE**: This release is fully compatible with the previous version, except that if you want to use new features, like Mutual TLS, you need to upgrade all the related components.
 
@@ -288,9 +288,6 @@ Cloud users will be automatically upgraded to the new release.
 Hybrid users should follow the upgrade instructions [here]({{< ref "upgrading-tyk#tyk-multi-cloud-gateway" >}}).
 
 Self-Managed users can download the new release packages from their usual repositories.
-
-
-
 
 
 [3]: /img/release-notes/tag_headers.png

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.5.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.5.md
@@ -9,14 +9,14 @@ aliases:
   - /release-notes/version-2.5/ 
 ---
 
-# <a name="new"></a>New in this Release:
+## <a name="new"></a>New in this Release:
 
 This release touches all our products and brings you numerous features and fixes. Here are the packages and their versions we are releasing today: Tyk Gateway v2.5.0, Tyk Dashboard v1.5.0, Tyk Pump v0.6.0, MDCB v1.5.0, TIB v0.3.
 
 
-# <a name="major-highlights"></a>Major Highlights
+## <a name="major-highlights"></a>Major Highlights
 
-## <a name="dashboard"></a>New Dashboard Look and Feel
+### <a name="dashboard"></a>New Dashboard Look and Feel
 
 Our Dashboard has had a UI overhaul, with the following improvements:
 
@@ -25,28 +25,28 @@ Our Dashboard has had a UI overhaul, with the following improvements:
 * Better feedback on errors and updates
 * Various UX improvements
 
-## <a name="sso"></a>SSO with OpenId Identity Providers
+### <a name="sso"></a>SSO with OpenId Identity Providers
 
 With TIB v0.3 we have made it possible to integrate any OpenID supported Identity provider with Tyk so you can configure Single Sign On (SSO), if the provider supports those.
 
-## <a name="search"></a>Searching API and Policies List
+### <a name="search"></a>Searching API and Policies List
 
 This long awaited feature has been added on the Dashboard UI.
 
-## <a name="versioning"></a>Default API Versioning
+### <a name="versioning"></a>Default API Versioning
 
 You can now specify a default API version when using a versioning strategy.
 
-## <a name="pump"></a>Tyk Pump with MDCB
+### <a name="pump"></a>Tyk Pump with MDCB
 
 We've added MDCB support in this release of Tyk Pump
 
-# Moar!
+## Moar!
 This release is packed with way more more cool stuff. Here are detailed release notes for each product:
 
-## <a name="gateway"></a>Tyk Gateway v2.5.0
+### <a name="gateway"></a>Tyk Gateway v2.5.0
 
-### New Relic Instrumentation Support
+#### New Relic Instrumentation Support
 
 We have added support for New Relic Instrumentation using:
 
@@ -54,7 +54,7 @@ We have added support for New Relic Instrumentation using:
 
 [Docs]({{< ref "basic-config-and-security/report-monitor-trigger-events/instrumentation" >}})
 
-### Default API Versioning
+#### Default API Versioning
 
 You can now specify a default API version, and it will be used if a version is not set via headers, or URL parameters. Use the new option:
 
@@ -62,7 +62,7 @@ You can now specify a default API version, and it will be used if a version is n
 
 [Docs]({{< ref "getting-started/key-concepts/versioning" >}})
 
-### Disable URL Encoding
+#### Disable URL Encoding
 
 You can disable URL encoding using a new boolean `http_server_options` setting:
  
@@ -70,14 +70,14 @@ You can disable URL encoding using a new boolean `http_server_options` setting:
 
 [Docs]({{< ref "tyk-oss-gateway/configuration#a-name-http-server-options-a-http-server-options" >}})
 
-### Enable Key Logging
+#### Enable Key Logging
 
 By default all key ids in logs are hidden. You can now turn it on if you want to see them for debugging reasons using the `enable_key_logging` option.
 
 [Docs]({{< ref "tyk-oss-gateway/configuration#a-name-enable-key-logging-a-enable-key-logging" >}})
 
 
-### Specify TLS Cipher Suites
+#### Specify TLS Cipher Suites
 
 We have added support for specifying allowed  SSL ciphers using the following option:
 
@@ -85,7 +85,7 @@ We have added support for specifying allowed  SSL ciphers using the following op
 
 [Docs]({{< ref "basic-config-and-security/security/tls-and-ssl" >}})
 
-## <a name="plugins"></a>Plugins Updates
+### <a name="plugins"></a>Plugins Updates
 
 * Coprocess plugins now have access to `config_data`
 * The JSVM `spec` object now has access to `APIID` and `OriginID` to reflect similar functionality of Coprocess plugins.
@@ -95,9 +95,9 @@ We have added support for specifying allowed  SSL ciphers using the following op
 [Plugin Data Structure Docs]({{< ref "plugins/supported-languages/rich-plugins/rich-plugins-data-structures" >}})
 
 
-## <a name="dashboard"></a>Tyk Dashboard v1.5.0
+### <a name="dashboard"></a>Tyk Dashboard v1.5.0
 
-### A Fresh Look and Feel
+#### A Fresh Look and Feel
 
 With this release we have refreshed the entire Dashboard UI with a new look-and-feel, bringing with it such improvements as:
 
@@ -106,47 +106,47 @@ With this release we have refreshed the entire Dashboard UI with a new look-and-
 * Better feedback on errors and updates
 * UX improvements
 
-### Search on API and Policy List Pages
+#### Search on API and Policy List Pages
 
 We have added API and Policy search functionality, which should help those with long lists.
 
 * [API Docs]({{< ref "tyk-apis/tyk-dashboard-api/api-definitions" >}})
 * [Policy Docs]({{< ref "tyk-apis/tyk-dashboard-api/portal-policies" >}})
 
-### A New, Interactive Getting Started Walkthrough
+#### A New, Interactive Getting Started Walkthrough
 
 We have swapped out the old Getting started tutorial and added a new interactive one, which should make it easier for new users to get started with the Dashboard UI.
 
-### Advanced URL Rewrites
+#### Advanced URL Rewrites
 
 We have extended the URL Rewrite plugin functionality by enabling users to create more advanced rewrite rules based on Header matches, Query string variable/value matches, Path part matches, (i.e. components of the path itself), Session metadata values, and Payload matches.
 
 [Docs]({{< ref "transform-traffic/url-rewriting" >}})
 
-### Portal Session Lifetime
+#### Portal Session Lifetime
 
 You can now control the portal session lifetime using the `portal_session_lifetime` config variable.
 
 [Docs](https://tyk.io/docs/configure/tyk-dashboard-configuration-options/)
 
-### Configure Port for WebSockets
+#### Configure Port for WebSockets
 
 We have added `notifications_listen_port` option to configure the port used by WebSockets for real-time notifications.
 
 [Docs]({{< ref "tyk-oss-gateway/configuration" >}})
 
-### Slug
+#### Slug
 
 Once set, the API slug will no longer be overridden when the API title is changed.
 
-### Custom Domain
+#### Custom Domain
 
 We have fixed the API URL if a custom domain is set.
 
 
-## <a name="pump"></a> Tyk Pump v0.5.0
+### <a name="pump"></a> Tyk Pump v0.5.0
 
-### Splunk Support
+#### Splunk Support
 
 We added support for forwarding analytics data to Splunk. A sample configuration is:
 
@@ -164,18 +164,18 @@ We added support for forwarding analytics data to Splunk. A sample configuration
 },
 ```
 
-### <a name="analytics"></a>Analytics Collection Capping
+#### <a name="analytics"></a>Analytics Collection Capping
 
 Detailed analytics collection capping is now enabled by default and configurable via the `collection_cap_enable` and `collection_cap_max_size_bytes` options.
 
 
 
-## <a name="mdcb"></a> MDCB v1.5.0
+### <a name="mdcb"></a> MDCB v1.5.0
 
 We've introduced long awaited support for using Tyk Pump in conjunction with MDCB to use any of services supported by Tyk Pump, like ElasticSearch, Splunk and etc. This works by setting `forward_analytics_to_pump` to true, which disables analytics processing by MDCB itself, and enables the forwarding of all data to Tyk Pump running inside your management environment.
 
 
-## <a name="tib"></a>TIB v0.3
+### <a name="tib"></a>TIB v0.3
   
 With this release, you now can use any OpenID Connect compatible provider with TIB. This means that you can use almost any Identity management solution, supporting OpenID, like Okta, Ping or Keycloak.
  
@@ -190,7 +190,7 @@ Use `SocialProvider` with the following options:
 }]
 ```
 
-## Packaging changes across all products
+### Packaging changes across all products
 
 New deb and rpm packages add the "tyk" user and group so that package files and directories would be owned by it and the process run with its effective uid and gid. In addition to this gateway PID now has to reside in its own sub-rundir due to this change, so that's created (and additionally managed by systemd where it's available), default pidfile location changed appropriately so that upgrade wouldn't require any config changes by the users. The gateway config file is now only readable and writable by the "tyk" user and group. This change is applied across all our products except Gateway: its changes scheduled to 2.6. 
 
@@ -199,11 +199,11 @@ The "default" init system files are not removed on upgrade/remove anymore so tha
 The bug with removal of init system files on upgrade in rpm-based systems is now fixed.
 
 
-## <a name="upgrade"></a>Upgrading all new Components
+### <a name="upgrade"></a>Upgrading all new Components
 
 For details on upgrading all Tyk versions, see [Upgrading Tyk](https://tyk.io/docs/upgrading-tyk/).
 
-## <a name="new"></a>Don't Have Tyk Yet?
+### <a name="new"></a>Don't Have Tyk Yet?
 
 Get started now, for free, or contact us with any questions.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.6.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.6.md
@@ -8,11 +8,11 @@ aliases:
     - /release-notes/version-2.6/
 ---
 
-# <a name="new"></a>New in this Release:
+## <a name="new"></a>New in this Release:
 
-## <a name="gateway"></a>Tyk Gateway v2.6.0
+### <a name="gateway"></a>Tyk Gateway v2.6.0
 
-### Organisation Level Rate Limiting
+#### Organisation Level Rate Limiting
 
 Endpoints Create organisation keys and 
 Add/update organisation keys now allow you to set rate limits at an organisation level. You will need to add the following fields in your create/add/update key request:
@@ -35,7 +35,7 @@ So, if you want to restrict an organisation rate limit to 100 requests per secon
 
 See the Keys section of the [Tyk Gateway REST API]({{< ref "tyk-gateway-api" >}}) Swagger doc for more details.
 
-### Keys hashing improvements
+#### Keys hashing improvements
 
 Now it is possible to do more operations with key by hash (when we set `"hash_keys":` to `true` in `tyk.conf`):
 
@@ -45,7 +45,7 @@ Now it is possible to do more operations with key by hash (when we set `"hash_ke
 and call it with the new optional query parameter `hashed=true`. So the new format is `GET /keys/{keyName}?hashed=true"`
 - also, we already have the same optional parameter for endpoint `DELETE /keys/{keyName}?hashed=true`
 
-### JSON schema validation
+#### JSON schema validation
 
 You can now use Tyk to verify user requests against a specified JSON schema and check that the data sent to your API by a consumer is in the right format. This means you can offload data validation from your application to us.
 
@@ -84,7 +84,7 @@ The schema must be a draft v4 JSON Schema spec, see http://json-schema.org/speci
 ```
 
 
-### New endpoint to get list of tokens generated for provided OAuth-client
+#### New endpoint to get list of tokens generated for provided OAuth-client
 
 `GET /oauth/clients/{apiID}/{oauthClientId}/tokens`
 
@@ -112,13 +112,13 @@ This endpoint allows you to retrieve a list of all current tokens and their expi
 
 You can control how long you want to store expired tokens in this list using `oauth_token_expired_retain_period ` which specifies the retain period for expired tokens stored in Redis. The value is in seconds, and the default value is `0`. Using the default value means expired tokens are never removed from Redis.
 
-### Creating OAuth clients with access to multiple APIs
+#### Creating OAuth clients with access to multiple APIs
 
 When creating a client using `POST /oauth/clients/create`, the `api_id` is now optional - these changes make the endpoint more generic. If you provide the `api_id` it works the same as in previous releases. If you don't provide the `api_id` the request uses policy access rights and enumerates APIs from their setting in the newly created OAuth-client. 
 
 At the moment this changes not reflected on Dashboard UI yet, as we going to do major OAuth improvements in 2.7
 
-### Certificate public key pinning
+#### Certificate public key pinning
 
 Certificate pinning is a feature which allows you to allow public keys used to generate certificates, so you will be protected in case an upstream certificate is compromised.
 
@@ -148,7 +148,7 @@ If you already have a certificate, and just need to get its public key, you can 
 
 **Note:** Upstream certificates now also have wildcard domain support
 
-### JQ transformations (experimental support)
+#### JQ transformations (experimental support)
 
 > This feature is experimental and can be used only if you compile Tyk yourself own using `jq` tag: `go build --tags 'jq'`
 
@@ -164,7 +164,7 @@ We have added two new plugins:
 Both have the same structure, similar to the rest of our plugins: 
 `{ "path": "<path>", "method": "<method>", "filter": "<content>" }`
 
-### Request Transforms
+#### Request Transforms
 Inside a request transform you can use following variables: 
 * `.body` - your current request body
 * `._tyk_context` - Tyk context variables. You can use it to access request headers as well.
@@ -175,7 +175,7 @@ Your JQ request transform should return an object in the following format:
 `body` is required, while `rewrite_headers` and `tyk_context` are optional.
 
 
-### Response Transforms 
+#### Response Transforms 
 Inside a response transform you can use following variables: 
 * `.body` - your current response body
 * `._tyk_context` - Tyk context variables. You can use it to access request headers as well.
@@ -186,7 +186,7 @@ Your JQ response transform should return an object in the following format:
 
 `body` is required, while `rewrite_headers` is optional.
 
-### Example
+#### Example
 ```
 "extended_paths": {
   "transform_jq": [{
@@ -205,7 +205,7 @@ Your JQ response transform should return an object in the following format:
 
 ## <a name="dashboard"></a>Tyk Dashboard v1.6.0
 
-### API categories
+#### API categories
 
 You can apply multiple categories to an API definition, and then filter by these categories on the API list page.
 
@@ -215,7 +215,7 @@ From an API perspective, categories are stored inside API definition `name` fiel
 
 Added new API `/api/apis/categories` to return list of all categories and belonging APIs.
 
-### Raw API Definition mode
+#### Raw API Definition mode
 
 Now you can directly edit a raw API definition JSON object directly from the API Designer, by selecting either the **Raw API Definition** or the **API Designer** at the top of the API Designer screen. 
 
@@ -223,17 +223,17 @@ Now you can directly edit a raw API definition JSON object directly from the API
 
 This feature comes especially handy if you need copy paste parts of one API to another, or if you need to access fields not yet exposed to the Dashboard UI.
 
-### Certificate public key pinning
+#### Certificate public key pinning
 
 You can configure certificate pinning on the **Advanced** tab of the API Designer, using a similar method to how you specify upstream client certificates.
 
 {{< img src="/img/release-notes/certificate_pinning.png" alt="Certificate Pinning" >}}
 
-### JSON schema validation
+#### JSON schema validation
 
 Reflecting the Tyk Gateway changes, on the Dashboard we have added a new **Validate JSON** plugin, which you can specify per URL, and can set both a schema, and custom error code, if needed.
 
-### Improved key hashing support
+#### Improved key hashing support
 
 The Tyk Dashboard API reflects changes made in the v2.6.0 Gateway API, and now supports more operations with key by hash (when we have set `"hash_keys":` to ` true` in `tyk_analytics.conf`):
 
@@ -243,7 +243,7 @@ The Tyk Dashboard API reflects changes made in the v2.6.0 Gateway API, and now s
 - endpoint `DELETE /apis/{apiId}/keys?hashed=true` can delete a key by its hash, but its functionality is disabled by default, unless you set `enable_delete_key_by_hash` boolean option inside the Dashboard configuration file. 
 
 
-### Key requests management API now supports OAuth
+#### Key requests management API now supports OAuth
 
 For this release we've improved our developer portal APIs to fully support an OAuth2.0 based workflow. Developers using your API will now be able to register OAuth clients and manage them.
 
@@ -312,7 +312,7 @@ was approved, i.e.:
 },
 ```
 
-### New endpoints to get tokens per OAuth client
+#### New endpoints to get tokens per OAuth client
 
 These endpoints allow you to get a list of all current tokens issued for provided OAuth client ID:
 
@@ -320,14 +320,14 @@ These endpoints allow you to get a list of all current tokens issued for provide
 - `GET /apis/oauth/{oauthClientId}/tokens` when the API ID is unknown or OAuth-client provides access to several APIs
 
 
-### Renamed the response `_id` field to `id` in List Key Requests
+#### Renamed the response `_id` field to `id` in List Key Requests
 
 We have renamed the response `_id` field when retrieving a list of key requests to `id`.
 
 See [List Key Requests]({{< ref "tyk-apis/tyk-dashboard-api/manage-key-requests#list-key-requests" >}}) for more details.
 
 
-### Developers can request a password reset email
+#### Developers can request a password reset email
 
 If a developer forgets their password, they can now request a password reset email from the Developer Portal Login screen.
 
@@ -335,7 +335,7 @@ If a developer forgets their password, they can now request a password reset ema
 
 See [Developer Profiles]({{< ref "tyk-developer-portal/tyk-portal-classic/developer-profiles#reset-developer-password" >}}) for more details.
 
-### SSO API custom email support
+#### SSO API custom email support
 
 Now you can set email address for users logging though the Dashboard SSO API, by adding an "Email" field to the JSON payload which you sent to `/admin/sso` endpoint. For example:
 ```
@@ -350,7 +350,7 @@ admin-auth: 12345
 }
 ```
 
-### Set Catalogue settings for each individual API 
+#### Set Catalogue settings for each individual API 
 
 Now you can override the global catalogue settings and specify settings per catalogue. 
 The Catalogue object now has `config` field, with exactly same structure as Portal Config, except new `override` boolean field. 
@@ -358,7 +358,7 @@ If set, Catalogue settings will override global ones.
 
 At the moment the following options can be overriden: `Key request fields`, `Require key approval` and `Redirect on key request` (with `Redirect to` option as well).
 
-### {{<fn>}}Blocklist{{</fn>}} IP Support
+#### {{<fn>}}Blocklist{{</fn>}} IP Support
 
 Tyk allows you to block IP Addresses, which is located in the **Advanced Options** tab in the **Endpoint Designer**.
 
@@ -368,18 +368,18 @@ Tyk allows you to block IP Addresses, which is located in the **Advanced Options
 
 With this release TIB joins the Tyk product line as a first class citizen and is now distributed via packages and [Docker image](https://hub.docker.com/r/tykio/tyk-identity-broker/).
 
-### Support for SSO API email field
+#### Support for SSO API email field
 If IDP provides a user email, it should be passed to the Dashboard SSO API, and you should see it in the Dashboard UI.
 
-### Improved support for local IDPs
+#### Improved support for local IDPs
 If you run a local IDP, like Ping, with an untrusted SSL certificate, you can now turn off SSL verification by setting `SSLInsecureSkipVerify` to `true` in the TIB configuration file. 
 
-### Added Redis TLS support
+#### Added Redis TLS support
 To enable set `BackEnd.UseSSL` and, optionally, `BackEnd.SSLInsecureSkipVerify`.
 
 ## <a name="tib"></a>Tyk Pump v0.5.2
 
-### Redis TLS support
+#### Redis TLS support
 Added new `redis_use_ssl` and `redis_ssl_insecure_skip_verify` options.
 
 
@@ -391,7 +391,7 @@ Whether it's the open source API Gateway, or Dashboard, Pump, Sink and Tyk Ident
 
 ## <a name="mdcb"></a>MDCB v1.5.3
 
-### Redis TLS support
+#### Redis TLS support
 Added new `redis_use_ssl` and `redis_ssl_insecure_skip_verify` options.
 
 ## <a name="upgrade"></a>Upgrading all new Components

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.7.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.7.md
@@ -8,11 +8,11 @@ aliases:
   - /release-notes/version-2.7/ 
 ---
 
-# <a name="new"></a>New in this Release:
+## <a name="new"></a>New in this Release:
 
-## <a name="gateway"></a>Tyk Gateway v2.7.0
+### <a name="gateway"></a>Tyk Gateway v2.7.0
 
-### Performance improvements
+#### Performance improvements
 
 
 > **TLDR**
@@ -32,7 +32,7 @@ In 2.7 we optimised the connection pool between Tyk and upstream, and previously
 
 To get the benefit of optimised connection pooling, ensure that `close_connections` is set to `false`, which enables keep-alive between Tyk and Upstream.
 
-### Custom key hashing algorithms
+#### Custom key hashing algorithms
 
 Key hashing is a security technique introduced inside Tyk a long time ago, which allows you to prevent storing your API tokens in database, and instead, only store their hashes. Only API consumers have access to their API tokens, and API owners have access to the hashes, which gives them access to usage and analytics in a secure manner. Time goes on, algorithms age, and to keep up with the latest security trends, we introduce a way to change algorithms used for key hashing.
 
@@ -51,9 +51,9 @@ Technically wise, it is implemented by new key generation algorithms, which now 
 Changing hashing algorithm is entirely backward compatible. All your existing keys will continue working with the old `murmur32` hashing algorithm, and your new keys will use algorithm specified in Tyk config. Moreover, changing algorithms is also backward compatible, and Tyk will maintain keys multiple hashing algorithms without any issues.
 
 
-## Tyk Dashboard v1.7.0
+### Tyk Dashboard v1.7.0
 
-### User Groups
+#### User Groups
 
 Instead of setting permissions per user, you can now [create a user group]({{< ref "basic-config-and-security/security/dashboard/create-user-groups" >}}), and assign it to multiple users. It works for Single Sign-On too, just specify group ID during [SSO API]({{< ref "tyk-apis/tyk-dashboard-admin-api/sso" >}}) flow.
 
@@ -63,7 +63,7 @@ To manage user groups, ensure that you have either admin or “user groups” pe
 
 From an API standpoint, user groups can be managed by [new Dashboard API]({{< ref "tyk-apis/tyk-dashboard-api/user-groups" >}}). The User object now has a new `group_id` field, and if it is specified, all permissions will be inherited from the specified group. [SSO API]({{< ref "tyk-apis/tyk-dashboard-admin-api/sso" >}}) has been updated to include `group_id` field as well.
 
-### Added SMTP support
+#### Added SMTP support
 Now you can configure the Dashboard to send transactional emails using your SMTP provider. See [Outbound Email Configuration]({{< ref "configure/outbound-email-configuration" >}}) for details.
 
 ## <a name="upgrade"></a>Upgrading all new Components

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.0.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.0.md
@@ -6,7 +6,9 @@ aliases:
     - /release-notes/version-3.0/
 ---
 
-### Version changes and LTS releases
+## Release Highlights
+
+#### Version changes and LTS releases
 
 We have bumped our major Tyk Gateway version from 2 to 3, a long overdue change as we’ve been on version 2 for 3 years. We have also changed our Tyk Dashboard major version from 1 to 3, and from now on it will always be aligned with the Tyk Gateway for major and minor releases. The Tyk Pump has also now updated to 1.0, so we can better indicate major changes in future. 
 
@@ -16,7 +18,7 @@ Additionally we are introducing Long Term Releases (also known as LTS).
 Read more about this changes in our blogpost: https://tyk.io/introducing-long-term-support-some-changes-to-our-release-process-product-versioning/
 
 
-### Universal Data Graph and GraphQL
+#### Universal Data Graph and GraphQL
 
 Tyk now supports GraphQL **natively**. This means Tyk doesn’t have to use any external services or process for any GraphQL middleware. You can securely expose existing GraphQL APIs using our GraphQL core functionality.
 
@@ -28,46 +30,38 @@ With the Universal Data Graph Tyk becomes your central integration point for all
 
 Read more about the [GraphQL]({{< ref "graphql" >}}) and [Universal Data Graph]({{< ref "universal-data-graph" >}})
 
-
-
-
-
-
-
-
-### Using external secret management services
+#### Using external secret management services
 
 Want to reference secrets from a KV store in your API definitions? We now have native Vault & Consul integration. You can even pull from a tyk.conf dictionary or environment variable file.
 
 [Read more]({{< ref "tyk-configuration-reference/kv-store" >}})
 
-
-### Co-Process Response Plugins
+#### Co-Process Response Plugins
 
 We added a new middleware hook allowing middleware to modify the response from the upstream. Using response middleware you can transform, inspect or obfuscate parts of the response body or response headers, or fire an event or webhook based on information received by the upstream service.
 
 At the moment the Response hook is supported for [Python and gRPC plugins]({{< ref "plugins/supported-languages/rich-plugins/rich-plugins-work#overriding-response" >}}).
 
 
-### Enhanced Gateway health check API
+#### Enhanced Gateway health check API
 
 Now the standard Health Check API response include information about health of the dashboard, redis and mdcb connections.
 You can configure notifications or load balancer rules, based on new data. For example, you can be notified if your Tyk Gateway can’t connect to the Dashboard (or even if it was working correctly with the last known configuration).
 
 [Read More]({{< ref "planning-for-production/ensure-high-availability/health-check" >}})
 
-### Enhanced Detailed logging
+#### Enhanced Detailed logging
 Detailed logging is used in a lot of the cases for debugging issues. Now as well as enabling detailed logging globally (which can cause a huge overhead with lots of traffic), you can enable it for a single key, or specific APIs. 
 
 New detailed logging changes are available only to our Self-Managed customers currently.
 
 [Read More]({{< ref "tyk-stack/tyk-pump/useful-debug-modes#enabling-detailed-logging" >}})
 
-### Better Redis failover
+#### Better Redis failover
 
 Now, if Redis is not available, Tyk will be more gracefully handle this scenario, and instead of simply timing out the Redis connection, will dynamically disable functionality which depends on redis, like rate limits or quotas, and will re-enable it back once Redis is available. The Tyk Gateway can even be started without Redis, which makes possible scenarios, such as when the Gateway proxies Redis though itself, like in a Redis Sentinel setup.
 
-### Ability to shard analytics to different data-sinks
+#### Ability to shard analytics to different data-sinks
 
 In a multi-org deployment, each organisation, team, or environment might have their preferred analytics tooling. At present, when sending analytics to the Tyk Pump, we do not discriminate analytics by org - meaning that we have to send all analytics to the same database - e.g. MongoDB. Now the Tyk Pump can be configured to send analytics for different organisations to different places. E.g. Org A can send their analytics to MongoDB + DataDog. But Org B can send their analytics to DataDog + expose the Prometheus metrics endpoint.
 
@@ -77,25 +71,24 @@ This change requires updating to new Tyk Pump 1.0
 
 [Read More]({{< ref "tyk-pump/configuration" >}})
 
-### 404 Error logging - unmatched paths
+#### 404 Error logging - unmatched paths
 
 Concerned that client’s are getting a 404 response? Could it be that the API definition or URL rewrites have been misconfigured? Telling Tyk to track 404 logs, will cause the Tyk Gateway to produce error logs showing that a particular resource has not been found. 
 
 The feature can be enabled by setting the config `track_404_logs` to `true` in the gateway's config file.
 
+## Changelog
 
-### Fixes
+#### Fixes
 
 - Fixed the bug when tokens created with non empty quota, and quota expiration set to `Never`, were treated as having unlimited quota. Now such tokens will stop working, once initial quota is reached. 
 
-
-
-### Updated Versions
+## Updated Versions
 
 - Tyk Gateway 3.0
 - Tyk Pump 1.0
 
-### Upgrading From Version 2.9
+## Upgrading From Version 2.9
 
 No specific actions required.
 If you are upgrading from version 2.8, pls [read this guide]({{< ref "product-stack/tyk-gateway/release-notes/archived-releases/version-2.9.md" >}})

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.1.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.1.md
@@ -6,9 +6,9 @@ aliases:
     - /release-notes/version-3.1/
 ---
 
-## What’s new?
+## Release Highlights
 
-### Identity Management UX and SAML support
+#### Identity Management UX and SAML support
 You will notice that the experience for creating a new profile in the Identity management section of the dashboard was changed to a ‘wizard’ approach which reduces the time it takes to get started and configure a profile. 
 In addition, users are now able to use SAML for the dashboard and portal login, whether you use TIB(Tyk Identity Broker) internally or externally of the dashboard.
 
@@ -16,18 +16,18 @@ This follows the recent changes that we have made to embed TIB (Tyk Identity Bro
 
 To learn more [see the documentation](https://tyk.io/docs/getting-started/tyk-components/identity-broker/)
 
-## UDG (Universal Data Graph) & GraphQL
-### Schema Validation
+#### UDG (Universal Data Graph) & GraphQL
+##### Schema Validation
 
 For any GraphQL API that is created via Dashboard or through our API, the GraphQL schema is now validated before saving the definition. Instant feedback is returned in case of error.
 
-### Sync / Update schema with upstream API (Proxy Only Mode)
+##### Sync / Update schema with upstream API (Proxy Only Mode)
 
 If you’ve configured just a proxy GraphQL API, you can now keep in sync the upstream schema with the one from the API definition, just by clicking on the `Get latest version` button on the `Schema` tab from API Designer
 
 Docs [here](https://tyk.io/docs/graphql/syncing-schema/)
 
-### Debug logs
+##### Debug logs
 
 You can now see what responses are being returned by the data sources used while configuring a UDG (universal data graph). These can be seen by calling the `/api/debug` API or using the playground tab within API designer.
 
@@ -48,20 +48,20 @@ Example:
 
 Docs [here](https://tyk.io/docs/graphql/graphql-playground/)
 
-## Portal
-### GraphQL Documentation
+#### Portal
+##### GraphQL Documentation
 
 Documentation for the GraphQL APIs that you are exposing to the portal is available now through a GraphQL Playground UI component, same as on the playground tab of API Designer.
 
 Also to overcome the CORS issues that you might encounter while testing documentation pages on the portal, we have pre-filled the CORS settings section in API Designer with explicit values from the start. All you need to do is to check the “Enable CORS” option.
 
-### Portal - API key is hidden in email
+##### Portal - API key is hidden in email
 You now have the option to hide the API key in the email generated after you approve the key request for a developer.
 
 [Docs here](https://tyk.io/docs/tyk-developer-portal/key-requests/)
 
 
-## Bug Fixes
+## Changelog
 The 3.1 version includes the fixes that are part of 3.0.1. 
 https://github.com/TykTechnologies/tyk/releases/tag/v3.0.1
 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-3.2.md
@@ -6,9 +6,9 @@ aliases:
     - /release-notes/version-3.2/
 ---
 
-# What’s new?
+## Release Highlights
 
-## GraphQL and UDG improvements
+#### GraphQL and UDG improvements
 
 We've updated the GraphQL functionality of our [Universal Data Graph]({{< ref "universal-data-graph" >}}). You’re now able to deeply nest GraphQL & REST APIs and stitch them together in any possible way.
 
@@ -22,18 +22,18 @@ Query-depth limits can now be configured on a per-field level.
 
 If you’re using GraphQL upstream services with UDG, you’re now able to forward upstream error objects through UDG so that they can be exposed to the client.
 
-## Go response plugins
+#### Go response plugins
 
 With Go response plugins you are now able to modify and create a full request round trip made through the Tyk Gateway. 
 Find out more about [plugins]({{< ref "plugins" >}}) and how to write [Go response plugins]({{< ref "plugins/supported-languages/golang#using-a-go-response-plugin" >}}).
 
-# Bug fixes and minor changes
+## Changelog
 
 In addition to the above, version 3.2 includes all the fixes that are part of 3.0.5
 https://github.com/TykTechnologies/tyk/releases/tag/v3.0.5
 
-# Updated Versions
+## Updated Versions
 Tyk Gateway 3.2
 
-# Upgrade process
+## Upgrade process
 If you already have GraphQL or UDG APIs you need to follow this upgrade guide https://tyk.io/docs/graphql/migration-guide/

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.0.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.0.md
@@ -6,7 +6,9 @@ aliases:
     - /release-notes/version-4.0/
 ---
 
-## GraphQL federation
+## Release Highlights
+
+#### GraphQL federation
 
 As we know, ease-of-use is an important factor when adopting GraphQL. Modern enterprises have dozens of backend services and need a way to provide a unified interface for querying them. Building a single, monolithic GraphQL server is not the best option. It is hard to maintain and leads to a lot of dependencies and over-complication.
 
@@ -16,7 +18,7 @@ To remedy this, Tyk 4.0 offers GraphQL federation that allows the division of Gr
 
 [Subgraphs and Supergraphs docs]({{< ref "/content/getting-started/key-concepts/graphql-federation.md#subgraphs-and-supergraphs" >}})
 
-## GraphQL subscriptions
+#### GraphQL subscriptions
 
 Subscriptions are a way to push data from the server to the clients that choose to listen to real-time messages from the server, using the WebSocket protocol. There is no need to enable subscriptions separately; Tyk supports them alongside GraphQL as standard.
 
@@ -24,16 +26,18 @@ With release 4.0, users can federate GraphQL APIs that support subscriptions. Fe
 
 [Subscriptions docs]({{< ref "/content/getting-started/key-concepts/graphql-subscriptions.md" >}})
 
-## Other minor changes
+## Changelog
+
 - Now it is possible to configure GraphQL upstream authentification, in order for Tyk to work with its schema
 - JWT scopes now support array and comma delimeters
 - Go plugins can be attached on per-endpoint level, similar to virtual endpoints
 
-# Updated Versions
+## Updated Versions
+
 Tyk Gateway 4.0
 Tyk Pump 1.5
 
-# Upgrade process
+## Upgrade process
 
 Follow the [standard upgrade guide]({{< ref "/content/upgrading-tyk.md" >}}), there are no breaking changes in this release.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.1.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.1.md
@@ -6,9 +6,9 @@ aliases:
     - /release-notes/version-4.1/
 ---
 
-# Major features
+## Release Highlights
 
-## OpenAPI as a native API definition format
+#### OpenAPI as a native API definition format
 Tyk has always had a proprietary specification for defining APIs. From Tyk v4.1 we now support defining APIs using the Open API Specification (OAS) as well, which can offer significant time and complexity savings. [This is an early access capability]({{< ref "frequently-asked-questions/using-early-access-features" >}}).
 
 As we extend our OAS support, we would very much like your feedback on how we can extend and update to best meet your needs: .
@@ -16,7 +16,7 @@ As we extend our OAS support, we would very much like your feedback on how we ca
 This capability is available in both the open source and paid versions of Tyk. See our [High Level Concepts]({{< ref "getting-started/key-concepts/high-level-concepts" >}}) for more details, or jump to [OAS Getting Started documentation]({{< ref "getting-started/using-oas-definitions/create-an-oas-api" >}}).
 
 
-## MDCB Synchroniser
+#### MDCB Synchroniser
 
 Tyk Gateway v4.1 enables an improved synchroniser functionality within Multi Data Centre Bridge (MDCB) v2.0. Prior to this release, the API keys, certificates and OAuth clients required by worker Gateways were synchronised from the controller Gateway on-demand. With Gateway v4.1 and MDCB v2.0 we introduce proactive synchronisation of these resources to the worker Gateways when they start up.
  
@@ -24,7 +24,7 @@ This change improves resilience in case the MDCB link or controller Gateway is u
  
 Changes to keys, certificates and OAuth clients are still synchronised to the worker Gateways from the controller when there are changes and following any failure in the MDCB link.
 
-## Go Plugin Loader
+#### Go Plugin Loader
 When upgrading your Tyk Installation you need to re-compile your plugin with the new version. At the moment of loading a plugin, the Gateway will try to find a plugin with the name provided in the API definition. If none is found then it will fallback to search the plugin file with the name: `{plugin-name}_{Gw-version}_{OS}_{arch}.so`
 
 From v4.1.0 the plugin compiler automatically names plugins with the above naming convention. It enables you to have one directory with different versions of the same plugin. For example:
@@ -34,10 +34,10 @@ From v4.1.0 the plugin compiler automatically names plugins with the above namin
 
 So, if you upgrade from Tyk v4.1.0 to v4.2.0 you only need to have the plugins compiled for v4.2.0 before performing the upgrade.
 
-# Changelog
+## Changelog
 
-## Tyk Gateway
-### Added
+#### Tyk Gateway
+##### Added
 - Added support for new OAS API definition format
 - Added support for headers on subgraph level for federated GraphQL APIs
 - Added support for interfaces implementing interfaces in GQL schema editor
@@ -51,11 +51,11 @@ So, if you upgrade from Tyk v4.1.0 to v4.2.0 you only need to have the plugins c
 - Added support for introspecting schemas with interfaces implementing interfaces for proxy only GQL
 - Added support for input coercion in lists for GraphQL
 - Added support for repeatable directives for GraphQL
-### Changed
+##### Changed
 - Generate API ID when API ID is not provided while creating API. 
 - Updated the Go plugin loader to load the most appropriate plugin bundle, honouring Tyk version, architecture and OS
 - When a GraphQL query with a @skip directive is sent to the upstream it will no longer return “null” for the skipped field, but remove the field completely from the response
-### Fixed
+##### Fixed
 - Fixed a bug where the MDCB worker Gateway could become unresponsive when a certificate is added in the Tyk Dashboard
 - Fixed an issue with the calculation of TTL for keys in an MDCB deployment such that TTL could be different between worker and controller Gateways
 - Fixed a bug when using Open ID where quota was not tracked correctly
@@ -63,11 +63,11 @@ So, if you upgrade from Tyk v4.1.0 to v4.2.0 you only need to have the plugins c
 - Fixed an issue where schema merging in GraphQL federation could fail depending on the order or resolving subgraph schemas and only first instance of a type and its extension would be valid. Subgraphs are now individually normalised before a merge is attempted and all extensions that are possible in the federated schema are applied.
 - Fixed an issue with accessing child properties of an object query variable for GraphQL where query {{.arguments.arg.foo}} would return "{ "foo":"123456" }" instead of "123456"
 
-# Updated Versions
+## Updated Versions
 Tyk Gateway 4.1
 Tyk MDCB 2.0.1
 
-# Upgrade process
+## Upgrade process
 
 Follow the [standard upgrade guide]({{< ref "/content/upgrading-tyk.md" >}}), there are no breaking changes in this release.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.2.md
@@ -6,11 +6,11 @@ aliases:
     - /release-notes/version-4.2/
 ---
 
-# Major features
+## Release Highlights
 
-## GraphQL Federation improvements
+#### GraphQL Federation improvements
 
-### Changed GUI in Universal Data Graph configuration section.
+##### Changed GUI in Universal Data Graph configuration section.
 
 A new GUI introduces enhancements to the user experience and more consistent user journey for UDG. 
 This change does not yet cover all possible use cases and is released with a feature flag. To enable the new GUI, analytics.conf needs the following setting:
@@ -31,8 +31,8 @@ What’s possible with this change:
 
 > Note: Full configuration of new Universal Data Graph is not yet possible in the GUI, however any UDGs created earlier will not be broken and will work as previously. 
 
-## Changes to federation entities
-### Defining the base entity
+#### Changes to federation entities
+##### Defining the base entity
 Entities must be defined with the `@key` directive. The fields argument must reference a field by which the entity can be uniquely identified. Multiple primary keys are possible. For example:
 
 Subgraph 1 (base entity):
@@ -44,7 +44,7 @@ type MyEntity @key(fields: "id") @key(fields: "name") {
 ```
  Attempting to extend a non-entity with an extension that includes the @key directive or attempting to extend a base entity with an extension that does not include the @key directive will both result in errors.
 
-### Entity stubs
+##### Entity stubs
 
 Entities cannot be shared types (be defined in more than one single subgraph).
 If one subgraph references a base entity (an entity defined in another subgraph), that reference must be declared as a stub (stubs look like an extension without any new fields in federation v1). This stub would contain the minimal amount of information to identify the entity (referencing exactly one of the primary keys on the base entity regardless of whether there are multiple primary keys on the base entity). For example, a stub for MyEntity from Subgraph 1 (defined above):
@@ -56,21 +56,21 @@ extend type MyEntity @key(fields: "id") {
 }
 ```
 
-### Supergraph extension orphans
+##### Supergraph extension orphans
 It is now possible to define an extension for a type in a subgraph that does not define the base type.
 However, if an extension is unresolved (an extension orphan) after an attempted federation, the federation will fail and produce an error.
 
-### Improved Dashboard UI and error messages
+##### Improved Dashboard UI and error messages
 GraphQL-related (for example when federating subgraphs into a supergraph) errors in the Dashboard UI will show a lean error message with no irrelevant prefixes or suffixes.
 
 Changed the look & feel of request logs in Playground tab for GraphQL APIs. New component presents all logs in a clearer way and is easier to read for the user
 
-### Shared types
+##### Shared types
 Types of the same name can be defined in more than one subgraph (a shared type). This will no longer produce an error if each definition is identical.
 Shared types cannot be extended outside of the current subgraph, and the resolved extension must be identical to the resolved extension of the shared type in all other subgraphs (see subgraph normalisation notes). Attempting to extend a shared type will result in an error.
 The federated supergraph will include a single definition of a shared type, regardless of how many times it has been identically defined in its subgraphs.
 
-### Subgraph normalisation before federation
+##### Subgraph normalisation before federation
 Extensions of types whose base type is defined in the same subgraph will be resolved before an attempt at federation. A valid example involving a shared type:
 
 Subgraph 1:
@@ -96,40 +96,40 @@ enum Example {
  
 The enum named “Example” defined in Subgraph 1 would resolve to be identical to the same-named enum defined in Subgraph 2 before federation takes place. The resulting supergraph would include a single definition of this enum.
 
-### Validation
+##### Validation
 Union members must be both unique and defined.
 Types must have bodies, e.g., enums must contain at least one value; inputs, interfaces, or objects must contain at least one field
 
-## OpenAPI 
+#### OpenAPI 
 Added support for the Request Body Transform middleware, for new Tyk OAS API Definitions.
 
-## Universal Data Graph
+#### Universal Data Graph
 
 Added support for Kafka as a data source in Universal Data Graph. Configuration allows the user to provide multiple topics and broker addresses.
 
-# Changelog
+## Changelog
 
-## Tyk Gateway
-### Added
+#### Tyk Gateway
+##### Added
 - Added support for Kafka as a data source in Universal Data Graph.
 - Adding a way to defining the base GraphQL entity via @key directive
 - It is now possible to define an extension for a type in a subgraph that does not define the base type.
 - Added support for the Request Body Transform middleware, for the new Tyk OAS API Definition
 - Session lifetime now can be controled by Key expiration, e.g. key removed when it is expired. Enabled by setting `session_lifetime_respects_key_expiration` to `true`
-### Changed
+##### Changed
 - Generate API ID when API ID is not provided while creating API. 
 - Updated the Go plugin loader to load the most appropriate plugin bundle, honouring the Tyk version, architecture and OS
 - When GraphQL query with a @skip directive is sent to the upstream it will no longer return “null” for the skipped field, but remove the field completely from the response
 - Added validation to Union members - must be both unique and defined.
-### Fixed
+##### Fixed
 - Fixed an issue where the Gateway would not create the circuit breaker events (BreakerTripped and BreakerReset) for which the Tyk Dashboard offers webhooks.
 - Types of the same name can be defined in more than one subgraph (a shared type). This will no longer produce an error if each definition is exactly identical.
 - Apply Federation Subgraph normalisation do avoid merge errors. Extensions of types whose base type is defined in the same subgraph will be resolved before an attempt at federation.
 
-# Updated Versions
+## Updated Versions
 Tyk Gateway 4.2
 
-# Upgrade process
+## Upgrade process
 
 Follow the [standard upgrade guide]({{< ref "/content/upgrading-tyk.md" >}}), there are no breaking changes in this release.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.3.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.3.md
@@ -6,19 +6,19 @@ aliases:
     - /release-notes/version-4.3/
 ---
 
-## Major features
+## Release Highlights
 
-### Mock Responses with Tyk OAS API Definitions
+#### Mock Responses with Tyk OAS API Definitions
 
 Does your Tyk OAS API Definition define examples or a schema for your path responses? If so, starting with Tyk v4.3, Tyk can use those configurations to mock your API responses, enabling your teams to integrate easily without being immediately dependent on each other. Check it out! [Mock Responses Documentation]({{< ref "/content/getting-started/using-oas-definitions/mock-response.md" >}})
 
-### External OAuth - 3rd party OAuth IDP integration
+#### External OAuth - 3rd party OAuth IDP integration
 
 If you’re using a 3rd party IDP to generate tokens for your OAuth applications, Tyk can now validate the generated tokens by either performing JWT validation or by communicating with the authorisation server and executing token introspection. 
 
 This can be achieved by configuring the new External OAuth authentication mechanism. Find out more here [External OAuth Integration]({{< ref "/content/basic-config-and-security/security/authentication-authorization/ext-oauth-middleware.md" >}})
 
-### Updated the Tyk Gateway version of Golang, to 1.16.
+#### Updated the Tyk Gateway version of Golang, to 1.16.
 
 **Our Gateway is using Golang 1.16 version starting with 4.3 release. This version of the Golang release deprecates x509 commonName certificates usage. This will be the last release where it's still possible to use commonName, users need to explicitly re-enable it with an environment variable.**
 
@@ -26,7 +26,7 @@ The deprecated, legacy behavior of treating the CommonName field on X.509 certif
 
 Note that if the CommonName is an invalid host name, it's always ignored, regardless of GODEBUG settings. Invalid names include those with any characters other than letters, digits, hyphens and underscores, and those with empty labels or trailing dots.
 
-### Improved GQL security
+#### Improved GQL security
 
 4.3 adds two important features that improve security settings for GraphQL APIs in Tyk.
 
@@ -36,9 +36,9 @@ Note that if the CommonName is an invalid host name, it's always ignored, regard
 
 ## Changelog
 
-### Tyk Gateway
+#### Tyk Gateway
 
-#### Added
+##### Added
 - Minor modifications to the Gateway needed for enabling support for Graph Mongo Pump.
 - Added header `X-Tyk-Sub-Request-Id` to each request dispatched by federated supergraph and Universal Data Graph, so that those requests can be distinguished from requests directly sent by consumers.
 - Added a functionality that allows to block introspection for any GraphQL API, federated supergraph and Universal Data Graph (currently only supported via Gateway, UI support coming in the next release).
@@ -46,7 +46,7 @@ Note that if the CommonName is an invalid host name, it's always ignored, regard
 - Added new middleware that can be used with HTTP APIs to set up persisted queries for GraphQL upstreams.
 - Added support for two additional subscription protocols for GraphQL subscriptions. Default protocol used between the gateway and upstream remains to be `graphql-ws`, two additional protocols are possible to configure and use: `graphql-transport-ws` and `SSE`.
 
-#### Changed
+##### Changed
 
 Updated the Tyk Gateway version of Golang, to 1.16. 
 
@@ -56,7 +56,7 @@ The deprecated, legacy behavior of treating the CommonName field on X.509 certif
 
 Note that if the CommonName is an invalid host name, it's always ignored, regardless of GODEBUG settings. Invalid names include those with any characters other than letters, digits, hyphens and underscores, and those with empty labels or trailing dots.
 
-#### Fixed
+##### Fixed
 
 - Fixed an issue where introspection query was returning a wrong response in cases where introspection query had additional objects.
 - Fixed an issue where gateway was crashing when a subscription was started while no datasource was connected to it.


### PR DESCRIPTION
[Dx 902] Remove H1 headings from GW Release Notes < 5.x (#3740)

* update RN headings for GW versions < 5.x
---------

Co-authored-by: Simon Pears <simon@tyk.io>