### PR TITLE
Merging to release-5.1: [DX-1182] Update HMAC signatures snippet to fix bug (#4248)

### DIFF
--- a/tyk-docs/content/basic-config-and-security/security/authentication-authorization/hmac-signatures.md
+++ b/tyk-docs/content/basic-config-and-security/security/authentication-authorization/hmac-signatures.md
@@ -66,10 +66,10 @@ req.Header.Add("X-Test-1", "hello")
 req.Header.Add("X-Test-2", "world")
 
 // Prepare the signature to include those headers:
-signatureString := "(request-target): " + "get /"
-signatureString += "date:" + tim + " "
-signatureString += "x-test-1:" + "hello" + " "
-signatureString += "x-test-2:" + "world"
+signatureString := "(request-target): " + "get /your/path/goes/here"
+signatureString += "date: " + tim + "\n"
+signatureString += "x-test-1: " + "hello" + "\n"
+signatureString += "x-test-2: " + "world"
 
 // SHA1 Encode the signature
 HmacSecret := "secret-key"


### PR DESCRIPTION
[DX-1182] Update HMAC signatures snippet to fix bug (#4248)

Update hmac signatures snippet to fix bug
Each header should be separated by a new line and the header field should have a space after :

[DX-1182]: https://tyktech.atlassian.net/browse/DX-1182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ