### PR TITLE
Merging to release-5.1: [DX-973]fix warning  DEPRECATED: Kind taxonomyterm (#3932)

### DIFF
--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -3,8 +3,13 @@ languageCode = "en-gb"
 title = "Tyk Documentation"
 theme = "tykio"
 MetaDataFormat = "yaml"
+<<<<<<< HEAD
 enableGitInfo = false
 disableKinds = ["taxonomy", "taxonomyTerm"]
+=======
+enableGitInfo = true
+disableKinds = ["term","taxonomy"]
+>>>>>>> f343fbc2... [DX-973]fix warning  DEPRECATED: Kind taxonomyterm (#3932)
 canonifyURLs = false
 timeout = "60s"
 [params]


### PR DESCRIPTION
[DX-973]fix warning  DEPRECATED: Kind taxonomyterm (#3932)

* fix warning  DEPRECATED: Kind taxonomyterm

* fix error in hugo

[DX-973]: https://tyktech.atlassian.net/browse/DX-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ