### PR TITLE
[DX-1203, TT-11115] Added default values for min/max TLS version

### DIFF
--- a/tyk-docs/content/basic-config-and-security/security/tls-and-ssl.md
+++ b/tyk-docs/content/basic-config-and-security/security/tls-and-ssl.md
@@ -124,7 +124,7 @@ Finally, set the [host_config.generate_secure_paths]({{< ref "tyk-dashboard/conf
 
 #### Values for TLS Versions
 
-You need to use the following values for setting the TLS `min_version`:
+You need to use the following values for setting the TLS `min_version` and `max_version`:
 
 | TLS Version   | Value to Use   |
 |---------------|----------------|
@@ -133,6 +133,13 @@ You need to use the following values for setting the TLS `min_version`:
 |      1.2      |      771       |
 |      1.3      |      772       |
 
+{{< note success >}}
+**Note**  
+
+If you do not configure minimum and maximum TLS versions, then Tyk Gateway will default to:
+ - minimum TLS version: 1.0
+ - maximum TLS version: 1.2
+{{< /note >}}
 
 #### Specify TLS Cipher Suites for Tyk Gateway & Tyk Dashboard
 


### PR DESCRIPTION
## **User description**
### Preview Link

### Description
Added default values for min/max TLS version


___

## **Type**
documentation


___

## **Description**
- Updated the TLS and SSL documentation to include information on setting both minimum and maximum TLS versions.
- Introduced default values for TLS `min_version` and `max_version`, enhancing clarity for users on the default behavior.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tls-and-ssl.md</strong><dd><code>Documentation Update for TLS Version Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/basic-config-and-security/security/tls-and-ssl.md
<li>Expanded the TLS version configuration section to include <code>max_version</code>.<br> <li> Added default values for <code>min_version</code> and <code>max_version</code> if not <br>configured.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4303/files#diff-b17c249d7eeec9b4df7b3d5b3a59081c026f529f5e0888153443cd2f72e2d97c">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

