### PR TITLE
Merging to release-5.3: [TT-11929, DX-1279] Clarification of Go template behaviour (#4486)

### DIFF
--- a/tyk-docs/content/transform-traffic/request-body.md
+++ b/tyk-docs/content/transform-traffic/request-body.md
@@ -59,7 +59,13 @@ The middleware has direct access to the request body and also to dynamic data as
  - inbound form or query data can be accessed through the `._tyk_context.request_data` namespace where it will be available in as a `key:[]value` map
  - values from [key-value (KV) storage]({{< ref "tyk-configuration-reference/kv-store#transformation-middleware" >}}) can be injected into the template using the notation appropriate to the location of the KV store
  
-Note that the request body transform middleware can iterate through list indices in dynamic data so, for example, calling `{{ index ._tyk_context.request_data.variablename 0 }}` in a template will expose the first entry in the `request_data.variablename` key/value array.
+The request body transform middleware can iterate through list indices in dynamic data so, for example, calling `{{ index ._tyk_context.request_data.variablename 0 }}` in a template will expose the first entry in the `request_data.variablename` key/value array.
+
+{{< note success >}}
+**Note**  
+
+As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. The template receives the decoded JSON or XML of the request body. If session variables or meta data are enabled, additional fields will be provided: `_tyk_context` and `_tyk_meta` respectively.
+{{< /note >}}
 
 ### Automatic XML <-> JSON Transformation
 


### PR DESCRIPTION
## **User description**
[TT-11929, DX-1279] Clarification of Go template behaviour (#4486)

* Clarification of Go template behaviour
* Apply suggestions from code review
* Update tyk-docs/content/transform-traffic/request-body.md


___

## **Type**
documentation


___

## **Description**
- Updated the documentation for Go template behavior in the request body transformation section.
- Added a detailed note on how templates process data structures, including session variables and metadata.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>request-body.md</strong><dd><code>Update and Clarify Go Template Behavior in Documentation</code>&nbsp; </dd></summary>
<hr>

tyk-docs/content/transform-traffic/request-body.md
<li>Clarified the behavior of request body transformation middleware in Go <br>templates.<br> <li> Added a note explaining how templates are executed with data <br>structures.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4512/files#diff-5320a3b289a2735f9afca5a4be7e55c1aca50cb2d127fbe07453d7fd83fb3546">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

