### PR TITLE
Merging to release-4.1: [DX-910] Remove remaining H1 headers from release-4.2 to improve searches & SEO (#3784)

### DIFF
--- a/tyk-docs/content/api-management/api-management.md
+++ b/tyk-docs/content/api-management/api-management.md
@@ -55,7 +55,7 @@ Which one is right for your organisation depends on your requirements and prefer
 [15]: /docs/basic-config-and-security/security/dashboard/organisations/
 
 
-# Licensing
+## Licensing
 ### Open Source (OSS)
 The Tyk Gateway is the backbone of all our solutions.  You can deploy it for free, forever.
 


### PR DESCRIPTION
[DX-910] Remove remaining H1 headers from release-4.2 to improve searches & SEO (#3784)

remove H1 headings from api-management

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-910]: https://tyktech.atlassian.net/browse/DX-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ