### PR TITLE
Update to all title to h2

### DIFF
--- a/tyk-docs/content/plugins/tutorials/quick-starts/go/open-source.md
+++ b/tyk-docs/content/plugins/tutorials/quick-starts/go/open-source.md
@@ -16,7 +16,7 @@ In this tutorial you will learn how to:
 3. View the analytics.
 4. Next steps.
 
-### 1. Bootstrap the getting started example
+## 1. Bootstrap the getting started example
 
 Please run the following command from within your newly cloned directory to run the Tyk Stack and compile the sample plugin.  This will take a few minutes as we have to download all the necessary dependencies and docker images.
 
@@ -24,7 +24,7 @@ Please run the following command from within your newly cloned directory to run 
 make up-oss && make build
 ```
 
-### 2. Test the plugin
+## 2. Test the plugin
 
 Let's test the plugin by sending an API request to the pre-configured API definition:
 
@@ -53,7 +53,7 @@ We've sent an API request to the Gateway. We can see that the sample custom plug
 The `./tyk/scripts/bootstrap-oss.sh` script creates an API definition that includes the custom plugin.
 
 
-### 3. View the analytics
+## 3. View the analytics
 
 We can see that Tyk Pump is running in the background. Let's check the logs after sending the API request:
 
@@ -71,7 +71,7 @@ As we can see, when we send API requests, the Tyk Pump will scrape them from Red
 
 In this example, we've configured a simple `STDOUT` Pump where the records will be printed to the Standard OUT (docker logs!)
 
-### 4. Next steps
+## 4. Next steps
 
 Try updating the code of the plugin and experimenting. Once you've made changes to the example plugin, please run `make build` to compile the plugin and reload the gateway with the changes.
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated section titles from H3 to H2 in the Go quick start guide for better readability and consistency across the documentation.
- This change affects the headings for "Bootstrap the getting started example", "Test the plugin", "View the analytics", and "Next steps".


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>open-source.md</strong><dd><code>Update Section Titles from H3 to H2 for Better Readability</code></dd></summary>
<hr>

tyk-docs/content/plugins/tutorials/quick-starts/go/open-source.md
<li>Updated section titles from H3 to H2 for consistency and better <br>readability.<br> <li> No changes to the code or content, purely formatting adjustments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4275/files#diff-4c5027158e0e424899844466b0374ce43e2b5eecd0e3a9060e5639d52521c395">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

