### PR TITLE
Merging to release-5.3: [DX-1395] Add branch processor back to Tyk Streams (#4752)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/branch.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/branch.md
@@ -1,0 +1,178 @@
+---
+title: Branch
+description: Branch Processor
+tags: ["Branch","Processors","Composition"]
+---
+
+The `branch` processor allows you to create a new request message via a Bloblang mapping, execute a list of processors on the request messages, and, finally, map the result back into the source message using another mapping.
+
+```yml
+# Config fields, showing default values
+label: ""
+branch:
+  request_map: ""
+  processors: [] # No default (required)
+  result_map: ""
+```
+
+This is useful for preserving the original message contents when using processors that would otherwise replace the entire contents.
+
+## Metadata
+<!-- TODO: add a link -->
+Metadata fields that are added to messages during branch processing will not be automatically copied into the resulting message. In order to do this you should explicitly declare in your `result_map` either a wholesale copy with `meta = metadata()`, or selective copies with `meta foo = metadata("bar")` and so on. It is also possible to reference the metadata of the origin message in the `result_map` using the @ operator.
+
+## Error Handling
+<!-- TODO: add a link -->
+If the `request_map` fails the child processors will not be executed. If the child processors themselves result in an (uncaught) error then the `result_map` will not be executed. If the `result_map` fails the message will remain unchanged. Under any of these conditions standard error handling methods can be used in order to filter, DLQ or recover the failed messages.
+
+## Conditional Branching
+
+If the root of your request map is set to `deleted()` then the branch processors are skipped for the given message, this allows you to conditionally branch messages.
+
+## Fields
+
+### request_map
+<!-- TODO: add a link -->
+A Bloblang mapping that describes how to create a request payload suitable for the child processors of this branch. If left empty then the branch will begin with an exact copy of the origin message (including metadata).
+
+
+Type: `string`  
+Default: `""`
+
+```yml
+# Examples
+
+request_map: |-
+  root = {
+  	"id": this.doc.id,
+  	"content": this.doc.body.text
+  }
+
+request_map: |-
+  root = if this.type == "foo" {
+  	this.foo.request
+  } else {
+  	deleted()
+  }
+```
+
+### processors
+
+A list of processors to apply to mapped requests. When processing message batches the resulting batch must match the size and ordering of the input batch, therefore filtering, grouping should not be performed within these processors.
+
+
+Type: `array`
+
+### result_map
+
+A Bloblang mapping that describes how the resulting messages from branched processing should be mapped back into the original payload. If left empty the origin message will remain unchanged (including metadata).
+
+
+Type: `string`  
+Default: `""`
+
+```yml
+# Examples
+
+result_map: |-
+  meta foo_code = metadata("code")
+  root.foo_result = this
+
+result_map: |-
+  meta = metadata()
+  root.bar.body = this.body
+  root.bar.id = this.user.id
+
+result_map: root.raw_result = content().string()
+
+result_map: |-
+  root.enrichments.foo = if metadata("request_failed") != null {
+    throw(metadata("request_failed"))
+  } else {
+    this
+  }
+
+result_map: |-
+  # Retain only the updated metadata fields which were present in the origin message
+  meta = metadata().filter(v -> @.get(v.key) != null)
+```
+
+## Examples
+
+### HTTP Request
+This example strips the request message into an empty body, grabs an HTTP payload, and places the result back into the original message at the path `image.pull_count`:
+
+```yaml
+pipeline:
+  processors:
+    - branch:
+        request_map: 'root = ""'
+        processors:
+          - http:
+              url: https://hub.docker.com/v2/repositories/tykio/tyk-gateway
+              verb: GET
+              headers:
+                Content-Type: application/json
+        result_map: root.image.pull_count = this.pull_count
+
+# Example input:  {"id":"foo","some":"pre-existing data"}
+# Example output: {"id":"foo","some":"pre-existing data","image":{"pull_count":1234}}
+```
+
+### Non Structured Results
+When the result of your branch processors is unstructured and you wish to simply set a resulting field to the raw output use the content function to obtain the raw bytes of the resulting message and then coerce it into your value type of choice:
+
+```yaml
+pipeline:
+  processors:
+    - branch:
+        request_map: 'root = this.document.id'
+        processors:
+          - cache:
+              resource: descriptions_cache
+              key: ${! content() }
+              operator: get
+        result_map: root.document.description = content().string()
+
+# Example input:  {"document":{"id":"foo","content":"hello world"}}
+# Example output: {"document":{"id":"foo","content":"hello world","description":"this is a cool doc"}}
+```
+
+### Lambda Function
+
+This example maps a new payload for triggering a lambda function with an ID and username from the original message, and the result of the lambda is discarded, meaning the original message is unchanged.
+
+```yaml
+pipeline:
+  processors:
+    - branch:
+        request_map: '{"id":this.doc.id,"username":this.user.name}'
+        processors:
+          - aws_lambda:
+              function: trigger_user_update
+
+# Example input: {"doc":{"id":"foo","body":"hello world"},"user":{"name":"fooey"}}
+# Output matches the input, which is unchanged
+```
+
+### Conditional Caching
+This example caches a document by a message ID only when the type of the document is a foo:
+
+```yaml
+pipeline:
+  processors:
+    - branch:
+        request_map: |
+          meta id = this.id
+          root = if this.type == "foo" {
+            this.document
+          } else {
+            deleted()
+          }
+        processors:
+          - cache:
+              resource: TODO
+              operator: set
+              key: ${! @id }
+              value: ${! content() }
+```

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/cache.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/cache.md
@@ -1,0 +1,188 @@
+---
+title: Cache
+description: Cache Processor
+tags: ["Cache","Processors","Integration" ]
+---
+
+<!-- TODO: add a link -->
+Performs operations against a cache resource for each message, allowing you to store or retrieve data within message payloads.
+
+## Common
+
+```yml
+# Common config fields, showing default values
+label: ""
+cache:
+  resource: "" # No default (required)
+  operator: "" # No default (required)
+  key: "" # No default (required)
+  value: "" # No default (optional)
+```
+
+## Advanced
+```yml
+# All config fields, showing default values
+label: ""
+cache:
+  resource: "" # No default (required)
+  operator: "" # No default (required)
+  key: "" # No default (required)
+  value: "" # No default (optional)
+  ttl: 60s # No default (optional)
+```
+
+For use cases where you wish to cache the result of processors consider using the [cached processor]({{< ref "/product-stack/tyk-streaming/configuration/processors/cached" >}}) instead.
+
+This processor will interpolate functions within the `key` and `value` fields individually for each message. This allows you to specify dynamic keys and values based on the contents of the message payloads and metadata.
+
+## Examples
+
+### Deduplication
+
+Deduplication can be done using the add operator with a key extracted from the message payload, since it fails when a key already exists we can remove the duplicates using a [mapping processor]({{< ref "/product-stack/tyk-streaming/configuration/processors/mapping" >}}):
+
+```yaml
+pipeline:
+  processors:
+    - cache:
+        resource: foocache
+        operator: add
+        key: '${! json("message.id") }'
+        value: "storeme"
+    - mapping: root = if errored() { deleted() }
+
+cache_resources:
+  - label: foocache
+    redis:
+      url: tcp://TODO:6379
+```
+
+### Deduplication Batch-Wide
+
+Sometimes it's necessary to deduplicate a batch of messages (AKA a window) by a single identifying value. This can be done by introducing a [branch processor]({{< ref "/product-stack/tyk-streaming/configuration/processors/branch" >}}), which executes the cache only once on behalf of the batch, in this case with a value make from a field extracted from the first and last messages of the batch:
+
+```yaml
+pipeline:
+  processors:
+    # Try and add one message to a cache that identifies the whole batch
+    - branch:
+        request_map: |
+          root = if batch_index() == 0 {
+            json("id").from(0) + json("meta.tail_id").from(-1)
+          } else { deleted() }
+        processors:
+          - cache:
+              resource: foocache
+              operator: add
+              key: ${! content() }
+              value: t
+    # Delete all messages if we failed
+    - mapping: |
+        root = if errored().from(0) {
+          deleted()
+        }
+```
+
+### Hydration
+
+It's possible to enrich payloads with content previously stored in a cache by using the [branch]({{< ref "/product-stack/tyk-streaming/configuration/processors/branch" >}}) processor:
+
+```yaml
+pipeline:
+  processors:
+    - branch:
+        processors:
+          - cache:
+              resource: foocache
+              operator: get
+              key: '${! json("message.document_id") }'
+        result_map: 'root.message.document = this'
+
+        # NOTE: If the data stored in the cache is not valid JSON then use
+        # something like this instead:
+        # result_map: 'root.message.document = content().string()'
+
+cache_resources:
+  - label: foocache
+    memcached:
+      addresses: [ "TODO:11211" ]
+```
+
+## Fields
+
+### resource
+<!-- TODO: add a link -->
+The cache resource to target with this processor.
+
+
+Type: `string`
+
+### operator
+
+The [operation](#operators) to perform with the cache.
+
+
+Type: `string`  
+Options: `set`, `add`, `get`, `delete`.
+
+### key
+
+A key to use with the cache.
+This field supports interpolation functions.
+
+
+Type: `string`
+
+### value
+
+A value to use with the cache (when applicable).
+<!-- TODO: add a link -->
+This field supports interpolation functions.
+
+
+Type: `string`
+
+### ttl
+
+The TTL of each individual item as a duration string. After this period an item will be eligible for removal during the next compaction. Not all caches support per-key TTLs, those that do will have a configuration field `default_ttl`, and those that do not will fall back to their generally configured TTL setting.
+<!-- TODO: add a link -->
+This field supports interpolation functions.
+
+
+Type: `string`  
+Requires version 3.33.0 or newer
+
+```yml
+# Examples
+
+ttl: 60s
+
+ttl: 5m
+
+ttl: 36h
+```
+
+## Operators
+
+### set
+
+Set a key in the cache to a value. If the key already exists the contents are
+overridden.
+
+### add
+
+Set a key in the cache to a value. If the key already exists the action fails
+with a 'key already exists' error, which can be detected with
+<!-- TODO: add a link -->
+processor error handling.
+
+### get
+
+Retrieve the contents of a cached key and replace the original message payload
+with the result. If the key does not exist the action fails with an error, which
+can be detected with processor error handling.
+
+### delete
+
+Delete a key and its contents from the cache.  If the key does not exist the
+action is a no-op and will not fail with an error.

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/cached.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/cached.md
@@ -51,6 +51,7 @@ cache_resources:
 ```
 
 ### Periodic Global Enrichment
+
 In the following example we enrich all messages with the same data obtained from a static URL with an `http` processor within a `branch`. However, we expect the data from this URL to change roughly every 10 minutes, so we configure a `cached` processor with a static key (since this request is consistent for all messages) and a TTL of `10m`.
 
 ```yaml
@@ -76,14 +77,14 @@ cache_resources:
 
 ## Fields
 
-### `cache`
+### cache
 
 The cache resource to read and write processor results from.
 
 
 Type: `string`
 
-### `skip_on`
+### skip_on
 
 A condition that can be used to skip caching the results from the processors.
 
@@ -96,7 +97,7 @@ Type: `string`
 skip_on: errored()
 ```
 
-### `key`
+### key
 
 A key to be resolved for each message, if the key already exists in the cache then the cached result is used, otherwise the processors are applied and the result is cached under this key. The key could be static and therefore apply generally to all messages or it could be an interpolated expression that is potentially unique for each message.
 This field supports interpolation functions.
@@ -116,7 +117,7 @@ key: ${! meta("kafka_key") }
 key: ${! meta("kafka_topic") }
 ```
 
-### `ttl`
+### ttl
 
 An optional expiry period to set for each cache entry. Some caches only have a general TTL and will therefore ignore this setting.
 This field supports interpolation functions.
@@ -124,7 +125,7 @@ This field supports interpolation functions.
 
 Type: `string`
 
-### `processors`
+### processors
 
 The list of processors whose result will be cached.
 

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/redis.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/redis.md
@@ -1,0 +1,380 @@
+---
+title: Redis
+description: Redis Processor
+tags: [ "Processors", "Redis","Integration" ]
+---
+
+Performs actions against Redis that aren't possible using a [cache]({{< ref "/product-stack/tyk-streaming/configuration/processors/cache" >}}) processor.
+
+Actions are performed for each message and the message contents are replaced with the result.
+
+In order to merge the result into the original message compose this processor within a [branch processor]({{< ref "/product-stack/tyk-streaming/configuration/processors/branch" >}}).
+
+## Common
+
+```yml
+# Common config fields, showing default values
+label: ""
+redis:
+  url: redis://:6397 # No default (required)
+  command: scard # No default (optional)
+  args_mapping: root = [ this.key ] # No default (optional)
+```
+
+## Advanced
+
+```yml
+# All config fields, showing default values
+label: ""
+redis:
+  url: redis://:6397 # No default (required)
+  kind: simple
+  master: ""
+  tls:
+    enabled: false
+    skip_cert_verify: false
+    enable_renegotiation: false
+    root_cas: ""
+    root_cas_file: ""
+    client_certs: [ ]
+  command: scard # No default (optional)
+  args_mapping: root = [ this.key ] # No default (optional)
+  retries: 3
+  retry_period: 500ms
+```
+
+
+
+## Examples
+
+### Querying Cardinality
+
+If given payloads containing a metadata field `set_key` it's possible to query and store the cardinality of the set for
+each message using a [branch processor]({{< ref "/product-stack/tyk-streaming/configuration/processors/branch" >}}) in order to augment rather than replace
+the message contents:
+
+```yaml
+pipeline:
+  processors:
+    - branch:
+        processors:
+          - redis:
+              url: TODO
+              command: scard
+              args_mapping: 'root = [ meta("set_key") ]'
+        result_map: 'root.cardinality = this'
+```
+
+
+### Running Total
+
+If we have JSON data containing number of friends visited during covid 19:
+
+```json
+{
+  "name": "ash",
+  "month": "feb",
+  "year": 2019,
+  "friends_visited": 10
+}
+{
+  "name": "ash",
+  "month": "apr",
+  "year": 2019,
+  "friends_visited": -2
+}
+{
+  "name": "bob",
+  "month": "feb",
+  "year": 2019,
+  "friends_visited": 3
+}
+{
+  "name": "bob",
+  "month": "apr",
+  "year": 2019,
+  "friends_visited": 1
+}
+```
+
+We can add a field that contains the running total number of friends visited:
+
+```json
+{
+  "name": "ash",
+  "month": "feb",
+  "year": 2019,
+  "friends_visited": 10,
+  "total": 10
+}
+{
+  "name": "ash",
+  "month": "apr",
+  "year": 2019,
+  "friends_visited": -2,
+  "total": 8
+}
+{
+  "name": "bob",
+  "month": "feb",
+  "year": 2019,
+  "friends_visited": 3,
+  "total": 3
+}
+{
+  "name": "bob",
+  "month": "apr",
+  "year": 2019,
+  "friends_visited": 1,
+  "total": 4
+}
+```
+
+Using the `incrby` command:
+
+```yaml
+pipeline:
+  processors:
+    - branch:
+        processors:
+          - redis:
+              url: TODO
+              command: incrby
+              args_mapping: 'root = [ this.name, this.friends_visited ]'
+        result_map: 'root.total = this'
+```
+
+## Fields
+
+### url
+
+The URL of the target Redis server. Database is optional and is supplied as the URL path.
+
+Type: `string`
+
+```yml
+# Examples
+
+url: redis://:6397
+
+url: redis://localhost:6379
+
+url: redis://foousername:foopassword@redisplace:6379
+
+url: redis://:foopassword@redisplace:6379
+
+url: redis://localhost:6379/1
+
+url: redis://localhost:6379/1,redis://localhost:6380/1
+```
+
+### kind
+
+Specifies a simple, cluster-aware, or failover-aware redis client.
+
+Type: `string`  
+Default: `"simple"`  
+Options: `simple`, `cluster`, `failover`.
+
+### master
+
+Name of the redis master when `kind` is `failover`
+
+Type: `string`  
+Default: `""`
+
+```yml
+# Examples
+
+master: mymaster
+```
+
+### tls
+
+Custom TLS settings can be used to override system defaults.
+
+**Troubleshooting**
+
+Some cloud hosted instances of Redis (such as Azure Cache) might need some hand holding in order to establish stable
+connections. Unfortunately, it is often the case that TLS issues will manifest as generic error messages such as "i/o
+timeout". If you're using TLS and are seeing connectivity problems consider setting `enable_renegotiation` to `true`,
+and ensuring that the server supports at least TLS version 1.2.
+
+Type: `object`
+
+### tls.enabled
+
+Whether custom TLS settings are enabled.
+
+Type: `bool`  
+Default: `false`
+
+### tls.skip_cert_verify
+
+Whether to skip server side certificate verification.
+
+Type: `bool`  
+Default: `false`
+
+### tls.enable_renegotiation
+
+Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error
+message `local error: tls: no renegotiation`.
+
+Type: `bool`  
+Default: `false`
+
+### tls.root_cas
+
+An optional root certificate authority to use. This is a string, representing a certificate chain from the parent
+trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+This field contains sensitive information that usually shouldn't be added to a config directly.
+
+
+Type: `string`  
+Default: `""`
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+### tls.root_cas_file
+
+An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a
+certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host
+certificate.
+
+Type: `string`  
+Default: `""`
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+### tls.client_certs
+
+A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file`
+and `key_file` should be specified, but not both.
+
+Type: `array`  
+Default: `[]`
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+### tls.client_certs[].cert
+
+A plain text certificate to use.
+
+Type: `string`  
+Default: `""`
+
+### tls.client_certs[].key
+
+A plain text certificate key to use.
+
+This field contains sensitive information that usually shouldn't be added to a config directly.
+
+
+Type: `string`  
+Default: `""`
+
+### tls.client_certs[].cert_file
+
+The path of a certificate to use.
+
+Type: `string`  
+Default: `""`
+
+### tls.client_certs[].key_file
+
+The path of a certificate key to use.
+
+Type: `string`  
+Default: `""`
+
+### tls.client_certs[].password
+
+A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The
+obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format. Warning: Since it does not
+authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+
+This field contains sensitive information that usually shouldn't be added to a config directly.
+
+
+Type: `string`  
+Default: `""`
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
+```
+
+### command
+
+The command to execute.
+<!-- TODO: add a link -->
+This field supports interpolation functions.
+
+Type: `string`  
+
+
+```yml
+# Examples
+
+command: scard
+
+command: incrby
+
+command: ${! meta("command") }
+```
+
+### args_mapping
+
+<!-- TODO: add a link -->
+A Bloblang mapping which should evaluate to an array of values matching in size to the
+number of arguments required for the specified Redis command.
+
+Type: `string`
+
+```yml
+# Examples
+
+args_mapping: root = [ this.key ]
+
+args_mapping: root = [ meta("kafka_key"), this.count ]
+```
+
+### retries
+
+The maximum number of retries before abandoning a request.
+
+Type: `int`  
+Default: `3`
+
+### retry_period
+
+The time to wait before consecutive retry attempts.
+
+Type: `string`  
+Default: `"500ms"`  

--- a/tyk-docs/content/product-stack/tyk-streaming/getting-started.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/getting-started.md
@@ -72,7 +72,9 @@ In the Tyk Dashboard, create a new API. Click the *+CONFIGURE API* button to con
 {{< img src="/img/streams/create-new-api.png" alt="Create New API" width="1000px" >}}
 
 Select *Active* from the *Gateway Status* drop-down list and then select *External* from the *Access* drop-down list.
+
 **Note**: For this example, the *Upstream URL* will not be used, as the streaming server will handle the requests and responses directly. However, a value is still needed to comply with the API definition schema.
+
 Navigate to the *Streaming* section and click on *Add Stream*.
 
 {{< img src="/img/streams/streams.png" alt="Click the Add Stream button" width="1000px" >}}

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -3872,6 +3872,14 @@ menu:
             path: /product-stack/tyk-streaming/configuration/processors/bloblang
             category: Page
             show: True
+          - title: "Branch"
+            path: /product-stack/tyk-streaming/configuration/processors/branch
+            category: Page
+            show: True
+          - title: "Cache"
+            path: /product-stack/tyk-streaming/configuration/processors/cache
+            category: Page
+            show: True
           - title: "Cached"
             path: /product-stack/tyk-streaming/configuration/processors/cached
             category: Page
@@ -3886,6 +3894,10 @@ menu:
             show: True
           - title: "Protobuf"
             path: /product-stack/tyk-streaming/configuration/processors/protobuf
+            category: Page
+            show: True
+          - title: "Redis"
+            path: /product-stack/tyk-streaming/configuration/processors/redis
             category: Page
             show: True
       - title: "Deployment Considerations"


### PR DESCRIPTION
### **User description**
[DX-1395] Add branch processor back to Tyk Streams (#4752)

DX pushing update to re-add Branch processor

---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1395]: https://tyktech.atlassian.net/browse/DX-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
documentation


___

### **Description**
- Added documentation for the Branch processor, including configuration fields, metadata handling, error handling, and examples.
- Added documentation for the Cache processor, including configuration fields, common and advanced settings, and examples.
- Updated documentation for the Cached processor with examples and fields, including a periodic global enrichment example.
- Added documentation for the Redis processor, including configuration fields, common and advanced settings, and examples.
- Updated the getting started guide with a note about the Upstream URL requirement for the API definition schema.
- Updated the menu with new entries for Branch, Cache, and Redis processor documentation links.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>branch.md</strong><dd><code>Added documentation for Branch processor.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/branch.md
<li>Added a new document for the Branch processor.<br> <li> Included configuration fields, metadata handling, error handling, and <br>examples.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4754/files#diff-7d1b866d462211ba97a516b61e17c2227f0c82a69afc175cb66a8faf81f15663">+178/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cache.md</strong><dd><code>Added documentation for Cache processor.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/cache.md
<li>Added a new document for the Cache processor.<br> <li> Included configuration fields, common and advanced settings, and <br>examples.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4754/files#diff-078d50e6d7821914732b91cee50033e74b4bf92acb248e4af3b014d20bebc4ed">+188/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cached.md</strong><dd><code>Updated documentation for Cached processor.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/cached.md
<li>Added examples and fields for the Cached processor.<br> <li> Included periodic global enrichment example.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4754/files#diff-741baeaccf6a53d46fbbdcb1a633e765a4d719eab5c8f6d9d713e8f9e82e826b">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis.md</strong><dd><code>Added documentation for Redis processor.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/redis.md
<li>Added a new document for the Redis processor.<br> <li> Included configuration fields, common and advanced settings, and <br>examples.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4754/files#diff-26ac8e46ac40b0523ff4a70a8e419aeceb7355b1aec9e9c222f0a707048e2b8f">+380/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>getting-started.md</strong><dd><code>Updated getting started guide with Upstream URL note.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/getting-started.md
<li>Added note about the Upstream URL requirement for API definition <br>schema.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4754/files#diff-1f00bf5920d62b05656c8f452812d8b5c273b170cea59b179d4785c93d8c556a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Updated menu with new processor documentation links.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/data/menu.yaml
- Added menu entries for Branch, Cache, and Redis processors.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4754/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+12/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

