### PR TITLE
[DX-1250] Added note for Redis Rate Limiter enhancement

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
@@ -366,7 +366,7 @@ We have made some changes to the Tyk OAS API Definition to provide a stable cont
 <details>
 <summary>Optimised Gateway memory use and network interaction when using Redis Rate Limiter</summary>
 
-We have optimised the allocation behaviour of our sliding window log rate limiter implementation ([Redis Rate Limiter](getting-started/key-concepts/rate-limiting#redis-rate-limiter)). Previously the complete request log would be retrieved from Redis but with this enhancement only the count of the requests in the window is retrieved, optimising the network interaction with Redis and decreasing the memory in use on gateway side.
+We have optimised the allocation behaviour of our sliding window log rate limiter implementation ([Redis Rate Limiter]({{< ref "getting-started/key-concepts/rate-limiting#redis-rate-limiter" > }})). Previously the complete request log would be retrieved from Redis. With this enhancement only the count of the requests in the window is retrieved, optimising the interaction with Redis and decreasing the Gateway memory usage.
 
 </details>
 </li>

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
@@ -362,6 +362,14 @@ We have made some changes to the Tyk OAS API Definition to provide a stable cont
 
 </details>
 </li>
+<li>
+<details>
+<summary>Optimised Gateway memory use and network interaction when using Redis Rate Limiter</summary>
+
+We have optimised the allocation behaviour of our sliding window log rate limiter implementation ([Redis Rate Limiter](getting-started/key-concepts/rate-limiting#redis-rate-limiter)). Previously the complete request log would be retrieved from Redis but with this enhancement only the count of the requests in the window is retrieved, optimising the network interaction with Redis and decreasing the memory in use on gateway side.
+
+</details>
+</li>
 </ul>
  
 #### Fixed

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
@@ -366,7 +366,7 @@ We have made some changes to the Tyk OAS API Definition to provide a stable cont
 <details>
 <summary>Optimised Gateway memory usage and reduced network request payload with Redis Rate Limiter</summary>
 
-We have optimised the allocation behaviour of our sliding window log rate limiter implementation ([Redis Rate Limiter]({{< ref "getting-started/key-concepts/rate-limiting#redis-rate-limiter" > }})). Previously the complete request log would be retrieved from Redis. With this enhancement only the count of the requests in the window is retrieved, optimising the interaction with Redis and decreasing the Gateway memory usage.
+We have optimised the allocation behaviour of our sliding window log rate limiter implementation ([Redis Rate Limiter]({{< ref "getting-started/key-concepts/rate-limiting#redis-rate-limiter" >}})). Previously the complete request log would be retrieved from Redis. With this enhancement only the count of the requests in the window is retrieved, optimising the interaction with Redis and decreasing the Gateway memory usage.
 
 </details>
 </li>

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
@@ -364,7 +364,7 @@ We have made some changes to the Tyk OAS API Definition to provide a stable cont
 </li>
 <li>
 <details>
-<summary>Optimised Gateway memory use and network interaction when using Redis Rate Limiter</summary>
+<summary>Optimised Gateway memory usage and reduced network request payload with Redis Rate Limiter</summary>
 
 We have optimised the allocation behaviour of our sliding window log rate limiter implementation ([Redis Rate Limiter]({{< ref "getting-started/key-concepts/rate-limiting#redis-rate-limiter" > }})). Previously the complete request log would be retrieved from Redis. With this enhancement only the count of the requests in the window is retrieved, optimising the interaction with Redis and decreasing the Gateway memory usage.
 


### PR DESCRIPTION
## **User description**
Missed from original RN due to ticket being incorrectly labelled.

[DX-1250](https://tyktech.atlassian.net/browse/DX-1250)

[preview](https://deploy-preview-4396--tyk-docs.netlify.app/docs/nightly/product-stack/tyk-gateway/release-notes/version-5.3)
___

## **Type**
enhancement, documentation


___

## **Description**
- Added documentation for an enhancement to the Redis Rate Limiter, focusing on optimizing memory and network usage.
- This update ensures that only the count of requests within the rate limiting window is retrieved from Redis, improving performance and reducing memory usage on the gateway side.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version-5.3.md</strong><dd><code>Optimized Redis Rate Limiter Interaction and Memory Use</code>&nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
<li>Added a note about optimizing Gateway memory use and network <br>interaction when using Redis Rate Limiter.<br> <li> Describes the enhancement of the Redis Rate Limiter to only retrieve <br>the count of requests in the window, rather than the complete request <br>log.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4396/files#diff-ead598197a92e18014f4f7c35c341621948fb6cdf66d45c1dd05de21bc2b35aa">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



[DX-1250]: https://tyktech.atlassian.net/browse/DX-1250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ