### PR TITLE
Merging to release-5.3: Fix page_available_since.py to have trailing slash for release 5.2 (#4374)

### DIFF
--- a/scripts/page_available_since.py
+++ b/scripts/page_available_since.py
@@ -8,7 +8,7 @@ versions = [
         "branch": "release-5.3"
     },
     {
-        "path": "/docs/5.2",
+        "path": "/docs/5.2/",
         "name": "5.2",
         "branch": "release-5.2"
     },


### PR DESCRIPTION
## **User description**
Fix page_available_since.py to have trailing slash for release 5.2 (#4374)

Update page_available_since.py


___

## **Type**
bug_fix


___

## **Description**
- Corrected the path configuration for version 5.2 by adding a trailing slash, ensuring consistency and potentially fixing related path resolution issues.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page_available_since.py</strong><dd><code>Add Trailing Slash to Version Path in Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/page_available_since.py
<li>Added a trailing slash to the <code>path</code> for version 5.2 in the version <br>configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4375/files#diff-edbab172777b759de634afd083feceedee5dd15cb086cd9e5180ba0815bb4454">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

