### PR TITLE
[DX-973]fix warning  DEPRECATED: Kind taxonomyterm

### DIFF
--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -4,7 +4,7 @@ title = "Tyk Documentation"
 theme = "tykio"
 MetaDataFormat = "yaml"
 enableGitInfo = true
-disableKinds = ["taxonomy"]
+disableKinds = ["term","taxonomy"]
 canonifyURLs = false
 timeout = "60s"
 [params]

--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -4,7 +4,7 @@ title = "Tyk Documentation"
 theme = "tykio"
 MetaDataFormat = "yaml"
 enableGitInfo = true
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy"]
 canonifyURLs = false
 timeout = "60s"
 [params]


### PR DESCRIPTION
[DX-710]

<img width="798" alt="Screenshot 2024-01-17 at 08 37 15" src="https://github.com/TykTechnologies/tyk-docs/assets/8012032/02a4b26d-39c3-4e69-b513-8879936713d1">
Fix hugo warning :WARN  DEPRECATED: Kind "taxonomyterm" used in disableKinds is deprecated, use "taxonomy" 

[DX-710]: https://tyktech.atlassian.net/browse/DX-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ