### PR TITLE
Merging to release-5.1: [DX-1344] Replace whitelist/blacklist content where possible, for tier 1 compliance with inclusive naming (#4640)

### DIFF
--- a/tyk-docs/content/frequently-asked-questions/custom-developer-portal-options.md
+++ b/tyk-docs/content/frequently-asked-questions/custom-developer-portal-options.md
@@ -9,6 +9,6 @@ weight: 0
 
 Use case: What if your developer portal is not exactly what I need?
 
-Sometimes our Tyk Gateway won't suit your exact needs.  Maybe you want to combine multiple Tyk installations under the same portal, or use your existing portal and add our functionality, or maybe white label the portal per organisation?
+Sometimes our Tyk Gateway won't suit your exact needs.  Maybe you want to combine multiple Tyk installations under the same portal, or use your existing portal and add our functionality, or maybe customise the portal's branding per organisation?
 
 We have the ability to configure the portal to suit your needs. For details, including a video tutorial, see [Create a Custom Developer Portal]({{< ref "tyk-developer-portal/tyk-portal-classic/customise/custom-developer-portal" >}}).

--- a/tyk-docs/content/getting-started/import-apis.md
+++ b/tyk-docs/content/getting-started/import-apis.md
@@ -36,7 +36,7 @@ Tyk supports an easy way to import Apiary API Blueprints in JSON format using th
 
 Blueprints can be imported and turned into standalone API definitions (for new APIs) and also imported as versions into existing APIs.
 
-It is possible to import APIs and generate mocks or to generate White Lists that pass-through to an upstream URL.
+It is possible to import APIs and generate mocks or to generate Allow Lists that pass-through to an upstream URL.
 
 All imported Blueprints must be in the JSON representation of Blueprint's markdown documents. This can be created using Apiary's [Snow Crash tool](https://github.com/apiaryio/snowcrash).
 
@@ -90,7 +90,7 @@ Add a version to a definition:
 
 #### Mocks
 
-Tyk supports API mocking using our versioning `use_extended_paths` setup, adding mocked URL data to one of the three list types (white-list, black-list or ignored). In order to handle a mocked path, use an entry that has `action` set to `reply`:
+Tyk supports API mocking using our versioning `use_extended_paths` setup, adding mocked URL data to one of the three list types (white_list, black_list or ignored). In order to handle a mocked path, use an entry that has `action` set to `reply`:
 
 ```json
 "ignored": [

--- a/tyk-docs/content/getting-started/key-concepts/versioning.md
+++ b/tyk-docs/content/getting-started/key-concepts/versioning.md
@@ -118,7 +118,7 @@ To activate versioning in an API, create a version entry in the `version_data.ve
       ],
       "white_list": [
         {
-          "path": "v1/allowed/whitelist/literal",
+          "path": "v1/allowed/allowlist/literal",
           "method_actions": {
             "GET": {
               "action": "no_action",
@@ -132,7 +132,7 @@ To activate versioning in an API, create a version entry in the `version_data.ve
           }
         },
           {
-            "path": "v1/allowed/whitelist/reply/{id}",
+            "path": "v1/allowed/allowlist/reply/{id}",
             "method_actions": {
               "GET": {
                 "action": "reply",
@@ -146,7 +146,7 @@ To activate versioning in an API, create a version entry in the `version_data.ve
             }
           },
           {
-            "path": "v1/allowed/whitelist/{id}",
+            "path": "v1/allowed/allowlist/{id}",
             "method_actions": {
               "GET": {
                 "action": "no_action",
@@ -162,7 +162,7 @@ To activate versioning in an API, create a version entry in the `version_data.ve
       ],
       "black_list": [
         {
-          "path": "v1/disallowed/blacklist/literal",
+          "path": "v1/disallowed/blocklist/literal",
           "method_actions": {
             "GET": {
               "action": "no_action",
@@ -203,7 +203,7 @@ Finally, ensure that the API is actually set to allow versioning, this is done b
 ### A few notes on versioning and allowing access
 
 *   Version expiry is applied to all keys
-*   Version ignored / white-listing / black listing is applied to all keys
+*   Version ignored / allow listing / block listing is applied to all keys
 *   Version access control is only applied to keys which have access-control parameters applied to them. If a key has no access_rights data in the session key, then the request will be allowed through to the underlying API.
 
 #### Step 4

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.4.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.4.md
@@ -15,7 +15,7 @@ Here are the packages and their versions we are releasing today: Tyk Gateway v2.
 
 ### Mutual TLS
 
-A major feature of this release is the implementation of Mutual TLS. Now you can protect your APIs by white-listing certificates, idenitfy users based on them, and increase security between Tyk and upstream API. For details, see [Mutual TLS]({{< ref "basic-config-and-security/security/mutual-tls" >}}).
+A major feature of this release is the implementation of Mutual TLS. Now you can protect your APIs by allow listing certificates, idenitfy users based on them, and increase security between Tyk and upstream API. For details, see [Mutual TLS]({{< ref "basic-config-and-security/security/mutual-tls" >}}).
 
 
 ### Extended use of Multiple Policies
@@ -143,7 +143,7 @@ Internal JS API not budled into tyk binary, and `js/tyk.js` file used only for c
 
 #### Improved Swagger API import defaults
 
-When importing Swagger based APIs they now generate tracked URLs instead of white listed ones.
+When importing Swagger based APIs they now generate tracked URLs instead of allow listed ones.
 
 [More](https://github.com/TykTechnologies/tyk/issues/643)
 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.4.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/archived-releases/version-2.4.md
@@ -18,7 +18,7 @@ Here are the packages and their versions we are releasing today: Tyk Gateway v2.
 
 ### Mutual TLS
 
-A major feature of this release is the implementation of Mutual TLS. Now you can protect your APIs by white-listing certificates, idenitfy users based on them, and increase security between Tyk and upstream API. For details, see [Mutual TLS]({{< ref "basic-config-and-security/security/mutual-tls" >}}).
+A major feature of this release is the implementation of Mutual TLS. Now you can protect your APIs by allow listing certificates, idenitfy users based on them, and increase security between Tyk and upstream API. For details, see [Mutual TLS]({{< ref "basic-config-and-security/security/mutual-tls" >}}).
 
 
 ### Extended use of Multiple Policies
@@ -146,7 +146,7 @@ Internal JS API not budled into tyk binary, and `js/tyk.js` file used only for c
 
 #### Improved Swagger API import defaults
 
-When importing Swagger based APIs they now generate tracked URLs instead of white listed ones.
+When importing Swagger based APIs they now generate tracked URLs instead of allow listed ones.
 
 [More](https://github.com/TykTechnologies/tyk/issues/643)
 

--- a/tyk-docs/content/shared/api-def-version.md
+++ b/tyk-docs/content/shared/api-def-version.md
@@ -98,11 +98,11 @@ Each version of your API should be defined here with a unique name. This name is
 * `version_data.{version-name}.override_target`: Setting this value will override the target of the API for this version, overriding the target will invalidate (and is not compatible with) Round Robin Load balancing and Service Discovery.
 * `version_data.{version-name}.use_extended_paths`: Set this value to `true` to use the new extended-paths feature. This will eventually become the default mode of operation.
 
-Extended paths allow you to control which upstream paths are to be handled in a specific way (ignored, as part of white list or black list) by both path and method. The extended metadata set also allows you to provide forced reply data to override or trap inbound requests for specific versions. This is very useful for mocking or slowly exposing a development API to a live upstream back end.
+Extended paths allow you to control which upstream paths are to be handled in a specific way (ignored, as part of an allow list or block list) by both path and method. The extended metadata set also allows you to provide forced reply data to override or trap inbound requests for specific versions. This is very useful for mocking or slowly exposing a development API to a live upstream back end.
     
-Each entry in the ignored, blacklist and whitelist have the same specification. The path specification has the following format:
+Each entry in the ignored, blocklist and allowlist have the same specification. The path specification has the following format:
 
-```{.copyWrapper}
+```json
 {
   "path": "SOME_PATH",
   "method_actions": {
@@ -206,7 +206,7 @@ An example entry:
 ...
 "black_list": [
   {
-    "path": "v1/disallowed/blacklist/literal",
+    "path": "v1/disallowed/blocklist/literal",
     "method_actions": {
       "GET": {
         "action": "no_action",
@@ -217,7 +217,7 @@ An example entry:
     }
   },
   {
-    "path": "v1/disallowed/blacklist/{id}",
+    "path": "v1/disallowed/blocklist/{id}",
     "method_actions": {
       "GET": {
         "action": "reply",
@@ -242,7 +242,7 @@ An example entry:
 ...
 "white_list": [
   {
-    "path": "v1/allowed/whitelist/literal",
+    "path": "v1/allowed/allowlist/literal",
     "method_actions": {
       "GET": {
         "action": "no_action",
@@ -253,7 +253,7 @@ An example entry:
     }
   },
   {
-    "path": "v1/allowed/whitelist/reply/{id}",
+    "path": "v1/allowed/allowlist/reply/{id}",
     "method_actions": {
       "GET": {
         "action": "reply",
@@ -266,7 +266,7 @@ An example entry:
     }
   },
   {
-    "path": "v1/allowed/whitelist/{id}",
+    "path": "v1/allowed/allowlist/{id}",
     "method_actions": {
       "GET": {
         "action": "no_action",
@@ -291,7 +291,7 @@ An example entry:
 ...
 ```
     
-You'll notice we've included the end user rate-limit check URL as a white listed path. If you don't do this, Tyk will block access to this URL.
+You'll notice we've included the end user rate-limit check URL as an allowed path. If you don't do this, Tyk will block access to this URL.
 
 * `version_data.{version-name}.extended_paths.cache`: If the cache is enabled (see `cache_options`), then these paths will be cached. Caching is applied on all *safe* methods (GET, OPTIONS and HEAD). Caching cannot be controlled on a per-method basis.
     


### PR DESCRIPTION
[DX-1344] Replace whitelist/blacklist content where possible, for tier 1 compliance with inclusive naming (#4640)

* Update Whitelist to Allowlist ciphers in description of proxy_ssl_ciphers
---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1344]: https://tyktech.atlassian.net/browse/DX-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ