### PR TITLE
[Dx 961] Refactor Planning For Production Page To Link To Distributed Analytics FAQs

### DIFF
--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -143,7 +143,7 @@ In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analyti
 <br/>
 **Note:** *protobuf* is not currently supported in *MDCB* deployment.
 
-If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a localised data sink, such as PostgreSQL or MongoDB. This will reduce load since analytics traffic would not be sent across regions.
+If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can send the analytics to a localised data sink, such as PostgreSQL or MongoDB (no need for the hybrid pump). This can reduce traffic costs since your analytics would not be sent across regions.
 
 
 ### Use the right hardware

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -140,7 +140,7 @@ If using a [Redis cluster](https://redis.io/docs/management/scaling/) under high
 
 In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of [msgpack](https://msgpack.org) can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
 
-If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a localised data sink, such as PostgreSQL or MongoDB. In this scenario the hybrid pump will be bypassed across the *Control Plane* and *Data Planes*, thus reducing load since no analytics traffic is sent across regions.
+If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a localised data sink, such as PostgreSQL or MongoDB. This will reduce load since analytics traffic would not be sent across regions.
 
 
 ### Use the right hardware

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -136,11 +136,11 @@ Please read carefully through this [doc]({{< ref "basic-config-and-security/secu
 
 ### Analytics Optimisations
 
-If using a Redis cluster under high load it is recommended that analytics are sent to distributed Redis shards. To configure this ensure the Redis cluster is [enabled]({{< ref "tyk-multi-data-centre/mdcb-configuration-options/#storageenable_cluster" >}}) and [multiple analytics keys]({{< ref "tyk-oss-gateway/configuration#analytics_configenable_multiple_analytics_keys" >}}) are configured. Subsequently, analytics keys will be distributed across multiple nodes in the cluster.
+If using a Redis cluster under high load it is recommended that analytics are sent to distributed Redis shards. This can be configured using the *analytics_configenable_multiple_analytics_keys* parameter and following the process explained in this [FAQ - Requires PR Merged].
 
 In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of msgpack can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
 
-If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a local PostgreSQL or MongoDB instance. In this scenario the hybrid pump is bypassed in the Control Plane, thus reducing load since no analytics traffic is sent to synchronise analytics to the Data Planes.
+If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a localised data sink, such as PostgreSQL or MongoDB. In this scenario the hybrid pump will be bypassed in the Control Plane, thus reducing load since no analytics traffic is sent for synchronising with the Data Planes.
 
 ### Use the right hardware
 

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -136,7 +136,7 @@ Please read carefully through this [doc]({{< ref "basic-config-and-security/secu
 
 ### Analytics Optimisations
 
-If using a [Redis cluster](https://redis.io/docs/management/scaling/) under high load it is recommended that analytics are sent to distributed Redis shards. This can be configured using the *analytics_configenable_multiple_analytics_keys* parameter and following the process explained in this **[FAQ - PR #4018]**. Furthermore, analytics can also be disabled for an API or selected endpoints, as explained in this **[FAQ - PR #4032]**.
+If using a [Redis cluster](https://redis.io/docs/management/scaling/) under high load it is recommended that analytics are distributed among the Redis shards. This can be configured by setting the [analytics_config.enable_multiple_analytics_keys]({{< ref "tyk-oss-gateway/configuration#analytics_configenable_multiple_analytics_keys" >}}) parameter to true. Furthermore, analytics can also be disabled for an API using the [do_not_track]({{< ref "tyk-apis/tyk-gateway-api/api-definition-objects/other-root-objects" >}}) configuration parameter. Alternatively, tracking for analytics can be disabled for selected endpoints using the [do not track endpoint plugin]({{< ref "advanced-configuration/transform-traffic/endpoint-designer#do-not-track-endpoint" >}}).
 
 #### Protobuf Serialisation
 In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of [msgpack](https://msgpack.org) can increase performance for sending and processing analytics. 

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -140,7 +140,7 @@ If using a Redis cluster under high load it is recommended that analytics are se
 
 In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of msgpack can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
 
-If using Tyk Cloud platform under high load, it is also recommended that analytics are sent within a local region. 
+If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a local PostgreSQL or MongoDB instance. In this scenario the hybrid pump is bypassed in the Control Plane, thus reducing load since no analytics traffic is sent to synchronise analytics to the Data Planes.
 
 ### Use the right hardware
 

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -138,7 +138,10 @@ Please read carefully through this [doc]({{< ref "basic-config-and-security/secu
 
 If using a [Redis cluster](https://redis.io/docs/management/scaling/) under high load it is recommended that analytics are sent to distributed Redis shards. This can be configured using the *analytics_configenable_multiple_analytics_keys* parameter and following the process explained in this **[FAQ - PR #4018]**. Furthermore, analytics can also be disabled for an API or selected endpoints, as explained in this **[FAQ - PR #4032]**.
 
-In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of [msgpack](https://msgpack.org) can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
+#### Protobuf Serialisation
+In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of [msgpack](https://msgpack.org) can increase performance for sending and processing analytics. 
+<br/>
+**Note:** *protobuf* is not currently supported in *MDCB* deployment.
 
 If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a localised data sink, such as PostgreSQL or MongoDB. This will reduce load since analytics traffic would not be sent across regions.
 

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -136,7 +136,7 @@ Please read carefully through this [doc]({{< ref "basic-config-and-security/secu
 
 ### Analytics Optimisations
 
-If using a Redis cluster under high load it is recommended that analytics are sent to distributed Redis shards. This can be configured using the *analytics_configenable_multiple_analytics_keys* parameter and following the process explained in this **[FAQ - PR #4018]**. Furthermore, analytics can also be disabled for an API or selected endpoints, as explained in this **[FAQ - PR #4032]**.
+If using a [Redis cluster](https://redis.io/docs/management/scaling/) under high load it is recommended that analytics are sent to distributed Redis shards. This can be configured using the *analytics_configenable_multiple_analytics_keys* parameter and following the process explained in this **[FAQ - PR #4018]**. Furthermore, analytics can also be disabled for an API or selected endpoints, as explained in this **[FAQ - PR #4032]**.
 
 In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of msgpack can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
 

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -138,7 +138,7 @@ Please read carefully through this [doc]({{< ref "basic-config-and-security/secu
 
 If using a [Redis cluster](https://redis.io/docs/management/scaling/) under high load it is recommended that analytics are sent to distributed Redis shards. This can be configured using the *analytics_configenable_multiple_analytics_keys* parameter and following the process explained in this **[FAQ - PR #4018]**. Furthermore, analytics can also be disabled for an API or selected endpoints, as explained in this **[FAQ - PR #4032]**.
 
-In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of msgpack can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
+In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of [msgpack](https://msgpack.org) can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
 
 If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a localised data sink, such as PostgreSQL or MongoDB. In this scenario the hybrid pump will be bypassed across the *Control Plane* and *Data Planes*, thus reducing load since no analytics traffic is sent across regions.
 

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -136,11 +136,12 @@ Please read carefully through this [doc]({{< ref "basic-config-and-security/secu
 
 ### Analytics Optimisations
 
-If using a Redis cluster under high load it is recommended that analytics are sent to distributed Redis shards. This can be configured using the *analytics_configenable_multiple_analytics_keys* parameter and following the process explained in this [FAQ - Requires PR Merged].
+If using a Redis cluster under high load it is recommended that analytics are sent to distributed Redis shards. This can be configured using the *analytics_configenable_multiple_analytics_keys* parameter and following the process explained in this **[FAQ - PR #4018]**. Furthermore, analytics can also be disabled for an API or selected endpoints, as explained in this **[FAQ - PR #4032]**.
 
 In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of msgpack can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
 
-If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a localised data sink, such as PostgreSQL or MongoDB. In this scenario the hybrid pump will be bypassed in the Control Plane, thus reducing load since no analytics traffic is sent for synchronising with the Data Planes.
+If using Tyk Cloud platform under high load, it is also recommended that analytics are stored within a local region. This means that a local Tyk Pump instance can store the analytics within a localised data sink, such as PostgreSQL or MongoDB. In this scenario the hybrid pump will be bypassed across the *Control Plane* and *Data Planes*, thus reducing load since no analytics traffic is sent across regions.
+
 
 ### Use the right hardware
 

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -138,7 +138,7 @@ Please read carefully through this [doc]({{< ref "basic-config-and-security/secu
 
 If using a Redis cluster under high load it is recommended that analytics are sent to distributed Redis shards. To configure this ensure the Redis cluster is [enabled]({{< ref "tyk-multi-data-centre/mdcb-configuration-options/#storageenable_cluster" >}}) and [multiple analytics keys]({{< ref "tyk-oss-gateway/configuration#analytics_configenable_multiple_analytics_keys" >}}) are configured. Subsequently, analytics keys will be distributed across multiple nodes in the cluster.
 
-Using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of msgpack can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
+In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of msgpack can increase performance for sending and processing analytics. Please note that *protobuf* is not currently supported in MDCB environments.
 
 If using Tyk Cloud platform under high load, it is also recommended that analytics are sent within a local region. 
 


### PR DESCRIPTION
[DX-961](https://tyktech.atlassian.net/browse/DX-961) 

[preview](https://deploy-preview-4033--tyk-docs.netlify.app/docs/nightly/planning-for-production#analytics-optimisations)

This involves refactoring the Analytics optimisations as commented in this [PR](https://github.com/TykTechnologies/tyk-docs/pull/3621/files). Part of this refactoring involves linking to new FAQs for:
- When to use do_not_track
- How to configure Tyk to distribute analytics across Redis shards.

Subsequently, this PR should not be merged until the following PRs have been merged:
- [FAQ enable_do_not_track](https://github.com/TykTechnologies/tyk-docs/pull/4032)
- [FAQ configure Tyk to distribute analytics across Redis Shards](https://github.com/TykTechnologies/tyk-docs/pull/4018)

[DX-961]: https://tyktech.atlassian.net/browse/DX-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ