### PR TITLE
Merging to release-5.3: [DX-1286] Update minor typos in mTLS concepts page (#4497)

### DIFF
--- a/tyk-docs/content/basic-config-and-security/security/mutual-tls/concepts.md
+++ b/tyk-docs/content/basic-config-and-security/security/mutual-tls/concepts.md
@@ -49,19 +49,23 @@ The Tyk Gateway and Dashboard Admin APIs provide endpoints to create, remove, li
 
 * Create: `POST /tyk/certs` with PEM body. Returns `{"id": "<cert-id>", ... }`
 * Delete: `DELETE /tyk/certs/<cert-id>`
-* Get info: `GET /tyk/certs/<cert-id>`. Return meta info about certificate, something similar to: 
+* Get info: `GET /tyk/certs/<cert-id>`. Returns meta info about the certificate, something similar to: 
 ```json
 { 
   "id": "<cert-id>",
-  "fingerprint": <fingerprint>
+  "fingerprint": <fingerprint>,
   "has_private_key": false, 
-  "issuer": <issuer>
+  "issuer": <issuer>,
   "subject": "<cn>", ... 
 }
 ```
 * Get info about multiple certificates: `GET /tyk/certs/<cert-id1>,<cert-id2>,<cert-id3>`. 
 Returns array of meta info objects, similar to above.
-* List all certificate IDs: `GET /tyk/certs. Returns: { "certs": "<cert-id1>", "<cert-id2>", ...  }`
+* List all certificate IDs: `GET /tyk/certs`. Returns something similar to:
+
+```json
+{ "certs": "<cert-id1>", "<cert-id2>", ...  }
+```
 
 The Dashboard Admin API is very similar, except for a few minor differences:
 


### PR DESCRIPTION
## **User description**
[DX-1286] Update minor typos in mTLS concepts page (#4497)

* Update minor typos in mTLS concepts page
* Update concepts.md
---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1286]: https://tyktech.atlassian.net/browse/DX-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
documentation


___

## **Description**
- This PR focuses on improving the clarity and grammatical correctness of the mTLS concepts documentation.
- Specific changes include the addition of missing commas and improved phrasing in the descriptions of API endpoints.
- The JSON response format for listing all certificate IDs has been clarified with a better example.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>concepts.md</strong><dd><code>Improve Documentation Clarity and Grammar in mTLS Concepts Page</code></dd></summary>
<hr>

tyk-docs/content/basic-config-and-security/security/mutual-tls/concepts.md
<li>Corrected grammar and punctuation in the API endpoints descriptions.<br> <li> Added missing punctuation to JSON examples.<br> <li> Improved clarity in the listing of certificate IDs.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4508/files#diff-a75ed027494ad9947c95502e611b5c679201436c64d9f5a5fef1079034dc5df4">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

