### PR TITLE
Merging to release-5.2: [DX-1110] Update synchroniser.md (#4160)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-enterprise-mdcb/advanced-configurations/synchroniser.md
+++ b/tyk-docs/content/product-stack/tyk-enterprise-mdcb/advanced-configurations/synchroniser.md
@@ -94,7 +94,7 @@ If API keys were used and hash key is disabled, please also set these additional
 
 - Controller Gateway:
 
-`"slave_options":{ "synchroniser_enabled": true }, "hash_keys": false` 
+`"hash_keys": false` 
 
 If certificates were used, please also set these additional configurations:
 


### PR DESCRIPTION
[DX-1110] Update synchroniser.md (#4160)

Update synchroniser.md

Control Plane configuration" refers to a "Controller Gateway", yet the provided code snippet suggests a Worker Gateway configuration with slave_options. This might lead to confusion.

This PR removes the slave_options config and leaves hash_keys which is relevant to the context of that section

[DX-1110]: https://tyktech.atlassian.net/browse/DX-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ