### PR TITLE
[DX-908]dynamic versions creation in master also fix slash issue

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/version_selector.html
+++ b/tyk-docs/themes/tykio/layouts/partials/version_selector.html
@@ -1,14 +1,17 @@
+{{- $pattern := `\/docs\/\d+\.\d+` -}}
+{{- $pagePath := replaceRE $pattern "/docs" .RelPermalink -}}
+{{- $pagePath := replace $pagePath "/docs" "" -}}
+{{- $pagePath := replace $pagePath "/nightly" "" -}}
+{{- $values := index $.Site.Data.page_available_since.pages $pagePath -}}
+{{- $currentVersion := replace .RelPermalink $pagePath "/" -}}
 <label for="version-selector">Version: </label>
-<select onchange="var path = location.pathname.match('\/docs\/(?:nightly|[1-9][^\/]*\)?(.*)')[1].replace(/^\//,''); window.location = this.options[this.selectedIndex].value + path" id="version-selector">
-    <option value="/docs/">Latest - 5.2</option>
-    <option value="/docs/5.1/">5.1</option>
-    <option value="/docs/5.0/">5 LTS</option>
-    <option value="/docs/4.3/">4.3</option>
-    <option value="/docs/4.2/">4.2</option>
-    <option value="/docs/4.1/">4.1</option>
-    <option value="/docs/4.0/">4 LTS</option>
-    <option value="/docs/3.2/">3.2</option>
-    <option value="/docs/3.1/">3.1</option>
-    <option value="/docs/3-lts/">3 LTS</option>
-    <option value="/docs/nightly/" selected="selected">Nightly</option>
+<select onchange="var path =this.options[this.selectedIndex].getAttribute('data-url')|| location.pathname.match('\/docs\/(?:nightly|[1-9][^\/]*\)?(.*)')[1].replace(/^\//,''); window.location = this.options[this.selectedIndex].value + path" id="version-selector">
+    {{- range $.Site.Data.page_available_since.versions -}}
+    {{ $versionUrl := "" }}
+    {{- if  $values -}}
+        {{ $versionUrl = index $values .path }}
+    {{- end -}}
+    {{- $versionUrl = strings.TrimPrefix "/" $versionUrl }}
+    <option value="{{.path}}" {{if $versionUrl}} data-url="{{$versionUrl}}" {{end}}  {{if eq $currentVersion .path}} selected="selected" {{end}} {{- if not $versionUrl -}} disabled {{end}}>{{.name}}</option>
+    {{- end -}}
 </select>


### PR DESCRIPTION
NOTE: Before merging this pull request you need to merge: https://github.com/TykTechnologies/tyk-docs/pull/3986

We have now disabled version in which a given page does not appear in. This is to prevent users from clicking pages that will return a 404 anyway. We also want to make sure that if a previous page used a different url users will be able to access that page. For example let say a page was introduced in version 5.1 of the docs, we have disabled any version below version 5.1 
[DX-908]


[DX-908]: https://tyktech.atlassian.net/browse/DX-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

https://deploy-preview-3989--tyk-docs.netlify.app/docs/nightly/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/otel_jaeger/