### PR TITLE
Merging to release-5.3: [DX-1081] Add last_updated to SessionState protobuf in the plugins data structures page  (#4329)

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -248,6 +248,9 @@ Tags are embedded into analytics data when the request completes. If a policy ha
 `alias`
 As of v2.1, an Alias offers a way to identify a token in a more human-readable manner, add an Alias to a token in order to have the data transferred into Analytics later on so you can track both hashed and un-hashed tokens to a meaningful identifier that doesn't expose the security of the underlying token.
 
+`last_updated`
+A UNIX timestamp that represents the time the session was last updated. Applicable to *Post*, *PostAuth* and *Response* plugins. When developing *CustomAuth* plugins this should also be added to the SessionState instance.
+
 `id_extractor_deadline`
 This is a UNIX timestamp that signifies when a cached key or ID will expire. This relates to custom authentication, where authenticated keys can be cached to save repeated requests to the gRPC server. See [id_extractor]({{< ref "plugins/plugin-types/auth-plugins/id-extractor" >}}) and [Auth Plugins]({{< ref "plugins/plugin-types/auth-plugins/auth-plugins" >}}) for additional information.
 


### PR DESCRIPTION
## **User description**
[DX-1081] Add last_updated to SessionState protobuf in the plugins data structures page  (#4329)

* Add last_updated to SessionState protobuf message

[DX-1081]: https://tyktech.atlassian.net/browse/DX-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
enhancement, documentation


___

## **Description**
- Added a new field `last_updated` to the SessionState protobuf documentation.
- Described the use of `last_updated` in various plugin types, enhancing the clarity and utility of the documentation for developers.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rich-plugins-data-structures.md</strong><dd><code>Document `last_updated` Field in SessionState Protobuf</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
<li>Added documentation for the <code>last_updated</code> field in the SessionState <br>protobuf.<br> <li> Explained the relevance of <code>last_updated</code> for Post, PostAuth, Response, <br>and CustomAuth plugins.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4498/files#diff-145c1da09aa93cd7b1fbd3d9c15f65dbc8f633eaac8461743fbe2fe98dd81037">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

