### PR TITLE
[DX-1349] Fix versioning bug

### DIFF
--- a/tyk-docs/content/getting-started/key-concepts/oas-versioning.md
+++ b/tyk-docs/content/getting-started/key-concepts/oas-versioning.md
@@ -52,7 +52,7 @@ An example configuration of the versioning settings within the Base API:
 ```
 
 
-- Within the `versioning` section, you can set which of the APIs (versions) can be the default one if a versioning identifier (i.e. header) is provided with the request. By default, this is set to `self`, which tells your Tyk Gateway that the Base API is the default version. Otherwise, you can provide the API ID of the API you want to be the default version.
+- Within the `versioning` section, you can set which of the APIs (versions) can be the default one if a versioning identifier (i.e. header) is not provided with the request. By default, this is set to `self`, which tells your Tyk Gateway that the Base API is the default version. Otherwise, you can provide the API ID of the API you want to be the default version.
 - The `location` field describes where the versioning identifier can be picked up from by the Gateway: The available values are `header`, `path` or `query`.
 - The `key` field represents the name of the version identifier.
 - The `versions` array lists all the API versions besides the Base one.


### PR DESCRIPTION
### **User description**
Fix versioning bug to mention that if a version identifier header is not provided then the default version is used

### For internal users - Please add a Jira DX PR ticket to the subject!

---

### Preview Link
<!-- Add a direct preview link to make it easier for the reviewer to review. Best to add a few direct links to the pages in the PR -->
[preview](https://deploy-preview-4631--tyk-docs.netlify.app/docs/nightly/getting-started/key-concepts/oas-versioning)

### Description
<!-- 1. Describe your changes in detail. Why is this change required? What problem does it solve?
     2. Please explain the change to the reviewer. Pay special attention to changes that are hard to spot, 
       for example:
       2.1. Name change in the file name or directory name - please flag it out since it’s hard 
            to compare text after such a change 
       2.2. Terminology change - flag it out to make sure the reviewer is aware before approving
     3. @mentions of the person to review the proposed changes. They need to be able to know the topic well in order to approve it.
-->
Fix versioning bug to mention that if a version identifier header is *not* provided then the default version is used 

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have added a **preview link** to the PR description.
- [x] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [x] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x] Make sure you have started *your change* off *our latest `master`*.
- [x] I **labelled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->


___

### **PR Type**
bug_fix


___

### **Description**
- Corrected an error in the documentation regarding the default API version selection when no version identifier is provided.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas-versioning.md</strong><dd><code>Fix Incorrect Versioning Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/getting-started/key-concepts/oas-versioning.md
<li>Corrected the description of default versioning behavior when no <br>version identifier is provided in the request.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4631/files#diff-9ff86a042556cbdb6b3bfc77737dc264bcbfa44c05d1e5929cdbc4f4da1c6ef0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

