### PR TITLE
[DX-1182] Update HMAC signatures snippet to fix bug

### DIFF
--- a/tyk-docs/content/basic-config-and-security/security/authentication-authorization/hmac-signatures.md
+++ b/tyk-docs/content/basic-config-and-security/security/authentication-authorization/hmac-signatures.md
@@ -66,10 +66,10 @@ req.Header.Add("X-Test-1", "hello")
 req.Header.Add("X-Test-2", "world")
 
 // Prepare the signature to include those headers:
-signatureString := "(request-target): " + "get /"
-signatureString += "date:" + tim + " "
-signatureString += "x-test-1:" + "hello" + " "
-signatureString += "x-test-2:" + "world"
+signatureString := "(request-target): " + "get /your/path/goes/here"
+signatureString += "date: " + tim + "\n"
+signatureString += "x-test-1: " + "hello" + "\n"
+signatureString += "x-test-2: " + "world"
 
 // SHA1 Encode the signature
 HmacSecret := "secret-key"


### PR DESCRIPTION
## **User description**
The HMAC signature generation [snippet](https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/hmac-signatures/#a-sample-signature-generation-snippet) contains a bug.

Each header should be separated by a new line and each header field should have a space after :

There is a sample script attached in the ticket to test the proposed fix in this PR.

### For internal users - Please add a Jira DX PR ticket to the subject!
[DX-1182](https://tyktech.atlassian.net/browse/DX-1182)

---

### Preview Link
<!-- Add a direct preview link to make it easier for the reviewer to review. Best to add a few direct links to the pages in the PR -->
[preview](https://deploy-preview-4248--tyk-docs.netlify.app/docs/nightly/basic-config-and-security/security/authentication-authorization/hmac-signatures/#a-sample-signature-generation-snippet)

### Description
<!-- 1. Describe your changes in detail. Why is this change required? What problem does it solve?
     2. Please explain the change to the reviewer. Pay special attention to changes that are hard to spot, 
       for example:
       2.1. Name change in the file name or directory name - please flag it out since it’s hard 
            to compare text after such a change 
       2.2. Terminology change - flag it out to make sure the reviewer is aware before approving
     3. @mentions of the person to review the proposed changes. They need to be able to know the topic well in order to approve it.
-->
Each header in the signature should be separated by a new line and each field should have space after :
```go
	// Prepare the signature to include those headers:
	signatureString := "(request-target): " + "get /your/path/goes/here\n"
	signatureString += "date: " + date_time_string + "\n"
	signatureString += "x-test-1: " + "hello" + "\n"
	signatureString += "x-test-2: " + "world"
```

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have added a **preview link** to the PR description.
- [x] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [x] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x] Make sure you have started *your change* off *our latest `master`*.
- [x] I **labelled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->


[DX-1182]: https://tyktech.atlassian.net/browse/DX-1182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
bug_fix, documentation


___

## **Description**
- Corrected the HMAC signature snippet to ensure proper header formatting. This includes adding a newline between headers and ensuring a space after the colon for each header field.
- Added a missing newline at the end of the supported algorithms list to adhere to file formatting standards.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hmac-signatures.md</strong><dd><code>Correct HMAC Signature Snippet and Formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/basic-config-and-security/security/authentication-authorization/hmac-signatures.md
<li>Corrected the HMAC signature snippet to ensure headers are properly <br>separated by a newline and each header field has a space after the <br>colon.<br> <li> Added a missing newline at the end of the file.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4248/files#diff-186a7125f9bf4acad82d1c68572067dc938d032a536ca0581d0fc1557542673c">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

