### PR TITLE
Merging to release-5.3: [DX-1174] Update stable branch updater GHub action to ref release-5.3 branch (#4283)

### DIFF
--- a/.github/workflows/stable-updater.yaml
+++ b/.github/workflows/stable-updater.yaml
@@ -2,12 +2,12 @@ name: Stable branch update
 on:
   push:
     branches:
-      - release-5.2
+      - release-5.3
 
 jobs:
   stable:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/release-5.2'
+    if: github.ref == 'refs/heads/release-5.3'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## **User description**
[DX-1174] Update stable branch updater GHub action to ref release-5.3 branch (#4283)

update stable branch update to ref release-5.3 branch

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1174]: https://tyktech.atlassian.net/browse/DX-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
enhancement


___

## **Description**
- Updated the GitHub Actions workflow to trigger on pushes to `release-5.3` instead of `release-5.2`.
- Ensured the workflow conditionally runs only for pushes to `release-5.3`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stable-updater.yaml</strong><dd><code>Update GitHub Action for Stable Branch to Reference `release-5.3`</code></dd></summary>
<hr>

.github/workflows/stable-updater.yaml
<li>Updated the branch reference from <code>release-5.2</code> to <code>release-5.3</code> in both <br>the trigger condition and the job condition.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4367/files#diff-f7fcfa8300d37bebb207c3b4355f4361cd5c0cbf353e5dff62a50777179ee38d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

