### PR TITLE
add aliases to Deploy Hybrid Gateways

### DIFF
--- a/tyk-docs/content/tyk-cloud/environments-deployments/hybrid-gateways.md
+++ b/tyk-docs/content/tyk-cloud/environments-deployments/hybrid-gateways.md
@@ -7,6 +7,8 @@ menu:
   main:
     parent: "Environments & Deployments"
 weight: 5
+aliases:
+  - /tyk-cloud/environments-&-deployments/hybrid-gateways
 ---
 
 [Tyk Cloud](https://tyk.io/cloud/) hosts and manages the control planes for you. You can deploy the data planes across multiple locations:

--- a/tyk-docs/content/tyk-cloud/environments-deployments/hybrid-gateways.md
+++ b/tyk-docs/content/tyk-cloud/environments-deployments/hybrid-gateways.md
@@ -9,6 +9,7 @@ menu:
 weight: 5
 aliases:
   - /tyk-cloud/environments-&-deployments/hybrid-gateways
+  - /tyk-cloud/environments--deployments/hybrid-gateways
 ---
 
 [Tyk Cloud](https://tyk.io/cloud/) hosts and manages the control planes for you. You can deploy the data planes across multiple locations:


### PR DESCRIPTION
## **User description**

- We changed the folder structure aand forgot to add an alias to the hybrid gateway  file.

In release 3.1 the structure was :

![image](https://github.com/TykTechnologies/tyk-docs/assets/8012032/22e25e53-43a3-4273-854e-907c7f695f53)
 And in later version we changed it to :
 
 
![image](https://github.com/TykTechnologies/tyk-docs/assets/8012032/3dd978f6-859a-4e06-9f4b-299d30ed3ce5)

https://deploy-preview-4179--tyk-docs.netlify.app/docs/nightly/tyk-cloud/environments--deployments/hybrid-gateways/


___

## **Type**
documentation


___

## **Description**
- Added URL aliases to the Hybrid Gateways documentation to improve navigation and accessibility.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid-gateways.md</strong><dd><code>Add URL Aliases for Hybrid Gateways Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-cloud/environments-deployments/hybrid-gateways.md
<li>Added <code>aliases</code> to support alternative URL paths for the Hybrid Gateways <br>documentation.<br>


</details>
    

  </td>
  <td><a href="https:/TykTechnologies/tyk-docs/pull/4179/files#diff-4edf7de9e6c13e231f8d8324c855a6a8a32b10a8ca6d4d38f031a9b70003013f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

