### PR TITLE
[TT-11929, DX-1279] Clarification of Go template behaviour - response transform

### DIFF
--- a/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
+++ b/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
@@ -60,9 +60,9 @@ The middleware has direct access to the response body and also to dynamic data a
 The response body transform middleware can iterate through list indices in dynamic data so, for example, calling `{{ index ._tyk_context.request_data.variablename 0 }}` in a template will expose the first entry in the `request_data.variablename` key/value array.
 
 {{< note success >}}
- **Note**  
+**Note**  
 
- As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. Context variables and session metadata are, if enabled, provided with the response body in the data structure to which the template is applied and so will be processed accordingly if, for example, the template applies a transformation to the entire data structure.
+As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. This data structure consists of the request context variables (`_tyk_context`) and session metadata (`_tyk_meta`) - if enabled for the middleware - concatenated with the response body.
  {{< /note >}}
 
 ### Automatic XML <-> JSON Transformation

--- a/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
+++ b/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
@@ -57,7 +57,13 @@ The middleware has direct access to the response body and also to dynamic data a
 - Inbound form or query data can be accessed through the `._tyk_context.request_data` namespace where it will be available in as a `key:[]value` map
 - values from [key-value (KV) storage]({{< ref "tyk-configuration-reference/kv-store#transformation-middleware" >}}) can be injected into the template using the notation appropriate to the location of the KV store
  
-Note that the response body transform middleware can iterate through list indices in dynamic data so, for example, calling `{{ index ._tyk_context.request_data.variablename 0 }}` in a template will expose the first entry in the `request_data.variablename` key/value array.
+The response body transform middleware can iterate through list indices in dynamic data so, for example, calling `{{ index ._tyk_context.request_data.variablename 0 }}` in a template will expose the first entry in the `request_data.variablename` key/value array.
+
+{{< note success >}}
+ **Note**  
+
+ As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. Context variables and session metadata are, if enabled, provided alongside the response body in the data structure to which the template is applied and so will be processed accordingly if, for example, the template applies a transformation to the entire data structure.
+ {{< /note >}}
 
 ### Automatic XML <-> JSON Transformation
 

--- a/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
+++ b/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
@@ -62,7 +62,7 @@ The response body transform middleware can iterate through list indices in dynam
 {{< note success >}}
 **Note**  
 
-As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. The template receives the decoded JSON or XML of the request body. If session variables or meta data are enabled, additional fields will be provided: `_tyk_context` and `_tyk_meta` respectively.
+As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. The template receives the decoded JSON or XML of the response body. If session variables or meta data are enabled, additional fields will be provided: `_tyk_context` and `_tyk_meta` respectively.
  {{< /note >}}
 
 ### Automatic XML <-> JSON Transformation

--- a/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
+++ b/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
@@ -62,7 +62,7 @@ The response body transform middleware can iterate through list indices in dynam
 {{< note success >}}
 **Note**  
 
-As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. This data structure consists of the request context variables (`_tyk_context`) and session metadata (`_tyk_meta`) - if enabled for the middleware - concatenated with the response body.
+As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. The template receives the decoded JSON or XML of the request body. If session variables or meta data are enabled, additional fields will be provided: `_tyk_context` and `_tyk_meta` respectively.
  {{< /note >}}
 
 ### Automatic XML <-> JSON Transformation

--- a/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
+++ b/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
@@ -62,7 +62,7 @@ The response body transform middleware can iterate through list indices in dynam
 {{< note success >}}
  **Note**  
 
- As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. Context variables and session metadata are, if enabled, provided alongside the response body in the data structure to which the template is applied and so will be processed accordingly if, for example, the template applies a transformation to the entire data structure.
+ As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. Context variables and session metadata are, if enabled, provided with the response body in the data structure to which the template is applied and so will be processed accordingly if, for example, the template applies a transformation to the entire data structure.
  {{< /note >}}
 
 ### Automatic XML <-> JSON Transformation


### PR DESCRIPTION
DX-1279

### Preview Link
https://deploy-preview-4487--tyk-docs.netlify.app/docs/nightly/advanced-configuration/transform-traffic/response-body/

### Description
Added a note to explain behaviour of Go Templating with context variables and session metadata (to match the edit proposed for Request Body Transform)