### PR TITLE
[DX-1338] Improve signposting to per-endpoint custom plugin

### DIFF
--- a/tyk-docs/content/plugins/plugin-types/plugintypes.md
+++ b/tyk-docs/content/plugins/plugin-types/plugintypes.md
@@ -23,5 +23,5 @@ This table includes all the plugin types with the relevant hooks, their place in
 {{< note success >}}
 **Note**  
 
-There are two different options for the <b>Post</b> Plugin that is executed at the end of the request processing chain. The API-level Post Plugin is applied to all requests, whilst the [endpoint-level]({{< ref "product-stack/tyk-gateway/middleware/endpoint-plugin" >}}) custom Golang plugin is only applied to requests made to specific endpoints.
+There are two different options for the <b>Post</b> Plugin that is executed at the end of the request processing chain. The API-level Post Plugin is applied to all requests, whilst the [endpoint-level]({{< ref "product-stack/tyk-gateway/middleware/endpoint-plugin" >}}) custom Golang plugin is only applied to requests made to specific endpoints. If both are configured, the endpoint-level plugin will be executed first.
 {{< /note >}}

--- a/tyk-docs/content/plugins/plugin-types/plugintypes.md
+++ b/tyk-docs/content/plugins/plugin-types/plugintypes.md
@@ -16,12 +16,12 @@ This table includes all the plugin types with the relevant hooks, their place in
 | Pre (Request) | Request Plugin |  HTTP request | Before | The first thing to be executed, before any middleware  | IP Rate Limit plugins,  API Request enrichment      |
 | Authentication| Authentication Plugin |  HTTP request | Before | Replaces Tyk's authentication & authorization middleware with your own business logic |  When you need your a custom flow, for example, interfacing with legacy Auth database |
 | Post-Auth (Request)| Authentication Plugin |  HTTP request | Before | Executed immediately after authentication middleware  | Additional special custom authentication is needed |
-| Post (Request)| Request Plugin  |  HTTP request| Before | The final middleware to be executed during the *HTTP request* phase  | Update the request before it gets to the upstream, for example, adding a header that might override another header, so we add it at the end to ensure it doesn't get overridden |
+| Post (Request)| Request Plugin  |  HTTP request| Before | The final middleware to be executed during the *HTTP request* phase (see **Note** below)  | Update the request before it gets to the upstream, for example, adding a header that might override another header, so we add it at the end to ensure it doesn't get overridden |
 | Response Plugin| Response Plugin |  HTTP Response | After | Executed after the reverse proxy to the upstream API | Executed straight after the reverse proxy returns from the upstream API to Tyk  |  Change the response before the user gets it, for example, change `Location` header from internal to an external URL |
 | Analytics Plugin (Request+Response)| Analytics Plugin | HTTP request | After | The final middleware to be executed during the *HTTP response* phase  | Change analytics records, for example, obfuscating sensitive data such as the `Authorization` header |
 
 {{< note success >}}
 **Note**  
 
-There are two different options for the **Post** Plugin that is executed at the end of the request processing chain. The API-level Post Plugin is applied to all requests, whilst the [endpoint-level]({{< ref "product-stack/tyk-gateway/middleware/endpoint-plugin" >}}) custom Golang plugin is only applied to requests made to specific endpoints.
+There are two different options for the <b>Post</b> Plugin that is executed at the end of the request processing chain. The API-level Post Plugin is applied to all requests, whilst the [endpoint-level]({{< ref "product-stack/tyk-gateway/middleware/endpoint-plugin" >}}) custom Golang plugin is only applied to requests made to specific endpoints.
 {{< /note >}}

--- a/tyk-docs/content/plugins/plugin-types/plugintypes.md
+++ b/tyk-docs/content/plugins/plugin-types/plugintypes.md
@@ -19,3 +19,9 @@ This table includes all the plugin types with the relevant hooks, their place in
 | Post (Request)| Request Plugin  |  HTTP request| Before | The final middleware to be executed during the *HTTP request* phase  | Update the request before it gets to the upstream, for example, adding a header that might override another header, so we add it at the end to ensure it doesn't get overridden |
 | Response Plugin| Response Plugin |  HTTP Response | After | Executed after the reverse proxy to the upstream API | Executed straight after the reverse proxy returns from the upstream API to Tyk  |  Change the response before the user gets it, for example, change `Location` header from internal to an external URL |
 | Analytics Plugin (Request+Response)| Analytics Plugin | HTTP request | After | The final middleware to be executed during the *HTTP response* phase  | Change analytics records, for example, obfuscating sensitive data such as the `Authorization` header |
+
+{{< note success >}}
+**Note**  
+
+There are two different options for the **Post** Plugin that is executed at the end of the request processing chain. The API-level Post Plugin is applied to all requests, whilst the [endpoint-level]({{< ref "product-stack/tyk-gateway/middleware/endpoint-plugin" >}}) custom Golang plugin is only applied to requests made to specific endpoints.
+{{< /note >}}


### PR DESCRIPTION
### **User description**
### Preview Link

https://deploy-preview-4632--tyk-docs.netlify.app/docs/nightly/plugins/plugin-types/plugintypes/

___

### **PR Type**
documentation


___

### **Description**
- Added a note in the `plugintypes.md` to clarify the distinction between API-level Post Plugins and endpoint-level custom Golang plugins, enhancing the documentation for better user understanding.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugintypes.md</strong><dd><code>Add clarification note on Post Plugin types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/plugins/plugin-types/plugintypes.md
<li>Added a note to clarify the options for the **Post** Plugin, <br>distinguishing between API-level and endpoint-level custom plugins.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4632/files#diff-a7cad603a3a529dee3effa8ca034bef721280341861b76a2b38c52a6acf9cc17">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

