### PR TITLE
Merging to release-5.2: [DX-1093] Update id_extractor_deadline field description for protobuf documentation of the SessionState message (#4326)

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -262,7 +262,7 @@ Tags are embedded into analytics data when the request completes. If a policy ha
 As of v2.1, an Alias offers a way to identify a token in a more human-readable manner, add an Alias to a token in order to have the data transferred into Analytics later on so you can track both hashed and un-hashed tokens to a meaningful identifier that doesn't expose the security of the underlying token.
 
 `id_extractor_deadline`
-See [Auth Plugins]({{< ref "plugins/plugin-types/auth-plugins/auth-plugins" >}}) for additional information.
+This is a UNIX timestamp that signifies when a cached key or ID will expire. This relates to custom authentication, where authenticated keys can be cached to save repeated requests to the gRPC server. See [id_extractor]({{< ref "plugins/plugin-types/auth-plugins/id-extractor" >}}) and [Auth Plugins]({{< ref "plugins/plugin-types/auth-plugins/auth-plugins" >}}) for additional information.
 
 `session_lifetime`
 UNIX timestamp that denotes when the key will automatically expire. Any·subsequent API request made using the key will be rejected. Overrides the global session lifetime. See [Key Expiry and Deletion]({{< ref "basic-config-and-security/security/authentication-authorization/physical-key-expiry" >}}) for more information.


### PR DESCRIPTION
[DX-1093] Update id_extractor_deadline field description for protobuf documentation of the SessionState message (#4326)

Update id_extractor_deadline field description for protobuf plugins

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1093]: https://tyktech.atlassian.net/browse/DX-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ