### PR TITLE
Merging to release-5: Update documentation with default TYK_GW_PROXYDEFAULTTIMEOUT (#3911)

### DIFF
--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -834,7 +834,7 @@ Whitelist ciphers for connection between Tyk and your upstream service.
 EV: <b>TYK_GW_PROXYDEFAULTTIMEOUT</b><br />
 Type: `float64`<br />
 
-This can specify a default timeout in seconds for upstream API requests.
+This can specify a default timeout in seconds for upstream API requests. Default: 30 seconds.
 
 ### proxy_ssl_disable_renegotiation
 EV: <b>TYK_GW_PROXYSSLDISABLERENEGOTIATION</b><br />


### PR DESCRIPTION
Update documentation with default TYK_GW_PROXYDEFAULTTIMEOUT (#3911)

Update gateway-config.md with default TYK_GW_PROXYDEFAULTTIMEOUT default value

Co-authored-by: dcs3spp <dcs3spp@users.noreply.github.com>