### PR TITLE
Merging to release-5.2: Space between number to minutes (#4044)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/page_metadata.html
+++ b/tyk-docs/themes/tykio/layouts/partials/page_metadata.html
@@ -8,7 +8,7 @@
 <p class="last-modified-date">Last updated:
     <time datetime="2023-04-08T06:57:07.000Z">{{$lastmod}}</time>
     {{ $readTime := cond (gt .ReadingTime 1) "minutes" "minute" }}
-    ~ {{ .ReadingTime }}{{$readTime}} read.
+    ~ {{ .ReadingTime }} {{$readTime}} read.
 </p>
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Space between number to minutes (#4044)

Update page_metadata.html