### PR TITLE
Merging to release-5.3: tune docker install docs (#4604)

### DIFF
--- a/tyk-docs/content/tyk-oss/ce-docker.md
+++ b/tyk-docs/content/tyk-oss/ce-docker.md
@@ -24,30 +24,26 @@ The following are required for a Tyk OSS installation:
 
 **Step 1 - Create a network**
 
-```console
-$ docker network create tyk
-ab1084d034c7e95735e10de804fc54aa940c031d2c4bb91d984675e5de2755e7
+```bash
+docker network create tyk
 ```
 
 **Step 2 - Deploy Redis into the network, with the `6379` port open**
 
-```console
-$ docker run -itd --rm --name redis --network tyk -p 127.0.0.1:6379:6379 redis:4.0-alpine
-ea54db4da4b228b7868449882062a962f75a7b2d43cdb0ac5205fb4ccdbcde23
+```bash
+docker run -itd --rm --name tyk-redis --network tyk -p 127.0.0.1:6379:6379 redis:4.0-alpine
 ```
 
 **Step 3 - Next, let's download a JSON `tyk.conf` configuration file**
 
-```console
-$ wget https://raw.githubusercontent.com/TykTechnologies/tyk-gateway-docker/master/tyk.standalone.conf
-...
-2021-01-28 13:05:22 (6.81 MB/s) - ‘tyk.standalone.conf’ saved [1563/1563]
+```bash
+wget https://raw.githubusercontent.com/TykTechnologies/tyk-gateway-docker/master/tyk.standalone.conf
 ```
 
 **Step 4 - Run the Gateway, mounting the conf file into the container**
 
-```console
-$ docker run \
+```bash
+docker run \
   --name tyk_gateway \
   --network tyk \
   -p 8080:8080 \


### PR DESCRIPTION
### **User description**
tune docker install docs (#4604)

* tune docker install docs

1. Change the redis name to `tyk-redis` cause the default redis hostname in config is `tyk-redis`
2. Every time I copy the cmd, I need to manually delete the useless output, I think only the cmd is enough


---------

Co-authored-by: Yaara <yaara@tyk.io>


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Updated the Docker installation commands in the Tyk OSS documentation:
  - Changed the shell prompt from `console` to `bash` to simplify command copying.
  - Renamed the Redis container to `tyk-redis` to align with the default configuration in Tyk.
  - Removed unnecessary command output to clean up the documentation and improve user experience.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ce-docker.md</strong><dd><code>Enhance Docker Installation Documentation for Tyk OSS</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-oss/ce-docker.md
<li>Changed command prompt from <code>console</code> to <code>bash</code> for clarity and ease of <br>use.<br> <li> Updated Redis container name to <code>tyk-redis</code> to match the default <br>configuration.<br> <li> Removed output from command examples to simplify the documentation.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4623/files#diff-48d1a9ab911fc0f2bb3034342099029235feecb85ea5b578deb4c6768be73070">+9/-13</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

