### PR TITLE
Merging to release-5.3: DX-1339 Fix Badge So That Read Time Is Centred (#4665)

### DIFF
--- a/tyk-docs/assets/scss/_docs.scss
+++ b/tyk-docs/assets/scss/_docs.scss
@@ -92,6 +92,12 @@
   background-color: $brandpurple-dark;
 }
 
+.badge .nav.read {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .badge .nav.read::before {
   content: url("../img/read_white.png");
   margin-right: 5px;


### PR DESCRIPTION
### **User description**
DX-1339 Fix Badge So That Read Time Is Centred (#4665)

* add nav.read style to badge with time to read centred
---------

Co-authored-by: Simon Pears <simon@tyk.io>


___

### **PR Type**
Bug fix


___

### **Description**
- Added flexbox styling to `.badge .nav.read` to ensure the read time badge is centered.
- Updated alignment and justification properties to improve badge appearance.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_docs.scss</strong><dd><code>Center read time badge using flexbox styling.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/scss/_docs.scss
<li>Added flexbox styling to center read time badge.<br> <li> Ensured alignment and justification for badge content.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4674/files#diff-d29767519ca2fa4d8fce78b76e949905e03684c9f9d6572ff6b4f23888480e7e">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

