### PR TITLE
Merging to release-5.3: [DX-1253]reduce the padding with content (#4404)

### DIFF
--- a/tyk-docs/assets/scss/_bespoke.scss
+++ b/tyk-docs/assets/scss/_bespoke.scss
@@ -1578,13 +1578,13 @@ body {
 
 .wysiwyg h2 {
   font-size: 25px;
-  margin-bottom: 20px;
+  margin-bottom: 8px;
 }
 
 .wysiwyg h3 {
   font-size: 18px;
   font-weight: bold;
-  margin-bottom: 26px;
+  margin-bottom: 4px;
   margin-top: 55px;
 }
 
@@ -1610,7 +1610,7 @@ body {
 
 .wysiwyg hr {
   border: 0;
-  border-bottom: 2px solid #E4E4E4;
+  border-bottom: 1px solid #000000;
   outline: none;
   margin-top: 52px;
 }

--- a/tyk-docs/assets/scss/_docs.scss
+++ b/tyk-docs/assets/scss/_docs.scss
@@ -403,28 +403,28 @@ iframe {
   font-size: 22px;
   font-family: "Inter", sans-serif;
   font-weight: bold;
-  padding-top: 13px;
+  padding-top: 35px;
   margin-top: 0;
 }
 
 .wysiwyg h4 {
   font-size: 19px;
-  margin-bottom: 26px;
-  margin-top: 55px;
+  margin-bottom: 4px;
+  margin-top: 35px;
   font-family: "Inter", sans-serif;
   font-weight: bold;
 }
 
 .wysiwyg h5 {
   font-size: 17.5px;
-  margin-bottom: 26px;
-  margin-top: 55px;
+  margin-bottom: 4px;
+  margin-top: 27px;
   font-family: "Inter", sans-serif;
 }
 
 .wysiwyg p {
-  margin-bottom: 16px;
-  margin-top: 16px;
+  margin-bottom: 0px;
+  margin-top: 8px;
 }
 
 /* Code Blocks */


### PR DESCRIPTION
## **User description**
[DX-1253]reduce the padding with content (#4404)

* reduce the padding with content

[DX-1253]: https://tyktech.atlassian.net/browse/DX-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
enhancement


___

## **Description**
- Reduced the vertical spacing for headings (`h2`, `h3`, `h4`, `h5`) across documentation pages for a more compact look.
- Adjusted the styling of horizontal rules (`hr`) to be 1px solid black, enhancing visual consistency.
- Modified paragraph (`p`) spacing for improved readability and layout compactness.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_bespoke.scss</strong><dd><code>Adjust Heading Margins and Horizontal Rule Styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/scss/_bespoke.scss
<li>Reduced margin-bottom for <code>h2</code> from 20px to 8px.<br> <li> Reduced margin-bottom for <code>h3</code> from 26px to 4px, keeping margin-top as <br>55px.<br> <li> Changed <code>hr</code> border-bottom from 2px solid #E4E4E4 to 1px solid #000000.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4409/files#diff-4d88d302558832943d8a99db09e36c42f8f75ba4a04df83b0b2ada3e1613e4a5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_docs.scss</strong><dd><code>Enhance Spacing for Headings and Paragraphs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/scss/_docs.scss
<li>Increased padding-top for <code>h3</code> from 13px to 35px.<br> <li> Adjusted margins for <code>h4</code> and <code>h5</code>, reducing bottom margin to 4px and <br>setting top margins to 35px and 27px respectively.<br> <li> Set paragraph (<code>p</code>) margin-bottom to 0px and margin-top to 8px.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4409/files#diff-d29767519ca2fa4d8fce78b76e949905e03684c9f9d6572ff6b4f23888480e7e">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

