### PR TITLE
Merging to release-5.2: DX-1339 Fix Badge So That Read Time Is Centred (#4665)

### DIFF
--- a/tyk-docs/assets/scss/_docs.scss
+++ b/tyk-docs/assets/scss/_docs.scss
@@ -92,6 +92,12 @@
   background-color: $brandpurple-dark;
 }
 
+.badge .nav.read {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .badge .nav.read::before {
   content: url("../img/read_white.png");
   margin-right: 5px;


### PR DESCRIPTION
DX-1339 Fix Badge So That Read Time Is Centred (#4665)

* add nav.read style to badge with time to read centred
---------

Co-authored-by: Simon Pears <simon@tyk.io>