### PR TITLE
[DX-1205] Update gateway-config.md to clarify value format

### DIFF
--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -91,7 +91,8 @@ Specify public keys used for Certificate Pinning on global level.
 EV: <b>TYK_GW_SECURITY_CERTIFICATES_UPSTREAM</b><br />
 Type: `map[string]string`<br />
 
-Specify upstream mutual TLS certificates at a global level in the following format: `{ "<host>": "<cert>" }``
+Specify upstream mutual TLS certificates at a global level as a map of domain -> certificate id or path.<br />
+In tyk.conf, this would be `"security": {"certificates": {"upstream": {"*": "/certs/default.pem", "example.com": "ab23ef123"}}},`; as an environmental variable it would be `*:/certs/default.pem,example.com:ab23ef123`.
 
 ### security.certificates.control_api
 EV: <b>TYK_GW_SECURITY_CERTIFICATES_CONTROLAPI</b><br />


### PR DESCRIPTION
The description currently attached to TYK_GW_SERCURITY_CERTIFICATES_UPSTREAM makes it appear that a JSON string should be set as the environmental variable to override the `security.certificatges.upstream` map in `tyk.conf`. However, using this format results in Tyk totally ignoring the specified upstream certificates. I updated the description to make it clear that the JSON map is used in `tyk.conf` while the environmental variable is set via a comma separated list of `host:cert` statements.

### For internal users - Please add a Jira DX PR ticket to the subject!
<br>

---

### Preview Link
<!-- Add a direct preview link to make it easier for the reviewer to review. Best to add a few direct links to the pages in the PR -->
<br>

### Description
<!-- 1. Describe your changes in detail. Why is this change required? What problem does it solve?
     2. Please explain the change to the reviewer. Pay special attention to changes that are hard to spot, 
       for example:
       2.1. Name change in the file name or directory name - please flag it out since it’s hard 
            to compare text after such a change 
       2.2. Terminology change - flag it out to make sure the reviewer is aware before approving
     3. @mentions of the person to review the proposed changes. They need to be able to know the topic well in order to approve it.
-->
<br>

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have added a **preview link** to the PR description.
- [x] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [x] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x] Make sure you have started *your change* off *our latest `master`*.
- [ ] I **labelled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->
