### PR TITLE
Merging to release-5.3: [TT-11929, DX-1279] Clarification of Go template behaviour - response transform (#4487)

### DIFF
--- a/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
+++ b/tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
@@ -57,7 +57,13 @@ The middleware has direct access to the response body and also to dynamic data a
 - Inbound form or query data can be accessed through the `._tyk_context.request_data` namespace where it will be available in as a `key:[]value` map
 - values from [key-value (KV) storage]({{< ref "tyk-configuration-reference/kv-store#transformation-middleware" >}}) can be injected into the template using the notation appropriate to the location of the KV store
  
-Note that the response body transform middleware can iterate through list indices in dynamic data so, for example, calling `{{ index ._tyk_context.request_data.variablename 0 }}` in a template will expose the first entry in the `request_data.variablename` key/value array.
+The response body transform middleware can iterate through list indices in dynamic data so, for example, calling `{{ index ._tyk_context.request_data.variablename 0 }}` in a template will expose the first entry in the `request_data.variablename` key/value array.
+
+{{< note success >}}
+**Note**  
+
+As explained in the [documentation](https://pkg.go.dev/text/template), templates are executed by applying them to a data structure. The template receives the decoded JSON or XML of the response body. If session variables or meta data are enabled, additional fields will be provided: `_tyk_context` and `_tyk_meta` respectively.
+ {{< /note >}}
 
 ### Automatic XML <-> JSON Transformation
 


### PR DESCRIPTION
## **User description**
[TT-11929, DX-1279] Clarification of Go template behaviour - response transform (#4487)

* Clarification of Go template behaviour - response
---------

Co-authored-by: Tit Petric <black@scene-si.org>


___

## **Type**
documentation


___

## **Description**
- Updated documentation to clarify the behavior of Go templates in the context of response transformations.
- Added a detailed note on how templates process decoded JSON or XML of the response body and how session variables and metadata are included.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>response-body.md</strong><dd><code>Clarify Go Template Behavior in Response Transform Documentation</code></dd></summary>
<hr>

tyk-docs/content/advanced-configuration/transform-traffic/response-body.md
<li>Updated the section on response body transform middleware to clarify <br>how list indices in dynamic data can be iterated.<br> <li> Added a note explaining how templates are executed with respect to the <br>data structure they receive, including session variables and metadata.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4513/files#diff-05d5458cb4b85a868bd816a1870620d9eacc2fb936d5cb5eb49622f6f521f383">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

