### PR TITLE
Merging to release-5.3: add html to make sure that the similar shortened url is rendered (#4588)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/version_selector.html
+++ b/tyk-docs/themes/tykio/layouts/partials/version_selector.html
@@ -9,7 +9,11 @@
     {{- range $.Site.Data.page_available_since.versions -}}
     {{ $versionUrl := "" }}
     {{- if  $values -}}
-        {{ $versionUrl = index $values .path }}
+        {{- if and (isset $values "all_versions_are_similar_to_path") (eq $values.all_versions_are_similar_to_path true) -}}
+            {{ $versionUrl = $pagePath }}
+        {{ else }}
+            {{ $versionUrl = index $values .path }}
+        {{- end -}}
     {{- end -}}
     {{- $versionUrl = strings.TrimPrefix "/" $versionUrl }}
     <option value="{{.path}}" {{if $versionUrl}} data-url="{{$versionUrl}}" {{end}}  {{if eq $currentVersion .path}} selected="selected" {{end}} {{- if not $versionUrl -}} disabled {{end}}>{{.name}}</option>


### PR DESCRIPTION
## **User description**
add html to make sure that the similar shortened url is rendered (#4588)


___

## **Type**
enhancement


___

## **Description**
- Enhanced the version selector in the Tyk documentation to dynamically set the version URL based on a new property `all_versions_are_similar_to_path`.
- This update allows for a more flexible URL rendering based on specific conditions, improving the user experience in navigating documentation versions.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version_selector.html</strong><dd><code>Enhance Version Selector with Conditional URL Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/themes/tykio/layouts/partials/version_selector.html
<li>Added conditional logic to handle version URLs based on a new property <br><code>all_versions_are_similar_to_path</code>.<br> <li> If <code>all_versions_are_similar_to_path</code> is true, the version URL is set to <br>the current page path.<br> <li> Otherwise, the version URL is fetched from the existing values.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4594/files#diff-da3b627b2125babaa85f108a3ef8179286e7609e7c8848f0cfbef4b8c0ee2326">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

