### PR TITLE
Merging to release-5.2: [DX-1019] Move LTS Page Out From Developer Support -> FAQ (#4058)

### DIFF
--- a/tyk-docs/content/developer-support/debugging-series/debugging-selfmanaged.md
+++ b/tyk-docs/content/developer-support/debugging-series/debugging-selfmanaged.md
@@ -136,7 +136,7 @@ You can find the full [log levels]({{< ref "log-data" >}}) in our documentation.
 
 You can access all Tyk release information on the [release notes](https://tyk.io/docs/developer-support/tyk-release-summary/overview/) overview page.
 
-We recommend always using the [Long-Term Support (LTS) release]({{<ref "frequently-asked-questions/long-term-support-releases#what-is-a-tyk-long-term-support-lts-release" >}}) for stability and long term support.
+We recommend always using the [Long-Term Support (LTS) release]({{<ref "developer-support/long-term-support-releases" >}}) for stability and long term support.
 
 ### Non-LTS versions
 Tyk is backwards compatible, upgrading to newer versions won't turn on new features or change the behaviour of your existing environment.

--- a/tyk-docs/content/developer-support/long-term-support-releases.md
+++ b/tyk-docs/content/developer-support/long-term-support-releases.md
@@ -7,6 +7,8 @@ menu:
   main:
     parent: "Frequently Asked Questions"
 weight: 0
+aliases:
+  - /frequently-asked-questions/long-term-support-releases/
 ---
 
 ## What is a Tyk Long Term Support (LTS) release

--- a/tyk-docs/content/upgrading-tyk.md
+++ b/tyk-docs/content/upgrading-tyk.md
@@ -17,7 +17,7 @@ This page provides guidance for upgrading your Tyk installation. When upgrading 
 All our components adhere to a few common standards:
 
 - We do not introduce breaking changes unless specifically stated in the release notes (and it rarely happens).
-- Check our [versioning and long-term-support policies]({{< ref "frequently-asked-questions/long-term-support-releases/" >}}) for more details on the way we release major and minor features, patches and the support dates for each release.
+- Check our [versioning and long-term-support policies]({{< ref "developer-support/long-term-support-releases" >}}) for more details on the way we release major and minor features, patches and the support dates for each release.
 - Make sure you follow our [comprehensive guide for backing up Tyk]({{< ref "frequently-asked-questions/how-to-backup-tyk" >}}) before starting the upgrade 
 - If you experience any issues with the new version you pulled, please contact Tyk Support or [Tyk community forum](https://community.tyk.io/)
 

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -3534,10 +3534,6 @@ menu:
         path: /frequently-asked-questions/how-to-backup-tyk-cloud-deployment
         category: Page
         show: True
-      - title: "Long Term Support Releases"
-        path: /frequently-asked-questions/long-term-support-releases
-        category: Page
-        show: True
       - title: "Support SLA Policies"
         path: /frequently-asked-questions/sla-policies
         category: Page
@@ -3554,6 +3550,10 @@ menu:
         path: /frequently-asked-questions/datadog-logs-showup-as-errors
         category: Page
         show: True
+    - title: "Long Term Support Releases"
+      path: /developer-support/long-term-support-releases 
+      category: Page
+      show: True
     - title: "Plug-in Hub"
       category: Page
       show: False


### PR DESCRIPTION
[DX-1019] Move LTS Page Out From Developer Support -> FAQ (#4058)

* move LTS page out from developer-support/frequently-asked-questions and hook up to nav menu structure
* Update tyk-docs/content/developer-support/debugging-series/debugging-selfmanaged.md

---------

Co-authored-by: Simon Pears <simon@tyk.io>
Co-authored-by: Yaara <yaara@tyk.io>

[DX-1019]: https://tyktech.atlassian.net/browse/DX-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ