### PR TITLE
Merging to release-5.2: [DX-1188] Remove section anchor in release notes 5.2.2 in changelog for enforced timeout (#4257)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
@@ -228,7 +228,7 @@ Fixed a minor issue with Go Plugin virtual endpoints where a runtime log error w
 **Attention**: Please read this section carefully. We have two topics to report:
 
 ##### Default proxy timeout
-We have fixed a bug where [request timeouts were not correctly enforced]({{< ref "#enforced-timeout-fix" >}}). As part of this solution we have introduced a default 30 second timeout for upstream requests (previously the default behaviour would be to wait forever). You can alter this Gateway-wide default using [proxy_default_timeout]({{< ref "tyk-oss-gateway/configuration#proxy_default_timeout" >}}).
+We have fixed a bug where request timeouts were not correctly enforced. As part of this solution we have introduced a default 30 second timeout for upstream requests (previously the default behaviour would be to wait forever). You can alter this Gateway-wide default using [proxy_default_timeout]({{< ref "tyk-oss-gateway/configuration#proxy_default_timeout" >}}).
 
 ##### Early Access Features:
 Please note that the `Tyk OAS APIs` feature, currently marked as *Early Access*, is subject to breaking changes in subsequent releases. Please refer to our [Early Access guide]({{<ref "frequently-asked-questions/using-early-access-features">}}) for specific details. Upgrading to a new version may introduce changes that are not backwards-compatible. Downgrading or reverting an upgrade may not be possible resulting in a broken installation.
@@ -271,7 +271,7 @@ The following CVEs have been resolved in this release:
 <ul>
 <li>
 <details>
-<summary>Enforced timeouts were incorrect on a per-request basis</summary> {#enforced-timeout-fix}
+<summary>Enforced timeouts were incorrect on a per-request basis</summary>
 
 Fixed an issue where [enforced timeouts]({{< ref "planning-for-production/ensure-high-availability/enforced-timeouts" >}}) values were incorrect on a per-request basis. Since we enforced timeouts only at the transport level and created the transport only once within the value set by [max_conn_time]({{< ref "tyk-oss-gateway/configuration#max_conn_time" >}}), the timeout in effect was not deterministic. Timeouts larger than 0 seconds are now enforced for each request. We have introduced a default timeout of 30 seconds, which you can alter using [proxy_default_timeout]({{< ref "tyk-oss-gateway/configuration#proxy_default_timeout" >}}).
 </details>


### PR DESCRIPTION
[DX-1188] Remove section anchor in release notes 5.2.2 in changelog for enforced timeout (#4257)

* Remove section anchor, not possible with summary
* Remove ref anchor and link
---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1188]: https://tyktech.atlassian.net/browse/DX-1188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ