### PR TITLE
Merging to release-5.3: DX-1283 add artifacthub link (#4494)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-charts/release-notes/version-1.3.md
+++ b/tyk-docs/content/product-stack/tyk-charts/release-notes/version-1.3.md
@@ -125,6 +125,9 @@ Tyk Charts 1.3 adds a field to enable Internal [Tyk Identity Broker (TIB)]({{<re
 
 #### Downloads
 - [Source code](https://github.com/TykTechnologies/tyk-charts/archive/refs/tags/v1.3.0.tar.gz)
+- [ArtifactHub - tyk-stack](https://artifacthub.io/packages/helm/tyk-helm/tyk-stack/1.3.0)
+- [ArtifactHub - tyk-data-plane](https://artifacthub.io/packages/helm/tyk-helm/tyk-data-plane/1.3.0)
+- [ArtifactHub - tyk-oss](https://artifacthub.io/packages/helm/tyk-helm/tyk-oss/1.3.0)
 
 #### Changelog {#Changelog-v1.3.0}
 <!-- Required. The change log should include the following ordered set of sections below that briefly summarise the features, updates and fixed issues of the release.


### PR DESCRIPTION
## **User description**
DX-1283 add artifacthub link (#4494)

add artifacthub link


___

## **Type**
enhancement, documentation


___

## **Description**
- Added ArtifactHub links for `tyk-stack`, `tyk-data-plane`, and `tyk-oss` to the Tyk Charts version 1.3 release notes.
- These links provide direct access to the respective Helm chart packages on ArtifactHub.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version-1.3.md</strong><dd><code>Add ArtifactHub Links to Tyk Helm Charts Release Notes</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-charts/release-notes/version-1.3.md
<li>Added links to ArtifactHub for different Tyk Helm charts in the <br>version 1.3 release notes.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4514/files#diff-b5e8b69c576a3b7d19d0afcf4913a42c549972f986d27659d425a35d2579a267">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

