### PR TITLE
[DX-1161] Update Dashboard API User Group samples

### DIFF
--- a/tyk-docs/content/tyk-apis/tyk-dashboard-api/user-groups.md
+++ b/tyk-docs/content/tyk-apis/tyk-dashboard-api/user-groups.md
@@ -133,7 +133,7 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 #### Sample Request
 
 ```{.copyWrapper}
-PUT /api/usergroup/54c25e845d932847067402e2 HTTP/1.1
+PUT /api/usergroups/54c25e845d932847067402e2 HTTP/1.1
 Host: localhost:3000
 authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 
@@ -157,7 +157,7 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 
 | **Property** | **Description**        |
 | ------------ | -----------------------|
-| Resource URL | `/api/users/{user-id}` |
+| Resource URL | `/api/usergroups/{user_group-id}` |
 | Method       | DELETE                 |
 | Type         | None                   |
 | Body         | None                   |
@@ -166,7 +166,7 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 #### Sample Request
 
 ```{.copyWrapper}
-DELETE /api/usergroup/54c25e845d932847067402e2 HTTP/1.1
+DELETE /api/usergroups/54c25e845d932847067402e2 HTTP/1.1
 Host: localhost:3000
 authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 ```

--- a/tyk-docs/content/tyk-apis/tyk-dashboard-api/user-groups.md
+++ b/tyk-docs/content/tyk-apis/tyk-dashboard-api/user-groups.md
@@ -20,7 +20,7 @@ weight: 6
 #### Sample Request
 
 ```{.copyWrapper}
-GET /api/user_groups HTTP/1.1
+GET /api/usergroups HTTP/1.1
 Host: localhost:3000
 authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 ```
@@ -29,12 +29,13 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 
 ```
 {
-  "user_groups": [
+  "groups": [
     {
       "org_id": "54b53d3aeba6db5c35000002",
       "id": "54b53d4bf25b920f09361526",
       "name": "Analytics team",
       "description": "Only access to analytics pages",
+      "active": true,
       "user_permissions": { "analytics": "read" }
     },
     {
@@ -42,6 +43,7 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
       "id": "54b53d4bf25b920f09361527",
       "name": "Certificates team",
       "description": "Team to manage certificates",
+      "active": true,
       "user_permissions": { "certificates": "write" }
     }
   ],
@@ -62,7 +64,7 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 #### Sample Request
 
 ```{.copyWrapper}
-GET /api/user_groups/54bd0ad9ff4329b88985aafb HTTP/1.1
+GET /api/usergroups/54bd0ad9ff4329b88985aafb HTTP/1.1
 Host: localhost:3000
 authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 ```
@@ -75,6 +77,7 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
   "id": "54b53d4bf25b920f09361526",
   "name": "Certificates team",
   "description": "Team to manage certificates",
+  "active": true,
   "user_permissions": { "certificates": "write" }  
 }
 ```
@@ -94,7 +97,7 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 #### Sample Request
 
 ```{.copyWrapper}
-POST /api/user_groups HTTP/1.1
+POST /api/usergroups HTTP/1.1
 Host: localhost:3000
 authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 
@@ -130,7 +133,7 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 #### Sample Request
 
 ```{.copyWrapper}
-PUT /api/user_group/54c25e845d932847067402e2 HTTP/1.1
+PUT /api/usergroup/54c25e845d932847067402e2 HTTP/1.1
 Host: localhost:3000
 authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 
@@ -163,7 +166,7 @@ authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 #### Sample Request
 
 ```{.copyWrapper}
-DELETE /api/user_group/54c25e845d932847067402e2 HTTP/1.1
+DELETE /api/usergroup/54c25e845d932847067402e2 HTTP/1.1
 Host: localhost:3000
 authorization:7a7b140f-2480-4d5a-4e78-24049e3ba7f8
 ```


### PR DESCRIPTION
## **User description**
---

### Description
The samples we provide in the docs for Dashboard User Groups are wrong and need to be updated.

All references to `/api/user_groups` should be replaced with `/api/usergroups`.

Additionally, the List User Groups sample response is incorrect.  `user_groups` should read `groups`
<br>


___

## **Type**
documentation


___

## **Description**
- Corrected API endpoint paths in the documentation from `/api/user_groups` to `/api/usergroups`.
- Updated sample responses to reflect the correct response object key (`groups` instead of `user_groups`) and included the `active` field.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user-groups.md</strong><dd><code>Update Dashboard API User Group Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-apis/tyk-dashboard-api/user-groups.md
<li>Updated API endpoint paths from <code>/api/user_groups</code> to <code>/api/usergroups</code>.<br> <li> Changed the response object key from <code>user_groups</code> to <code>groups</code> in the <br>sample responses.<br> <li> Added <code>active</code> field to the sample responses for user groups.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4231/files#diff-d05215f310dacc51d444ca4f2bac6135d68be32bdb20519930fe08e757486ad4">+10/-7</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

