### PR TITLE
Merging to release-5.2: [DX-973]fix warning  DEPRECATED: Kind taxonomyterm (#3932)

### DIFF
--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -4,7 +4,7 @@ title = "Tyk Documentation"
 theme = "tykio"
 MetaDataFormat = "yaml"
 enableGitInfo = true
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["term","taxonomy"]
 canonifyURLs = false
 timeout = "60s"
 [params]


### PR DESCRIPTION
[DX-973]fix warning  DEPRECATED: Kind taxonomyterm (#3932)

* fix warning  DEPRECATED: Kind taxonomyterm

* fix error in hugo

[DX-973]: https://tyktech.atlassian.net/browse/DX-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ