### PR TITLE
Revert "[DX-1163]make the page_available_since  smaller by removing links that are in all versions with similar urls"

### DIFF
--- a/scripts/page_available_since.py
+++ b/scripts/page_available_since.py
@@ -73,21 +73,6 @@ aliases = set()
 
 def process_and_write_to_file() -> None:
     available = get_and_process_urls()
-    for page_url, version_mapping in available.items():
-        available[page_url]["all_versions_are_similar_to_path"] = True
-        for version in versions:
-            path = version["path"]
-            if path not in version_mapping:
-                available[page_url]["all_versions_are_similar_to_path"] = False
-                break
-            elif version_mapping[path] != page_url:
-                available[page_url]["all_versions_are_similar_to_path"] = False
-                break
-        if available[page_url]["all_versions_are_similar_to_path"] == True:
-            available[page_url].clear()
-            available[page_url]["all_versions_are_similar_to_path"] = True
-        else:
-            del available[page_url]["all_versions_are_similar_to_path"]
     data_file = {"versions": versions, "pages": available}
     with open(filePath, 'w') as file:
         json.dump(data_file, file, indent=4)


### PR DESCRIPTION
## **User description**
Reverts TykTechnologies/tyk-docs#4232 reset Python script to rollack script that reduces size of json file


___

## **Type**
bug_fix


___

## **Description**
- This PR reverts a previous change which attempted to optimize the JSON file size by removing entries with similar URLs across all versions. The reverted changes had modified the logic in `process_and_write_to_file` function to filter out these entries, which has now been restored to its original state.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page_available_since.py</strong><dd><code>Revert changes to JSON file size optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/page_available_since.py
<li>Reverted changes that attempted to reduce JSON file size by removing <br>duplicate page entries.<br> <li> Restored original logic for processing and writing data to file <br>without filtering similar URLs across versions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4462/files#diff-edbab172777b759de634afd083feceedee5dd15cb086cd9e5180ba0815bb4454">+0/-15</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

