### PR TITLE
[DX-1318] Clarified MongoDB support with Tyk 5.3.0 and Tyk OAS

### DIFF
--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.3.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.3.md
@@ -45,6 +45,8 @@ Version compatibility with other components in the Tyk stack. This takes the for
 
 3rd party dependencies and tools -->
 
+With MongoDB 4.4 reaching [EOL](https://www.mongodb.com/legal/support-policy/lifecycles) in February 2024, we can no longer guarantee full compatibility with this version of the database. If you are [using MongoDB]({{< ref "planning-for-production/database-settings/mongodb" >}}) we recommend that you upgrade to a version that we have tested with, as indicated [below](#3rdPartyTools-v5.3.1).
+
 #### Compatibility Matrix For Tyk Components
 <!-- Required. Version compatibility with other components in the Tyk stack. This takes the form of a compatibility matrix and is only required for Gateway and Portal.
 An illustrative example is shown below. -->
@@ -58,7 +60,7 @@ An illustrative example is shown below. -->
 | | Pump v1.9.0 | Pump all versions |
 | | TIB (if using standalone) v1.5.1 | TIB all versions |
 
-#### 3rd Party Dependencies & Tools
+#### 3rd Party Dependencies & Tools {#3rdPartyTools-v5.3.1}
 <!-- Required. Third-party dependencies encompass tools (GoLang, Helm etc.), databases (PostgreSQL, MongoDB etc.) and external software libraries. This section should be a table that presents the third-party dependencies and tools compatible with the release. Compatible is used in the sense of those versions tested with the releases. Such information assists customers considering upgrading to a specific release.
 
 Additionally, a disclaimer statement was added below the table, for customers to check that the third-party dependency they decide to install remains in support.
@@ -69,7 +71,7 @@ An example is given below for illustrative purposes only. Tested Versions and Co
 | ---------------------------------------------------------- | ---------------------- | ---------------------- | -------- | 
 | [GoLang](https://go.dev/dl/)                               | 1.21       | 1.21       | [Go plugins]({{< ref "plugins/supported-languages/golang" >}}) must be built using Go 1.21 | 
 | [Redis](https://redis.io/download/)  | 6.2.x, 7.x  | 6.2.x, 7.x  | Used by Tyk Dashboard | 
-| [MongoDB](https://www.mongodb.com/try/download/community)  | 5.0.x, 6.0.x, 7.0.x  | 4.4.x, 5.0.x, 6.0.x, 7.0.x  | Used by Tyk Dashboard | 
+| [MongoDB](https://www.mongodb.com/try/download/community)  | 5.0.x, 6.0.x, 7.0.x  | 5.0.x, 6.0.x, 7.0.x  | Used by Tyk Dashboard | 
 | [PostgreSQL](https://www.postgresql.org/download/)         | 11.x - 15.x LTS        | 11.x - 15.x            | Used by Tyk Dashboard | 
 | [OpenAPI Specification](https://spec.openapis.org/oas/v3.0.3) | v3.0.x      | v3.0.x          | Supported by [Tyk OAS]({{< ref "tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc" >}})|
 
@@ -214,6 +216,7 @@ This upgrade transitions Tyk OAS APIs out of [Early Access]({{< ref "frequently-
   - Tyk OAS APIs in Tyk Dashboard v5.3.0 are not [backwards compatible](https://tinyurl.com/3xy966xn). This means that the new Tyk OAS API format used by Tyk Gateway/Dashboard v5.3.X does not work with older versions of Tyk Gateway/Dashboard, i.e. you cannot export these API definitions from a v5.3.X Tyk Dashboard and import to an earlier version.
   - The upgrade of Tyk OAS API definitions is **not reversible**, i.e. you cannot use version 5.3.X Tyk OAS API definitions with an older version of Tyk Dashboard.
   - This means that if you wish to downgrade or revert to your previous version of Tyk, you will need to restore these API definitions from a backup. Please go to the [backup]({{< ref "#upgrade-instructions" >}}) section for detailed instructions on backup before upgrading to v5.3.0.
+  - When using MongoDB as your persistent data store, Tyk OAS APIs from v5.3.0 require a minimum version of MongoDB 5.0.
   - If you are not using Tyk OAS APIs, Tyk will maintain backward compatibility standards.
 - **Not Forward Compatible**
   - Tyk OAS API Definitions prior to v5.3.0 are not [forward compatible](https://tinyurl.com/t3zz88ep) with Tyk Gateway v5.3.X.
@@ -235,6 +238,8 @@ Version compatibility with other components in the Tyk stack. This takes the for
 
 3rd party dependencies and tools -->
 
+With MongoDB 4.4 reaching [EOL](https://www.mongodb.com/legal/support-policy/lifecycles) in February 2024, we can no longer guarantee full compatibility with this version of the database and recommend upgrading to a version that we have tested with, as indicated [below](#3rdPartyTools-v5.3.0).
+
 #### Compatibility Matrix For Tyk Components
 <!-- Required. Version compatibility with other components in the Tyk stack. This takes the form of a compatibility matrix and is only required for Gateway and Portal.
 An illustrative example is shown below. -->
@@ -248,7 +253,7 @@ An illustrative example is shown below. -->
 | | Pump v1.9.0 | Pump all versions |
 | | TIB (if using standalone) v1.5.1 | TIB all versions |
 
-#### 3rd Party Dependencies & Tools
+#### 3rd Party Dependencies & Tools {#3rdPartyTools-v5.3.0}
 <!-- Required. Third-party dependencies encompass tools (GoLang, Helm etc.), databases (PostgreSQL, MongoDB etc.) and external software libraries. This section should be a table that presents the third-party dependencies and tools compatible with the release. Compatible is used in the sense of those versions tested with the releases. Such information assists customers considering upgrading to a specific release.
 
 Additionally, a disclaimer statement was added below the table, for customers to check that the third-party dependency they decide to install remains in support.
@@ -259,7 +264,7 @@ An example is given below for illustrative purposes only. Tested Versions and Co
 | ---------------------------------------------------------- | ---------------------- | ---------------------- | -------- | 
 | [GoLang](https://go.dev/dl/)                               | 1.21       | 1.21       | [Go plugins]({{< ref "plugins/supported-languages/golang" >}}) must be built using Go 1.21 | 
 | [Redis](https://redis.io/download/)  | 6.2.x, 7.x  | 6.2.x, 7.x  | Used by Tyk Dashboard | 
-| [MongoDB](https://www.mongodb.com/try/download/community)  | 5.0.x, 6.0.x, 7.0.x  | 4.4.x, 5.0.x, 6.0.x, 7.0.x  | Used by Tyk Dashboard | 
+| [MongoDB](https://www.mongodb.com/try/download/community)  | 5.0.x, 6.0.x, 7.0.x  | 5.0.x, 6.0.x, 7.0.x  | Used by Tyk Dashboard | 
 | [PostgreSQL](https://www.postgresql.org/download/)         | 11.x - 15.x LTS        | 11.x - 15.x            | Used by Tyk Dashboard | 
 | [OpenAPI Specification](https://spec.openapis.org/oas/v3.0.3) | v3.0.x      | v3.0.x          | Supported by [Tyk OAS]({{< ref "tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc" >}})|
 

--- a/tyk-docs/content/shared/mongodb-versions-include.md
+++ b/tyk-docs/content/shared/mongodb-versions-include.md
@@ -3,15 +3,17 @@
 
 [MongoDB](https://www.mongodb.com) is our default storage option. We support the following versions:
 
-- MongoDB 4.4.x (with mgo driver)
-- MongoDB 4.4.x, 5.0.x, 6.0.x, 7.0.x (with mongo-go driver). 
+- MongoDB 5.0.x, 6.0.x, 7.0.x (with `mongo-go` driver). 
 
-Note: mongo-go driver is available from Tyk 5.0.2.
-
+Note: `mongo-go` driver has been available since Tyk 5.0.2 and is the default from Tyk 5.3.0.
+<br>
+<br>
 {{< note success >}}
-**MongoDB 3.x to 4.2.x**
+**MongoDB 3.x to 4.4.x**
 
-mgo driver works with MongoDB 3.x to 4.2.x too, but we no longer test MongoDB versions prior to 4.4 since they are EOL
+Prior to Tyk 5.0.2, Tyk used the `mgo` driver which supported MongoDB 3.x to 4.4.x, but we no longer test MongoDB versions prior to 5.0 since they are EOL.
+<br>
+We can not guarantee full compatibility with these versions of MongoDB for [supported versions]({{< ref "developer-support/long-term-support-releases" >}}) of Tyk and recommend upgrading to a supported MongoDB version. In particular, when using Tyk OAS APIs with [Tyk 5.3.0]({{< ref "product-stack/tyk-dashboard/release-notes/version-5.3.md#TykOAS-v5.3.0" >}}) onwards, the minimum supported version of MongoDB is 5.0.
 {{< /note >}}
 
 You can also use the following as a drop-in replacement for MongoDB:

--- a/tyk-docs/content/shared/mongodb-versions-include.md
+++ b/tyk-docs/content/shared/mongodb-versions-include.md
@@ -13,7 +13,7 @@ Note: `mongo-go` driver has been available since Tyk 5.0.2 and is the default fr
 
 Prior to Tyk 5.0.2, Tyk used the `mgo` driver which supported MongoDB 3.x to 4.4.x, but we no longer test MongoDB versions prior to 5.0 since they are EOL.
 <br>
-We can not guarantee full compatibility with these versions of MongoDB for [supported versions]({{< ref "developer-support/long-term-support-releases" >}}) of Tyk and recommend upgrading to a supported MongoDB version. In particular, when using Tyk OAS APIs with [Tyk 5.3.0]({{< ref "product-stack/tyk-dashboard/release-notes/version-5.3.md#TykOAS-v5.3.0" >}}) onwards, the minimum supported version of MongoDB is 5.0.
+We can not guarantee full compatibility with these versions of MongoDB for Tyk and recommend upgrading to a supported MongoDB version. In particular, when using Tyk OAS APIs with [Tyk 5.3.0]({{< ref "product-stack/tyk-dashboard/release-notes/version-5.3.md#TykOAS-v5.3.0" >}}) onwards, the minimum supported version of MongoDB is 5.0.
 {{< /note >}}
 
 You can also use the following as a drop-in replacement for MongoDB:


### PR DESCRIPTION
## **User description**
### Preview Link
https://deploy-preview-4568--tyk-docs.netlify.app/docs/nightly/product-stack/tyk-dashboard/release-notes/version-5.3/#dependencies-5.3.0
https://deploy-preview-4568--tyk-docs.netlify.app/docs/nightly/planning-for-production/database-settings/mongodb/


### Description
We no longer support MongoDB 4.4.x (EOL February 2024) - Tyk OAS APIs don't work with this version of MongoDB (from Tyk 5.3.0).


___

## **Type**
enhancement, documentation


___

## **Description**
- Updated MongoDB compatibility information across Tyk documentation to reflect the discontinuation of support for MongoDB 4.4.x and the requirement of MongoDB 5.0.x as a minimum version for using Tyk OAS APIs from Tyk Dashboard v5.3.0 onwards.
- Clarified the transition from `mgo` driver to `mongo-go` driver starting from Tyk 5.0.2, and its default usage from Tyk 5.3.0.
- Added notes and recommendations for upgrading MongoDB to supported versions in light of the EOL of MongoDB 4.4.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version-5.3.md</strong><dd><code>Update MongoDB Compatibility Information for Tyk Dashboard v5.3.0</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.3.md
<li>Added a note on MongoDB 4.4 reaching EOL and recommendations for <br>upgrading.<br> <li> Updated the 3rd Party Dependencies & Tools section to reflect the new <br>MongoDB version compatibility.<br> <li> Added a requirement for MongoDB version 5.0 as a minimum for using Tyk <br>OAS APIs from v5.3.0.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4568/files#diff-14b1be0b2206c9ee21cb1002b55361919932e84558f614c4342f05b8eb5431f8">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mongodb-versions-include.md</strong><dd><code>Revise MongoDB Supported Versions and Driver Usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/mongodb-versions-include.md
<li>Removed support for MongoDB 4.4.x and updated supported versions to <br>5.0.x, 6.0.x, 7.0.x.<br> <li> Added clarification on the transition from <code>mgo</code> driver to <code>mongo-go</code> <br>driver and its implications.<br> <li> Emphasized the requirement of MongoDB version 5.0 as a minimum for Tyk <br>OAS APIs from Tyk 5.3.0 onwards.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4568/files#diff-04b86f86d2b8b24231659779eb134d7f79d047f03e600b5bc5d7e9a2a3c4c228">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

