### PR TITLE
Revert "[DX-1059]H4 and H5 Added"

### DIFF
--- a/tyk-docs/assets/scss/_table-of-contents.scss
+++ b/tyk-docs/assets/scss/_table-of-contents.scss
@@ -2,7 +2,7 @@
 
 /* Documentation : Table of Contents */
 .documentation-table-of-contents-container {
-	width: 250px;
+	width: 200px;
 	position: relative;
 
 	.page-documentation:not(.hasSidebar) & {
@@ -75,117 +75,6 @@
 				margin-bottom: 10px;
 				display: block;
 			}
-			>* {
-				padding-left: 18px;				 
-			}	
-			.sub-accordionHolder {
-				position: relative;
-				&:after{
-					pointer-events: auto;
-					content: '';
-					background-image: url(../img/icon-caret.svg);
-					background-repeat: no-repeat;
-					background-position: right;
-					inline-size: 100%;
-					block-size: var(--caret-size);
-					position: absolute;
-					top: 0;
-					right: 0;
-					cursor: pointer;
-					transition: scale 0.2s;
-					width: 20px;
-					height: 20px;
-				}
-				
-				
-			}
-			&.accordion-up{
-				.sub-accordionHolder {
-					position: relative;
-					/* &:after{
-						transform: rotate(180deg);
-					}*/
-				}
-			}
-			/*.sub-accordionHolder{
-				&:after{
-					display: none;
-				}
-			}
-			.sub-sub-accordionHolder{
-				&:after{
-					display: none;
-				}
-			}*/
-		}
-
-
-		.accordion-content.accordion-up {
-			>.sub-accordionHolder {
-				&:after {
-					transform: rotate(180deg);
-				}
-			}
-			>.sub-accordion {
-				>.sub-accordionHolder {
-					&:after {
-						transform: rotate(180deg);
-					}
-				}
-			}
-		}
-
-		.sub-accordion-content > *{
-			padding-left: 25px;
-		}
-		.sub-accordion-content, .sub-sub-accordion-content{
-			display: none;
-		}
-
-		.accordion-up .sub-accordion-content , .accordion-up .sub-accordion-content a , .sub-accordion .sub-sub-accordion-content {
-			display: block;
-		}
-		
-		margin-bottom: 20px;
-		>* {
-			font-size:  15px !important;
-			transition: all 400ms ease;
-			&:hover{
-				font-weight: 700;
-				color: #000 !important;
-			}
-			+ {
-				* {
-					position: relative;
-					&:before{
-						content: "";
-						background: #cfcfe5;
-						width: 1px;
-						height: 100%;
-						top: 0;
-						left: 0;
-						display: block;
-						position: absolute;
-						z-index: 1;
-					}
-					.sub_toc__item {
-						font-size: 15px !important;
-						color: #03031c;
-						margin: 0 !important;
-						font-weight: 400;
-						padding-bottom: 10px !important;
-						padding-left: 14px;
-						&:hover, &.js-active{
-							color: #8438FA;
-						}
-					}
-				}
-			}
-			&:last-child{
-				.sub_toc__item {
-					padding-bottom: 10px !important;					
-				}
-			}
 		}
 	}
 	.toc__content {
@@ -193,12 +82,9 @@
 		.accordion-content {
 		
 			a {
-				font-size: 15px !important;
-				color: #03031c;
-				margin: 0 !important;
-				font-weight: 400;
-				padding-bottom: 10px !important;
-				padding-left: 14px;
+				font-size: 12px;
+				margin-bottom: 10px;
+				display: block;
 			}
 		}
 	}

--- a/tyk-docs/static/js/docs-table-of-contents.js
+++ b/tyk-docs/static/js/docs-table-of-contents.js
@@ -7,7 +7,7 @@ var buildTableOfContents = function () {
         ToC = $(".documentation-table-of-contents"),
         ToContent = $(".toc__content"),
         ToClbl = $('<span class="toc__label">On this page</span>'),
-        contentTitles = $("h2, h3, h4, h5", "#main-content");
+        contentTitles = $("h2, h3", "#main-content");
 
     if (!ToC[0]) {
         return;
@@ -41,52 +41,13 @@ var buildTableOfContents = function () {
         }
 
         if ($(this).is('h3')) {
-            var h3 = $(this).text().replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-            var link = $(`<a href="#${$(this).attr("id")}" class="sub_toc__item sub-accordion-title ${h3}">${title}</a>`);
+            var link = $(`<a href="#${$(this).attr("id")}" class="sub_toc__item ${h2}">${title}</a>`);
             var accordionContent = $('<div class="accordion-content"></div>').append(link);
             if (accordionGroup.find('.accordion-item:last').length) {
                 accordionGroup.find('.accordion-item:last').append(accordionContent);
             } else {
                 ToContent.append(accordionContent);
             }
-
-            accordionContent.click(function () {
-                $(this).toggleClass('accordion-up');
-                                
-                // Toggle visibility of H4 elements under this H3
-                accordionContent.siblings('.sub-accordion-content').toggle();
-            });
-
-        }
-
-        if ($(this).is('h4')) {
-            var h4 = $(this).text().replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-            var subLink = $(`<a href="#${$(this).attr("id")}" class="sub-sub-toc-item sub-accordion-title ${h4}">${title}</a>`);
-            var subAccordionContent = $('<div class="sub-accordion-content"></div>').append(subLink);
-            if (accordionGroup.find('.accordion-item:last .accordion-content:last').length) {
-                accordionGroup.find('.accordion-item:last .accordion-content:last').append(subAccordionContent);
-            }
-            subAccordionContent.click(function () {
-                $(this).parent().toggleClass('accordion-up');                
-                // Toggle visibility of H5 elements under this H4
-                $(this).toggleClass('sub-accordion');
-
-                //subAccordionContent.find('.sub-sub-accordion-content').toggleClass('sub-accordion');
-            });
-        }
-
-        if ($(this).is('h5')) {
-            var h5 = $(this).text().replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-            var subSubLink = $(`<a href="#${$(this).attr("id")}" class="sub-sub-sub-toc-item sub-accordion-title ${h5}">${title}</a>`);
-            var subSubAccordionContent = $('<div class="sub-sub-accordion-content"></div>').append(subSubLink);
-            if (accordionGroup.find('.accordion-item:last .accordion-content:last .sub-accordion-content:last').length) {
-                accordionGroup.find('.accordion-item:last .accordion-content:last .sub-accordion-content:last').append(subSubAccordionContent);
-            }
-            subSubAccordionContent.click(function () {
-                $(this).parent().toggleClass('sub-accordion');
-                subSubAccordionContent.find('.sub-sub-accordion-content').toggleClass('accordion-up');
-                // You can add further logic if needed for H5 content
-            });
         }
     });
 
@@ -103,62 +64,42 @@ var buildTableOfContents = function () {
             // Do something if there is accordion content
         } else {
             $(this).find('a.toc__item').addClass('accordionHolder');
-        }        
+        }
     });
-
-    $('.accordion-content').each(function () {
-        var accordionContent = $(this).find('.sub-accordion-content');
-        if (accordionContent.length) {
-            // Do something if there is accordion content
-            $(this).find('a.sub_toc__item').addClass('sub-accordionHolder');
-        } else {
-            
-        }
-    });   
-
-    $('.sub-accordion-content').each(function () {
-        var accordionContent = $(this).find('.sub-sub-accordion-content');
-        if (accordionContent.length) {
-            // Do something if there is accordion content
-            $(this).find('a.sub-sub-toc-item').addClass('sub-accordionHolder');
-        } else {
-            
-        }
-    });   
-    
 };
 
 // Call the function to build the table of contents with accordion functionality
 $(document).ready(buildTableOfContents);
 $(document).on("turbolinks:load", buildTableOfContents);
+
 /**
  * Toggle TOC for small devices
  */
 
 function activeTocToggle() {
-    var tocLabel = $('.toc__label');
-    var tocItems = $('.toc__item');
-    var pageContent = $('.page-content__container, .header');
+	var tocLabel = $('.toc__label');
+	var tocItems = $('.toc__item');
+	var pageContent = $('.page-content__container, .header');
+	
+	tocLabel.on('click', function(e) {
+		if (window.innerWidth < 1024) {
+			$(e.currentTarget).toggleClass('js-open');
+		} else {
+			$(e.currentTarget).removeClass('js-open');
+		}
+	});
+	
+	/* tocItems.on('click', function(e) {
+		if (window.innerWidth < 1024) {
+			tocLabel.removeClass('js-open');
+		}
+	}); */
 
-    tocLabel.on('click', function (e) {
-        if (window.innerWidth < 1024) {
-            $(e.currentTarget).toggleClass('js-open');
-        } else {
-            $(e.currentTarget).removeClass('js-open');
-        }
-    });
-
-    /* tocItems.on('click', function(e) {
-        if (window.innerWidth < 1024) {
-            tocLabel.removeClass('js-open');
-        }
-    }); */
-
-    pageContent.on('click', function () {
-        if (tocLabel.hasClass('js-open')) {
-            tocLabel.removeClass('js-open');
-        }
-    });
+	pageContent.on('click', function() {
+		if ( tocLabel.hasClass('js-open') ) {
+			tocLabel.removeClass('js-open');
+		}
+	});
 }
 
 // function throttle(fn, wait) {
@@ -174,21 +115,21 @@ function activeTocToggle() {
 
 
 function highlightAnchor() {
-    var contentTitles = $("h2, h3, h4, h5", "#main-content");
-    var currentSectionId;
-    var sectionPosition = 0;
+	var contentTitles = $("h2, h3", "#main-content");
+	var currentSectionId;
+	var sectionPosition = 0;
+	
+	contentTitles.each(function () {
+		sectionPosition = $(this).offset().top;
+		currentSectionId = $(this).attr("id");
+		
+		if (sectionPosition > 120  && sectionPosition < (120 + ($(this).outerHeight() * 2) )) {	
+			$('.toc__item,.sub_toc__item').removeClass("js-active");
+			$('.toc__item[href*="#' + currentSectionId + '"],.sub_toc__item[href*="#' + currentSectionId + '"]').addClass("js-active");
 
-    contentTitles.each(function () {
-        sectionPosition = $(this).offset().top;
-        currentSectionId = $(this).attr("id");
-
-        if (sectionPosition > 120 && sectionPosition < (120 + ($(this).outerHeight() * 2))) {
-            $('.toc__item,.sub_toc__item').removeClass("js-active");
-            $('.toc__item[href*="#' + currentSectionId + '"],.sub_toc__item[href*="#' + currentSectionId + '"],.sub-sub-toc-item[href*="#' + currentSectionId + '"],.sub-sub-sub-toc-item[href*="#' + currentSectionId + '"]').addClass("js-active");
-
-            return;
-        }
-    });
+			return;
+		}
+	});
 }
 
 


### PR DESCRIPTION
## **User description**
Reverts TykTechnologies/tyk-docs#4024


___

## **Type**
enhancement, documentation


___

## **Description**
- Reduced the width of the table of contents container for better layout fit.
- Removed styling and JavaScript functionality for `h4` and `h5` headings in the table of contents, simplifying the code and focusing on `h2` and `h3` headings.
- Streamlined JavaScript functions for better readability and performance.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_table-of-contents.scss</strong><dd><code>Simplification and Width Adjustment of Table of Contents Styling</code></dd></summary>
<hr>

tyk-docs/assets/scss/_table-of-contents.scss
<li>Reduced the width of the table of contents container from 250px to <br>200px.<br> <li> Simplified the styling by removing nested accordion styles and <br>unnecessary complexity.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4130/files#diff-a9b2fe01555dddb1b7c553a79ac798f880b16abd38256b3ed7d741a50c4342ae">+4/-118</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docs-table-of-contents.js</strong><dd><code>Streamlining Table of Contents Script and Removing H4 and H5 Accordion </code><br><code>Functionality</code></dd></summary>
<hr>

tyk-docs/static/js/docs-table-of-contents.js
<li>Updated the content titles selector to only include <code>h2</code> and <code>h3</code> <br>headings, removing <code>h4</code> and <code>h5</code>.<br> <li> Removed the accordion functionality for <code>h4</code> and <code>h5</code> headings, <br>simplifying the script.<br> <li> Cleaned up and streamlined the <code>activeTocToggle</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4130/files#diff-40b5987da19f3922c5bb623c69fab23fe13bf09c588f5a95852e49542a62440e">+43/-102</a></td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
