### PR TITLE
Merging to release-5.2: [DX-1071] Bump LTS version for GW & Dashboard to 5.0.10 (#4144)

### DIFF
--- a/tyk-docs/data/releases/dashboard.json
+++ b/tyk-docs/data/releases/dashboard.json
@@ -1,15 +1,15 @@
 {
   "home": "tyk-dashboard",
   "licensed": true,
-  "latest": "5.2.4",
-  "lts": "5.0.9",
+  "latest": "5.2.5",
+  "lts": "5.0.10",
   "releaseNotesPath": "product-stack/tyk-dashboard/release-notes/overview",
-  "5.2.4": {
-    "date": "7/12/2023",
-    "docker": "https://hub.docker.com/r/tykio/tyk-dashboard/tags?page=1&name=5.2.3"
+  "5.2.5": {
+    "date": "20/12/2023",
+    "docker": "https://hub.docker.com/r/tykio/tyk-dashboard/tags?page=1&name=5.2.5"
   },
-  "5.0.9": {
+  "5.0.10": {
     "date": "13/11/2023",
-    "docker": "https://hub.docker.com/r/tykio/tyk-dashboard/tags?page=1&name=5.0.9"
+    "docker": "https://hub.docker.com/r/tykio/tyk-dashboard/tags?page=1&name=5.0.10"
   }
 }

--- a/tyk-docs/data/releases/gateway.json
+++ b/tyk-docs/data/releases/gateway.json
@@ -1,17 +1,17 @@
 {
   "home": "tyk-oss-gateway",
   "licensed": false,
-  "latest": "5.2.4",
-  "lts": "5.0.9",
+  "latest": "5.2.5",
+  "lts": "5.0.10",
   "releaseNotesPath": "product-stack/tyk-gateway/release-notes/overview",
-  "5.2.4": {
-    "date": "19/11/2023",
-    "tag": "https://github.com/TykTechnologies/tyk/releases/tag/v5.2.3",
-    "docker": "https://hub.docker.com/r/tykio/tyk-gateway/tags?page=1&name=5.2.3"
+  "5.2.5": {
+    "date": "20/12/2023",
+    "tag": "https://github.com/TykTechnologies/tyk/releases/tag/v5.2.5",
+    "docker": "https://hub.docker.com/r/tykio/tyk-gateway/tags?page=1&name=5.2.5"
   },
-  "5.0.9": {
-    "date": "14/12/2023",
-    "tag": "https://github.com/TykTechnologies/tyk/releases/tag/v5.0.9",
-    "docker": "https://hub.docker.com/r/tykio/tyk-gateway/tags?page=1&name=5.0.9"
+  "5.0.10": {
+    "date": "21/12/2023",
+    "tag": "https://github.com/TykTechnologies/tyk/releases/tag/v5.0.10",
+    "docker": "https://hub.docker.com/r/tykio/tyk-gateway/tags?page=1&name=5.0.10"
   }
 }

--- a/tyk-docs/data/releases/tib.json
+++ b/tyk-docs/data/releases/tib.json
@@ -1,11 +1,11 @@
 {
   "home": "tyk-identity-broker",
   "licensed": false,
-  "latest": "1.4.3",
+  "latest": "1.5.1",
   "releaseNotesPath": "https://github.com/TykTechnologies/tyk-identity-broker/releases",
-  "1.4.3": {
-    "date": "25/10/2023",
-    "tag": "https://github.com/TykTechnologies/tyk-identity-broker/releases/tag/v1.4.3",
-    "docker": "https://hub.docker.com/r/tykio/tyk-identity-broker/tags?page=1&name=1.4.3"
+  "1.5.1": {
+    "date": "9/2/2024",
+    "tag": "https://github.com/TykTechnologies/tyk-identity-broker/releases/tag/v1.5.1",
+    "docker": "https://hub.docker.com/r/tykio/tyk-identity-broker/tags?page=1&name=1.5.1"
   }
 }


### PR DESCRIPTION
[DX-1071] Bump LTS version for GW & Dashboard to 5.0.10 (#4144)

* bump version for GW LTS to 5.0.10
* bump version for Dashboard LTS to 5.0.10
* bump version for Dashboard & GW to 5.2.5
* bump version for TIB

---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1071]: https://tyktech.atlassian.net/browse/DX-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ