### PR TITLE
[DX-1093] Update id_extractor_deadline field description for protobuf documentation of the SessionState message

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -262,7 +262,7 @@ Tags are embedded into analytics data when the request completes. If a policy ha
 As of v2.1, an Alias offers a way to identify a token in a more human-readable manner, add an Alias to a token in order to have the data transferred into Analytics later on so you can track both hashed and un-hashed tokens to a meaningful identifier that doesn't expose the security of the underlying token.
 
 `id_extractor_deadline`
-See [Auth Plugins]({{< ref "plugins/plugin-types/auth-plugins/auth-plugins" >}}) for additional information.
+This is a UNIX timestamp that signifies when a cached key or ID will expire. This relates to custom authentication, where authenticated keys can be cached to save repeated requests to the gRPC server. See [id_extractor]({{< ref "plugins/plugin-types/auth-plugins/id-extractor" >}}) and [Auth Plugins]({{< ref "plugins/plugin-types/auth-plugins/auth-plugins" >}}) for additional information.
 
 `session_lifetime`
 UNIX timestamp that denotes when the key will automatically expire. Any·subsequent API request made using the key will be rejected. Overrides the global session lifetime. See [Key Expiry and Deletion]({{< ref "basic-config-and-security/security/authentication-authorization/physical-key-expiry" >}}) for more information.


### PR DESCRIPTION
## **User description**
### For internal users - Please add a Jira DX PR ticket to the subject!
[DX-1093](https://tyktech.atlassian.net/browse/DX-1093)

---

### Preview Link
<!-- Add a direct preview link to make it easier for the reviewer to review. Best to add a few direct links to the pages in the PR -->
[preview](/docs/nightly/plugins/supported-languages/rich-plugins/rich-plugins-data-structures/)

### Description
<!-- 1. Describe your changes in detail. Why is this change required? What problem does it solve?
     2. Please explain the change to the reviewer. Pay special attention to changes that are hard to spot, 
       for example:
       2.1. Name change in the file name or directory name - please flag it out since it’s hard 
            to compare text after such a change 
       2.2. Terminology change - flag it out to make sure the reviewer is aware before approving
     3. @mentions of the person to review the proposed changes. They need to be able to know the topic well in order to approve it.
-->
Update id_extractor_deadline field description for protobuf documentation of the SessionState message
The description of the id_extractor_deadline attribute needs to be improved so that it mentions that it is a UNIX timestamp that signifies when the cache key or ID will expire. This is relevant for custom authentication and is a performance benefit to cache authenticated keys, thus saving a request to gRPC server.

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have added a **preview link** to the PR description.
- [x] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [x] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x] Make sure you have started *your change* off *our latest `master`*.
- [x] I **labelled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->


[DX-1093]: https://tyktech.atlassian.net/browse/DX-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
documentation


___

## **Description**
- Updated the `id_extractor_deadline` field description in the rich plugin data structures documentation to clarify its use as a UNIX timestamp for cache expiration.
- This change aims to improve understanding of custom authentication performance benefits through caching.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rich-plugins-data-structures.md</strong><dd><code>Update <code>id_extractor_deadline</code> field description in plugin data <br>structures</code></dd></summary>
<hr>

tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
<li>Updated the description of <code>id_extractor_deadline</code> to include its <br>purpose and significance.<br> <li> Added information about the UNIX timestamp and its role in caching <br>authenticated keys.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4326/files#diff-145c1da09aa93cd7b1fbd3d9c15f65dbc8f633eaac8461743fbe2fe98dd81037">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

