### PR TITLE
Merging to release-5.3: [TT-11929, DX-1279] Clarified example Go templates (#4488)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/references/go-templates.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/references/go-templates.md
@@ -201,6 +201,8 @@ The `jsonMarshal` function converts XML formatted input into JSON, for example:
 {"hello":"world"}
 ```
 
+Note that in this example, Go will step through the entire data structure provided to the template. When used in the [Request]({{< ref "transform-traffic/request-body#data-accessible-to-the-middleware" >}}) or [Response]({{< ref "advanced-configuration/transform-traffic/response-body#data-accessible-to-the-middleware" >}}) Body Transform middleware, this would include Context Variables and Session Metadata if provided to the middleware.
+
 ### JSON to XML conversion using xmlMarshal
 The `xmlMarshal` function converts JSON formatted input into XML, for example:
 
@@ -217,3 +219,5 @@ The `xmlMarshal` function converts JSON formatted input into XML, for example:
 ```xml
 <hello>world</hello>
 ```
+
+Note that in this example, Go will step through the entire data structure provided to the template. When used in the [Request]({{< ref "transform-traffic/request-body#data-accessible-to-the-middleware" >}}) or [Response]({{< ref "advanced-configuration/transform-traffic/response-body#data-accessible-to-the-middleware" >}}) Body Transform middleware, this would include Context Variables and Session Metadata if provided to the middleware.


### PR DESCRIPTION
## **User description**
[TT-11929, DX-1279] Clarified example Go templates (#4488)

Clarified example Go templates

Clarified how Go templates using the `.` cursor will interact with context variables and session metadata


___

## **Type**
documentation


___

## **Description**
- Added detailed notes in the Go templates documentation to clarify how templates interact with data structures when used in middleware.
- Explained the processing of Context Variables and Session Metadata by Go templates in middleware scenarios, enhancing understanding for developers.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go-templates.md</strong><dd><code>Clarify Go Template Behavior in Middleware Contexts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/references/go-templates.md
<li>Added explanatory notes on how Go templates process data structures in <br>the context of middleware.<br> <li> Clarified the interaction of Go templates with Context Variables and <br>Session Metadata in middleware scenarios.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4507/files#diff-2f7409b08301c9ef699a9b39ece653009520a2c08ad3d1b6717fc6e851d79022">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

