### PR TITLE
Merging to release-5.3: [DX-1093] Update id_extractor_deadline field description for protobuf documentation of the SessionState message (#4326)

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -262,7 +262,7 @@ Tags are embedded into analytics data when the request completes. If a policy ha
 As of v2.1, an Alias offers a way to identify a token in a more human-readable manner, add an Alias to a token in order to have the data transferred into Analytics later on so you can track both hashed and un-hashed tokens to a meaningful identifier that doesn't expose the security of the underlying token.
 
 `id_extractor_deadline`
-See [Auth Plugins]({{< ref "plugins/plugin-types/auth-plugins/auth-plugins" >}}) for additional information.
+This is a UNIX timestamp that signifies when a cached key or ID will expire. This relates to custom authentication, where authenticated keys can be cached to save repeated requests to the gRPC server. See [id_extractor]({{< ref "plugins/plugin-types/auth-plugins/id-extractor" >}}) and [Auth Plugins]({{< ref "plugins/plugin-types/auth-plugins/auth-plugins" >}}) for additional information.
 
 `session_lifetime`
 UNIX timestamp that denotes when the key will automatically expire. Any·subsequent API request made using the key will be rejected. Overrides the global session lifetime. See [Key Expiry and Deletion]({{< ref "basic-config-and-security/security/authentication-authorization/physical-key-expiry" >}}) for more information.


### PR DESCRIPTION
## **User description**
[DX-1093] Update id_extractor_deadline field description for protobuf documentation of the SessionState message (#4326)

Update id_extractor_deadline field description for protobuf plugins

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1093]: https://tyktech.atlassian.net/browse/DX-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
documentation


___

## **Description**
- Updated the `id_extractor_deadline` field description in the documentation to clarify its role in caching keys for custom authentication and its expiration mechanism.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rich-plugins-data-structures.md</strong><dd><code>Update Field Description in Rich Plugins Data Structures Documentation</code></dd></summary>
<hr>

tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
<li>Updated the description of the <code>id_extractor_deadline</code> field to include <br>more detailed information about its purpose and usage.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4446/files#diff-145c1da09aa93cd7b1fbd3d9c15f65dbc8f633eaac8461743fbe2fe98dd81037">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

