### PR TITLE
Merging to release-5.3: [DX-1387] Update KV to fix agent_address typo in Using Vault as a KV store (#4698)

### DIFF
--- a/tyk-docs/content/deployment-and-operations/tyk-self-managed/deployment-lifecycle/deployment-to-production/key-value-storage/vault.md
+++ b/tyk-docs/content/deployment-and-operations/tyk-self-managed/deployment-lifecycle/deployment-to-production/key-value-storage/vault.md
@@ -16,7 +16,7 @@ Configuring Tyk Gateway to read values from Vault is straightforward - you simpl
     "kv": {
         "vault": {
             "address": "http://localhost:1023",
-            "agent_adress": "",
+            "agent_address": "",
             "max_retries": 3,
             "timeout": 30,
             "token": "",
@@ -29,7 +29,7 @@ Configuring Tyk Gateway to read values from Vault is straightforward - you simpl
 | Key          | Description                                                                                            |
 |--------------|--------------------------------------------------------------------------------------------------------|
 | address      | The address of the Vault server, which must be a complete URL such as `http://www.vault.example.com`   |
-| agent_adress | The address of the local Vault agent, if different from the Vault server, must be a complete URL       |
+| agent_address | The address of the local Vault agent, if different from the Vault server, must be a complete URL       |
 | max_retries  | The maximum number of attempts Tyk will make to retrieve the value if Vault returns an error           |
 | timeout      | The maximum time that Tyk will wait for a response from Vault (in nanoseconds, if set to 0 (default) will be interpreted as 60 seconds)                                         |
 | token        | The Vault root access token                                                                            |


### PR DESCRIPTION
### **User description**
[DX-1387] Update KV to fix agent_address typo in Using Vault as a KV store (#4698)

Update vault to fix agent_address typo

[DX-1387]: https://tyktech.atlassian.net/browse/DX-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation, Bug fix


___

### **Description**
- Corrected a typo in the Vault configuration documentation from `agent_adress` to `agent_address`.
- Updated the JSON configuration example and the corresponding description in the table to reflect the corrected key.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vault.md</strong><dd><code>Fix typo in Vault configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/deployment-and-operations/tyk-self-managed/deployment-lifecycle/deployment-to-production/key-value-storage/vault.md
<li>Corrected the typo <code>agent_adress</code> to <code>agent_address</code> in the JSON <br>configuration example.<br> <li> Updated the corresponding description in the table to reflect the <br>corrected key.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4713/files#diff-5b2faef4cf0ad05693e0ee366c6f64775feb00f7c6d2ec367d5e6b175c96fc5f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

