### PR TITLE
Merging to release-5.3: [DX-1349] Fix versioning bug (#4631)

### DIFF
--- a/tyk-docs/content/getting-started/key-concepts/oas-versioning.md
+++ b/tyk-docs/content/getting-started/key-concepts/oas-versioning.md
@@ -52,7 +52,7 @@ An example configuration of the versioning settings within the Base API:
 ```
 
 
-- Within the `versioning` section, you can set which of the APIs (versions) can be the default one if a versioning identifier (i.e. header) is provided with the request. By default, this is set to `self`, which tells your Tyk Gateway that the Base API is the default version. Otherwise, you can provide the API ID of the API you want to be the default version.
+- Within the `versioning` section, you can set which of the APIs (versions) can be the default one if a versioning identifier (i.e. header) is not provided with the request. By default, this is set to `self`, which tells your Tyk Gateway that the Base API is the default version. Otherwise, you can provide the API ID of the API you want to be the default version.
 - The `location` field describes where the versioning identifier can be picked up from by the Gateway: The available values are `header`, `path` or `query`.
 - The `key` field represents the name of the version identifier.
 - The `versions` array lists all the API versions besides the Base one.


### PR DESCRIPTION
### **User description**
[DX-1349] Fix versioning bug (#4631)

Fix versioning bug

[DX-1349]: https://tyktech.atlassian.net/browse/DX-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
documentation


___

### **Description**
- Updated the documentation in `oas-versioning.md` to clarify the behavior when no versioning identifier is provided in the request. This ensures that the documentation correctly describes that the default API version is set to `self` unless specified otherwise.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas-versioning.md</strong><dd><code>Update Documentation for Default API Version Selection</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/getting-started/key-concepts/oas-versioning.md
<li>Corrected the description of default API version selection when no <br>versioning identifier is provided.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4648/files#diff-9ff86a042556cbdb6b3bfc77737dc264bcbfa44c05d1e5929cdbc4f4da1c6ef0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

