### PR TITLE
[DX-1188] Remove section anchor in release notes 5.2.2 in changelog for enforced timeout

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
@@ -228,7 +228,7 @@ Fixed a minor issue with Go Plugin virtual endpoints where a runtime log error w
 **Attention**: Please read this section carefully. We have two topics to report:
 
 ##### Default proxy timeout
-We have fixed a bug where [request timeouts were not correctly enforced]({{< ref "#enforced-timeout-fix" >}}). As part of this solution we have introduced a default 30 second timeout for upstream requests (previously the default behaviour would be to wait forever). You can alter this Gateway-wide default using [proxy_default_timeout]({{< ref "tyk-oss-gateway/configuration#proxy_default_timeout" >}}).
+We have fixed a bug where request timeouts were not correctly enforced. As part of this solution we have introduced a default 30 second timeout for upstream requests (previously the default behaviour would be to wait forever). You can alter this Gateway-wide default using [proxy_default_timeout]({{< ref "tyk-oss-gateway/configuration#proxy_default_timeout" >}}).
 
 ##### Early Access Features:
 Please note that the `Tyk OAS APIs` feature, currently marked as *Early Access*, is subject to breaking changes in subsequent releases. Please refer to our [Early Access guide]({{<ref "frequently-asked-questions/using-early-access-features">}}) for specific details. Upgrading to a new version may introduce changes that are not backwards-compatible. Downgrading or reverting an upgrade may not be possible resulting in a broken installation.

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
@@ -271,7 +271,7 @@ The following CVEs have been resolved in this release:
 <ul>
 <li>
 <details>
-<summary>Enforced timeouts were incorrect on a per-request basis</summary> {#enforced-timeout-fix}
+<summary>Enforced timeouts were incorrect on a per-request basis</summary>
 
 Fixed an issue where [enforced timeouts]({{< ref "planning-for-production/ensure-high-availability/enforced-timeouts" >}}) values were incorrect on a per-request basis. Since we enforced timeouts only at the transport level and created the transport only once within the value set by [max_conn_time]({{< ref "tyk-oss-gateway/configuration#max_conn_time" >}}), the timeout in effect was not deterministic. Timeouts larger than 0 seconds are now enforced for each request. We have introduced a default timeout of 30 seconds, which you can alter using [proxy_default_timeout]({{< ref "tyk-oss-gateway/configuration#proxy_default_timeout" >}}).
 </details>


### PR DESCRIPTION
## **User description**
### For internal users - Please add a Jira DX PR ticket to the subject!
[DX-1188](https://tyktech.atlassian.net/browse/DX-1188)

---

### Preview Link
<!-- Add a direct preview link to make it easier for the reviewer to review. Best to add a few direct links to the pages in the PR -->
[preview](https://deploy-preview-4257--tyk-docs.netlify.app/docs/nightly/product-stack/tyk-gateway/release-notes/version-5.2)

### Description
<!-- 1. Describe your changes in detail. Why is this change required? What problem does it solve?
     2. Please explain the change to the reviewer. Pay special attention to changes that are hard to spot, 
       for example:
       2.1. Name change in the file name or directory name - please flag it out since it’s hard 
            to compare text after such a change 
       2.2. Terminology change - flag it out to make sure the reviewer is aware before approving
     3. @mentions of the person to review the proposed changes. They need to be able to know the topic well in order to approve it.
-->
<br>

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have added a **preview link** to the PR description.
- [x] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [x] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x] Make sure you have started *your change* off *our latest `master`*.
- [x] I **labelled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->


___

## **Type**
documentation


___

## **Description**
- Removed an anchor tag from the summary of the enforced timeouts section in the Tyk Gateway 5.2 release notes. This change was necessary because the anchor tag was not functioning as expected with the summary element.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version-5.2.md</strong><dd><code>Removal of Section Anchor in Gateway 5.2 Release Notes</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
<li>Removed an anchor tag from a section summary about enforced timeouts.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4257/files#diff-b6aafe51c3462aa4b79bcc868277e2224ec67ccd562a24716ddcae0401cda8bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



[DX-1188]: https://tyktech.atlassian.net/browse/DX-1188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ