### PR TITLE
[DX-1196]align to the center in mobile on this page

### DIFF
--- a/tyk-docs/assets/scss/_table-of-contents.scss
+++ b/tyk-docs/assets/scss/_table-of-contents.scss
@@ -190,6 +190,6 @@ body:not(.hasSidebar) .documentation-table-of-contents {
 @media only screen and (max-width: 768px) {
 	.documentation-table-of-contents a {
 		width: 100%;
-		text-align: center;
+		text-align: left;
 	}
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Changed text alignment for table of contents links to left on mobile view to improve readability and consistency with the rest of the page layout.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_table-of-contents.scss</strong><dd><code>Align Table of Contents Links to Left on Mobile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/scss/_table-of-contents.scss
<li>Changed the text alignment for <code>.documentation-table-of-contents a</code> from <br><code>center</code> to <code>left</code> on screens smaller than 768px.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4276/files#diff-a9b2fe01555dddb1b7c553a79ac798f880b16abd38256b3ed7d741a50c4342ae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

