### PR TITLE
Merging to release-5.3: [DX-1247] Add fix to remove /doc prefix (#4388)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
+++ b/tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
@@ -1,7 +1,7 @@
 {{- range $key, $value := .Site.RegularPages }}
    {{- $title := (replace .Title "\"" "\\\"") }}
    {{- $path := .File.Path }}
-   {{- $url := printf "%s" (replace $value.RelPermalink "/docs/" "/") }}
+   {{- $url := replaceRE "^/docs(/[0-9]+\\.[0-9]+)?(/.*)?$" "$2" $value.RelPermalink }}
    {{- $url = printf "%s" (replace $url "/nightly/" "/") }}
    {{- printf "{\"path\":\"%s\", \"title\":\"%s\", \"file\": \"./content/%s\"}\n" $url $title $path}}
    {{- range $value.Aliases }}


### PR DESCRIPTION
## **User description**
[DX-1247] Add fix to remove /doc prefix (#4388)

add fix to remove /doc prefix

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1247]: https://tyktech.atlassian.net/browse/DX-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
enhancement


___

## **Description**
- Updated URL generation logic in `list.urlcheck.json` to enhance documentation URL structure by removing the `/docs` prefix.
- This change applies a more robust regex for handling optional versioned paths in documentation URLs, ensuring a cleaner URL structure for all documentation pages.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>list.urlcheck.json</strong><dd><code>Update URL Generation to Remove `/docs` Prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/themes/tykio/layouts/_default/list.urlcheck.json
<li>Updated URL generation logic to remove <code>/docs</code> prefix from URLs.<br> <li> Improved URL replacement regex to handle versioned documentation <br>paths.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4390/files#diff-2dd99ef54318024ee70f9b72c59e69ac0c24637e2efc493c004d25789187d26c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

