### PR TITLE
Revert "[DX-1163]remove versions values if they are all similar (version selector)"

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/version_selector.html
+++ b/tyk-docs/themes/tykio/layouts/partials/version_selector.html
@@ -9,11 +9,7 @@
     {{- range $.Site.Data.page_available_since.versions -}}
     {{ $versionUrl := "" }}
     {{- if  $values -}}
-        {{- if and (isset $values "all_versions_are_similar_to_path") (eq $values.all_versions_are_similar_to_path true) -}}
-            {{ $versionUrl = $pagePath }}
-        {{ else }}
-            {{ $versionUrl = index $values .path }}
-        {{- end -}}
+        {{ $versionUrl = index $values .path }}
     {{- end -}}
     {{- $versionUrl = strings.TrimPrefix "/" $versionUrl }}
     <option value="{{.path}}" {{if $versionUrl}} data-url="{{$versionUrl}}" {{end}}  {{if eq $currentVersion .path}} selected="selected" {{end}} {{- if not $versionUrl -}} disabled {{end}}>{{.name}}</option>


### PR DESCRIPTION
## **User description**
Reverts TykTechnologies/tyk-docs#4234
This is being reverted since when select nightly it selects latest version


___

## **Type**
bug_fix


___

## **Description**
- Reverted changes that simplified the version URL setting when all versions were similar.
- This revert ensures that the version selector behaves correctly for nightly builds and does not default to the latest version.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version_selector.html</strong><dd><code>Simplify Version URL Setting in Version Selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/themes/tykio/layouts/partials/version_selector.html
<li>Removed conditional logic that set the version URL based on the <br>similarity of all versions.<br> <li> Always set the version URL based on the path from the versions data.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4460/files#diff-da3b627b2125babaa85f108a3ef8179286e7609e7c8848f0cfbef4b8c0ee2326">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

