### PR TITLE
Merging to release-5.1: [DX-1005] - Update Using Custom Domains content to mention that wild cards in custom domain certificates not supported by Tyk Cloud (#4238)

### DIFF
--- a/tyk-docs/content/tyk-cloud/using-custom-domains.md
+++ b/tyk-docs/content/tyk-cloud/using-custom-domains.md
@@ -14,6 +14,12 @@ aliases:
 
 You can set up Tyk Cloud to use a custom domain. Using custom domains is available on our free trial and all our paid [plans](https://tyk.io/price-comparison/). You can use a custom domain for both your **Control Planes** and **Cloud Data Planes**.
 
+{{< note success >}}
+**note**
+
+Wild cards are not supported by Tyk Cloud in custom domain certificates
+{{< /note >}}
+
 ### Custom Domains with Control Planes
 
 * Currently, you can only use **one custom domain** per Control Plane deployment.


### PR DESCRIPTION
[DX-1005] - Update Using Custom Domains content to mention that wild cards in custom domain certificates not supported by Tyk Cloud (#4238)

* Add note to mention that wild cards are not supported by Tyk Cloud in custom domains

---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1005]: https://tyktech.atlassian.net/browse/DX-1005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ