### PR TITLE
Merging to release-5.3: Erase the Support Message for EDP (#4628)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal.md
+++ b/tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal.md
@@ -12,20 +12,12 @@ aliases:
 - tyk-stack/tyk-developer-portal/enterprise-developer-portal/install-tyk-enterprise-portal/launching-portal/launching-portal
 ---
 
-{{< note success >}}
-**Tyk Enterprise Developer Portal**
-
-If you are interested in getting access contact us at [support@tyk.io](<mailto:support@tyk.io?subject=Tyk Enterprise Developer Portal Beta>)
-
-{{< /note >}}
-
-## Installing Tyk Enterprise Developer Portal
 We deliver the Tyk Enterprise Developer Portal as a Docker container. To  install Tyk Enterprise Developer Portal, you need to launch the Docker image for the portal with a database to store the portal metadata.
 Optionally, you may decide to use S3 to store the portal CMS assets (image and theme files)
 
 This guide explains how to install and bootstrap the Tyk Enterprise Developer Portal. On average, it should take around 5-10 minutes to install it depending on your setup.
 
-###  Installation steps
+##  Installation steps
 The portal installation process comprises two steps:
 1. **Install the portal application.** To install the portal and launch it in the bootstrap mode, you need to configure your portal instance by specifying settings such as TLS, log level, and database connection.
 For further guidance on launching the portal, please refer to one of the installation options: [Docker container]({{< ref "product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/install-portal-using-docker" >}}), [Docker Compose]({{< ref "product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/install-portal-using-docker-compose" >}}), [Helm chart]({{< ref "product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/install-portal-using-helm" >}}), or [RPM package]({{< ref "product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/install-portal-using-rpm" >}}).


### PR DESCRIPTION
### **User description**
Erase the Support Message for EDP (#4628)

* Erase the Support Message for EDP
* update heading for install steps to be H2

---------

Co-authored-by: Simon Pears <simon@tyk.io>


___

### **PR Type**
documentation, enhancement


___

### **Description**
- Removed an outdated support message that solicited contacts via email for access to the Tyk Enterprise Developer Portal.
- Changed the heading level for installation steps to improve document structure and readability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install-tyk-enterprise-portal.md</strong><dd><code>Update Installation Documentation for Tyk Enterprise Developer Portal</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal.md
<li>Removed support message for Tyk Enterprise Developer Portal.<br> <li> Updated the heading for installation steps from H3 to H2.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4635/files#diff-c8a340a0905207585ee5e2c0f912dd3bbd8f7a1510b9d9c8266cbace569c7625">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

