### PR TITLE
Merging to release-5.3: [DX-1293] Add Python gRPC support guides (#4672)

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/custom-auth-python.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/custom-auth-python.md
@@ -1,0 +1,662 @@
+---
+date: 2024-05-12T17:00:00Z
+title: "Create Custom Authentication Plugin With Python"
+---
+
+In the realm of API security, HMAC-signed authentication serves as a foundational concept. In this developer-focused blog post, we'll use HMAC-signed authentication as the basis for learning how to write gRPC custom authentication plugins with Tyk Gateway. Why learn how to write Custom Authentication Plugins?
+
+- **Foundational knowledge**: Writing custom authentication plugins provides foundational knowledge of Tyk's extensibility and customisation capabilities.
+- **Practical experience**: Gain hands-on experience in implementing custom authentication logic tailored to specific use cases, starting with HMAC-signed authentication.
+- **Enhanced control**: Exercise greater control over authentication flows and response handling, empowering developers to implement advanced authentication mechanisms beyond built-in features.
+
+While Tyk Gateway offers built-in support for HMAC-signed authentication, this tutorial serves as a practical guide for developers looking to extend Tyk's capabilities through custom authentication plugins. It extends the gRPC server that we developed in our [getting started guide]({{< ref "getting-started-python" >}}).
+
+We will develop a basic gRPC server that implements the Tyk Dispatcher service with a custom authentication plugin to handle authentication keys, signed using the HMAC SHA512 algorithm. Subsequently, you will be able to make a request to your API with a HMAC signed authentication key in the *Authorization* header. Tyk Gateway will intercept the request and forward it to your Python gRPC server for HMAC signature and token verification.
+
+Our plugin will only verify the key against an expected value. In a production environment it will be necessary to verify the key against Redis storage.
+
+Before we continue ensure that you have:
+
+- Read and completed our getting started guide that explains how to implement a basic Python gRPC server to echo the request payload received from Tyk Gateway. This tutorial extends the source code of the tyk_async_server.py file to implement a custom authentication plugin for a HMAC signed authentication key.
+- Read our HMAC signatures documentation for an explanation of HMAC signed authentication  with Tyk Gateway. A brief summary is given in the HMAC Signed Authentication section below. 
+
+
+## HMAC Signed Authentication
+
+Before diving in further, we will give a brief overview of HMAC signed authentication using our custom authentication plugin.
+
+- **Client request**: The journey begins with a client requesting access to a protected resource on the Tyk API.
+- **HMAC signing**: Before dispatching the request, the client computes an HMAC signature using a secret key and request date, ensuring the payload's integrity.
+- **Authorization header**: The HMAC signature, along with essential metadata such as the API key and HMAC algorithm, is embedded within the Authorization header.
+- **Tyk Gateway verification**: Upon receipt, Tyk Gateway forwards the request to our gRPC server to execute the custom authentication plugin. This will validate the HMAC signature, ensuring the request's authenticity before proceeding with further processing.
+
+Requests should be made to an API that uses our custom authentication plugin as follows. A HMAC signed key should be included in the *Authorization* header and a date/time string in the *Date* header. An example request is shown in the curl command below:
+
+```bash
+curl -v -H 'Date: Fri, 03 May 2024 12:00:42 GMT' \
+-H 'Authorization: Signature keyId="eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6ImdycGNfaG1hY19rZXkiLCJoIjoibXVybXVyNjQifQ==", \
+algorithm="hmac-sha512",signature="9kwBK%2FyrjbSHJDI7INAhBmhHLTHRDkIe2uRWHEP8bgQFQvfXRksm6t2MHeLUyk9oosWDZyC17AbGeP8EFqrp%2BA%3D%3D"' \
+http://localhost:8080/grpc-custom-auth/get
+```
+
+From the above example, it should be noted that:
+
+- The *Date* header contains a date string formatted as follows: *Fri, 03 May 2024 11:06:00 GMT*.
+- The *Authorization* header is formatted as *Signature keyId=”<keyId>”, algorithm=”<hmac-algorithm>”, signature=”<hmac signature>”* where:
+
+    - **keyId** is a Tyk authentication key.
+    - **algorithm** is the HMAC algorithm used to sign the signature, *hmac-sha512* or *hmac-sha256*. 
+    - **signature** is the HAMC signature calculated with the date string from the *Date* header, signed with a base64 encoded secret value, using the specified HMAC algorithm. The HMAC signature is then encoded as base64.
+
+## Prerequisites
+
+Firstly, we need to create the following:
+
+- An API configured to use a custom authentication plugin.
+- A HMAC enabled key with a configured secret for signing.
+
+This will enable us to issue a request to test that Tyk Gateway integrates with our custom authentication plugin on the gRPC server.
+
+#### Create API
+
+We will create an API served by Tyk Gateway, that will forward requests upstream to https://httpbin.org/. 
+
+The API will have the following parameters configured:
+
+- **Listen path**: Tyk Gateway will listen to API requests on */grpc-custom-auth/* and will strip the listen path for upstream requests.
+- **Target URL**: The target URL will be configured to send requests to *http://httpbin/*.
+- **Authentication Mode**: The authentication mode will be configured for custom authentication. This is used to trigger CoProcess (gRPC), Python or JSVM plugins to handle custom authentication.
+
+You can use the following Tyk Classic API definition to get you started, replacing the *org_id* with the ID of your organisation.
+
+```json
+{
+    "api_definition": {
+        "id": "662facb2f03e750001a03500",
+        "api_id": "6c56dd4d3ad942a94474df6097df67ed",
+        "org_id": "5e9d9544a1dcd60001d0ed20",
+        "name": "Python gRPC Custom Auth",
+        "enable_coprocess_auth": true,
+        "auth": {
+            "auth_header_name": "Authorization"
+        },
+        "proxy": {
+            "preserve_host_header": false,
+            "listen_path": "/grpc-custom-auth/",
+            "disable_strip_slash": true,
+            "strip_listen_path": true,
+            "target_url": "http://httpbin/"
+        },
+        "version_data": {
+            "not_versioned": false,
+            "versions": {
+                "Default": {
+                    "name": "Default",
+                    "expires": "",
+                    "use_extended_paths": true,
+                    "extended_paths": {
+                        "ignored": [],
+                        "white_list": [],
+                        "black_list": []
+                    }
+                }
+            },
+            "default_version": "Default"
+        },
+        "active": true
+    }
+}
+```
+
+The Tyk API definition above can be imported via Tyk Dashboard. Alternatively, if using Tyk Gateway OSS, a POST request can be made to the *api/apis* endpoint of Tyk Gateway. Consult the [Tyk Gateway Open API Specification documentation]({{< ref "tyk-gateway-api" >}}) for usage.
+
+An illustrative example using *curl* is given below. Please note that you will need to:
+
+- Update the location to use the protocol scheme, host and port suitable for your environment.
+- Replace the value in the *x-tyk-authorization* header with the secret value in your *tyk.conf* file.
+- Replace the *org_id* with the ID of your organisation.
+
+```bash
+curl -v \
+	--header 'Content-Type: application/json' \
+  	--header 'x-tyk-authorization: your Gateway admin secret' \
+	--location http://localhost:8080/tyk/apis/ \
+	--data '{\
+		"api_definition": {\
+			"id": "662facb2f03e750001a03502",\
+			"api_id": "6c56dd4d3ad942a94474df6097df67ef",\
+			"org_id": "5e9d9544a1dcd60001d0ed20",\
+			"name": "Python gRPC Custom Auth",\
+			"enable_coprocess_auth": true,\
+			"auth": {\
+				"auth_header_name": "Authorization"\
+			},\
+			"proxy": {\
+				"preserve_host_header": false,\
+				"listen_path": "/grpc-custom-auth-error/",\
+				"disable_strip_slash": true,\
+				"strip_listen_path": true,\
+				"target_url": "http://httpbin/"\
+			},\
+			"version_data": {\
+				"not_versioned": false,\
+				"versions": {\
+					"Default": {\
+						"name": "Default",\
+						"expires": "",\
+						"use_extended_paths": true,\
+						"extended_paths": {\
+							"ignored": [],\
+							"white_list": [],\
+							"black_list": []\
+						}\
+					}\
+				},\
+				"default_version": "Default"\
+			},\
+			"active": true\
+		}\
+	}'
+```
+
+A response similar to that given below will be returned by Tyk Gateway:
+
+```bash
+{
+    "key": "f97b748fde734b099001ca15f0346dfe",
+    "status": "ok",
+    "action": "added"
+}
+```
+
+#### Create HMAC Key
+
+We will create an key configured to use HMAC signing, with a secret of *secret*. The key will configured to have access to our test API.
+
+You can use the following configuration below, replacing the value of the *org_id* with the ID of your organisation.
+
+```bash
+{
+    "quota_max": 1000,
+    "quota_renews": 1596929526,
+    "quota_remaining": 1000,
+    "quota_reset": 1596843126,
+    "quota_used": 0,
+    "org_id": "5e9d9544a1dcd60001d0ed20",
+    "access_rights": {
+        "662facb2f03e750001a03500": {
+            "api_id": "662facb2f03e750001a03500",
+            "api_name": "Python gRPC Custom Auth",
+            "versions": ["Default"],
+            "allowed_urls": [],
+            "limit": null,
+            "quota_max": 1000,
+            "quota_renews": 1596929526,
+            "quota_remaining": 1000,
+            "quota_reset": 1596843126,
+            "quota_used": 0,
+            "per": 1,
+            "expires": -1
+        }
+    },
+    "enable_detailed_recording": true,
+    "hmac_enabled": true,
+    "hmac_string": "secret",
+    "meta_data": {}
+}
+```
+
+You can use Tyk Gateway’s API to create the key by issuing a POST request to the *tyk/keys* endpoint. Consult the [Tyk Gateway Open API Specification documentation]({{< ref "tyk-gateway-api" >}}) for usage.
+
+An illustrative example using *curl* is given below. Please note that you will need to:
+
+- Update the location to use the protocol scheme, host and port suitable for your environment.
+- Replace the value in the *x-tyk-authorization* header with the secret value in your *tyk.conf* file.
+
+Replace the *org_id* with the ID of your organisation.
+
+```bash
+curl --location 'http://localhost:8080/tyk/keys/grpc_hmac_key' \
+--header 'x-tyk-authorization: your Gateay admin secret' \
+--header 'Content-Type: application/json' \
+--data '{\
+    "alias": "grpc_hmac_key",\
+    "quota_max": 1000,\
+    "quota_renews": 1596929526,\
+    "quota_remaining": 1000,\
+    "quota_reset": 1596843126,\
+    "quota_used": 0,\
+    "org_id": "5e9d9544a1dcd60001d0ed20",\
+    "access_rights": {\
+        "662facb2f03e750001a03500": {\
+            "api_id": "662facb2f03e750001a03500",\
+            "api_name": "python-grpc-custom-auth",\
+            "versions": ["Default"],\
+            "allowed_urls": [],\
+            "limit": null,\
+            "quota_max": 1000,\
+            "quota_renews": 1596929526,\
+            "quota_remaining": 1000,\
+            "quota_reset": 1596843126,\
+            "quota_used": 0,\
+            "per": 1,\
+            "expires": -1\
+        }\
+    },\
+    "enable_detailed_recording": true,\
+    "hmac_enabled": true,\
+    "hmac_string": "secret",\
+    "meta_data": {}\
+}\
+'
+```
+
+A response similar to that given below should be returned by Tyk Gateway:
+
+```json
+{
+    "key": "eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6ImdycGNfaG1hY19rZXkiLCJoIjoibXVybXVyNjQifQ==",
+    "status": "ok",
+    "action": "added",
+    "key_hash": "a72fcdc09caa86b5"
+}
+```
+
+{{< note success>}}
+
+**Note**
+
+Make a note of the key ID given in the response, since we will need this to test our API.
+{{< /note >}}
+
+## Implement Plugin
+
+Our custom authentication plugin will perform the following tasks:
+
+- Extract the *Authorization* and *Date* headers from the request object.
+- Parse the *Authorization* header to extract the *keyId*, *algorithm* and *signature* attributes.
+- Compute the HMAC signature using the specific algorithm and date included in the header.
+- Verify that the computed HMAC signature matches the signature included in the *Authorization* header. A 401 error response will be returned if verification fails. Our plugin will only verify the key against an expected value. In a production environment it will be necessary to verify the key against Redis storage.
+- Verify that the *keyId* matches an expected value (VALID_TOKEN). A 401 error response will be returned to Tyk Gateway if verification fails.
+- If verification of the signature and key passes then update the session with HMAC enabled and set the HMAC secret. Furthermore, add the key to the *Object* metadata.
+
+Return the request *Object* containing the updated session back to Tyk Gateway. When developing custom authentication plugins it is the responsibility of the developer to update the session state with the token, in addition to setting the appropriate response status code and error message when authentication fails.
+
+### Import Python Modules
+
+Ensure that the following Python modules are imported at the top of your *tyk_async_server.py* file:
+
+```python
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import re
+import signal
+import logging
+import urllib.parse
+
+import grpc
+from google.protobuf.json_format import MessageToJson
+from grpc_reflection.v1alpha import reflection
+import coprocess_object_pb2_grpc
+import coprocess_object_pb2
+from coprocess_common_pb2 import HookType
+from coprocess_session_state_pb2 import SessionState
+```
+
+### Add Constants
+
+Add the following constants to the top of the *tyk_async_server.py* file, after the import statements:
+
+```bash
+SECRET = "c2VjcmV0"
+VALID_TOKEN = "eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6ImdycGNfaG1hY19rZXkiLCJoIjoibXVybXVyNjQifQ=="
+```
+
+- **SECRET** is a base64 representation of the secret used for HMAC signing.
+- **VALID_TOKEN** is the key ID that we will authenticate against.
+
+The values listed above are designed to align with the examples provided in the *Prerequisites* section, particularly those related to HMAC key generation. If you've made adjustments to the HMAC secret or you've modified the key alias referred to in the endpoint path (for instance, *grpc_hmac_key*), you'll need to update these constants accordingly.
+
+### Extract headers
+
+Add the following function to your *tyk_async_server.py* file to extract a dictionary of the key value pairs from the *Authorization* header. We will use a regular expression to extract the key value pairs.
+
+```python
+def parse_auth_header(auth_header: str) -> dict[str,str]:
+    pattern = r'(\w+)\s*=\s*"([^"]+)"'
+
+    matches = re.findall(pattern, auth_header)
+
+    parsed_data = dict(matches)
+
+    return parsed_data
+```
+
+### Compute HMAC Signature
+
+Add the following function to your *tyk_async_server.py* to compute the HMAC signature.
+
+```python
+def generate_hmac_signature(algorithm: str, date_string: str, secret_key: str) -> str:
+
+    if algorithm == "hmac-sha256":
+        hash_algorithm = hashlib.sha256
+    elif algorithm == "hmac-sha512":
+        hash_algorithm = hashlib.sha512
+    else:
+        raise ValueError("Unsupported hash algorithm")
+
+    base_string = f"date: {date_string}"
+
+    logging.info(f"generating signature from: {base_string}")
+    hmac_signature = hmac.new(secret_key.encode(), base_string.encode(), hash_algorithm)
+
+    return base64.b64encode(hmac_signature.digest()).decode()
+```
+
+Our function accepts three parameters:
+
+- **algorithm** is the HMAC algorithm to use for signing. We will use HMAC SHA256 or HMAC SHA512 in our custom authentication plugin
+- **date_string** is the date extracted from the date header in the request sent by Tyk Gateway.
+- **secret_key** is the value of the secret used for signing.
+
+The function computes and returns the HMAC signature for a string formatted as *date: date_string*, where *date_string* corresponds to the value of the *date_string* parameter. The signature is computed using the secret value given in the *secret_key* parameter and the HMAC algorithm given in the *algorithm* parameter. A *ValueError* is raised if the hash algorithm is unrecognised. 
+
+We use the following Python modules in our implementation:
+
+- hmac Python module to compute the HMAC signature.
+- base64 Python module to encode the result.
+
+### Verify HMAC Signature
+
+Add the following function to your *tyk_async_server.py* file to verify the HMAC signature provided by the client:
+
+```python
+def verify_hmac_signature(algorithm: str, signature: str, source_string) -> bool:
+
+    expected_signature = generate_hmac_signature(algorithm, source_string, SECRET)
+    received_signature = urllib.parse.unquote(signature)
+
+    if expected_signature != received_signature:
+        error = f"Signatures did not match\nreceived: {received_signature}\nexpected: {expected_signature}"
+        logging.error(error)
+    else:
+        logging.info("Signatures matched!")
+
+    return expected_signature == received_signature
+```
+
+Our function accepts three parameters:
+
+- **algorithm** is the HMAC algorithm to use for signing. We will use hmac-sha256 or hmac-sha512 in our custom authentication plugin.
+- **signature** is the signature string extracted from the *Authorization* header.
+- **source_string** is the date extracted from the date header in the request sent by Tyk Gateway.
+- **secret_key** is the value of the secret used for signing.
+
+The function calls *generate_hmac_signature* to verify the signatures match. It returns true if the computed and client HMAC signatures match, otherwise false is returned.
+
+### Set Error Response
+
+Add the following helper function to *tyk_async_server.py* to allow us to set the response status and error message if authentication fails.
+
+```python
+def set_response_error(object: coprocess_object_pb2.Object, code: int, message: str) -> None:
+    object.request.return_overrides.response_code = code
+    object.request.return_overrides.response_error = message
+```
+
+Our function accepts the following three parameters:
+
+- **object** is an instance of the [Object]({{< ref "plugins/supported-languages/rich-plugins/rich-plugins-data-structures#object" >}}) message representing the payload sent by Tyk Gateway to the *Dispatcher* service in our gRPC server. For further details of the payload structure dispatched by Tyk Gateway to a gRPC server please consult our gRPC documentation.
+- **code** is the HTTP status code to return in the response.
+- **message** is the response message.
+
+The function modifies the *return_overrides* attribute of the request, updating the response status code and error message. The *return_overrides* attribute is an instance of a [ReturnOverrides]({{< ref "plugins/supported-languages/rich-plugins/rich-plugins-data-structures#returnoverrides" >}}) message that can be used to override the response of a given HTTP request. When this attribute is modified the request is terminated and is not sent upstream.
+
+### Authenticate
+
+Add the following to your *tyk_async_server.py* file to implement the main custom authentication function. This parses the headers to extract the signature and date from the request, in addition to verifying the HMAC signature and key:
+
+```python
+def authenticate(object: coprocess_object_pb2.Object) -> coprocess_object_pb2.Object:
+    keys_to_check = ["keyId", "algorithm", "signature"]
+
+    auth_header = object.request.headers.get("Authorization")
+    date_header = object.request.headers.get("Date")
+
+    parse_dict = parse_auth_header(auth_header)
+
+    if not all(key in parse_dict for key in keys_to_check) or not all([auth_header, date_header]):
+        set_response_error(object, 400, "Custom middleware: Bad request")
+        return object
+
+    try:
+        signature_valid = verify_hmac_signature(
+            parse_dict["algorithm"],
+            parse_dict["signature"],
+            date_header
+        )
+    except ValueError:
+        set_response_error(object, 400, "Bad HMAC request, unsupported algorithm")
+        return object
+
+    if not signature_valid or parse_dict["keyId"] != VALID_TOKEN:
+        set_response_error(object, 401, "Custom middleware: Not authorized")
+    else:
+        new_session = SessionState()
+        new_session.hmac_enabled = True
+        new_session.hmac_secret = SECRET
+
+        object.metadata["token"] = VALID_TOKEN
+        object.session.CopyFrom(new_session)
+
+    return object
+```
+
+The *Object* payload received from the Gateway is updated and returned as a response from the *Dispatcher* service:
+
+- If authentication fails then we set the error message and status code for the response accordingly, using our *set_response_error* function.
+- If authentication passes then we update the session attribute in the *Object* payload to indicate that HMAC verification was performed and provide the secret used for signing. We also add the verified key to the meta data of the request payload.
+
+Specifically, our function performs the following tasks:
+
+- Extracts the *Date* and *Authorization* headers from the request and verifies that the *Authorization* header is structured correctly, using our *parse_auth_header* function. We store the extracted *Authorization* header fields in the *parse_dict* dictionary. If the structure is invalid then a 400 bad request response is returned to Tyk Gateway, using our *set_response_error* function.
+- We use our *verify_hmac_signature* function to compute and verify the HMAC signature. A 400 bad request error is returned to the Gateway if HMAC signature verification fails, due to an unrecognised HMAC algorithm.
+- A 401 unauthorised error response is returned to the Gateway under the following conditions:
+
+    - The client HMAC signature and the computed HMAC signature do not match.
+    - The extracted key ID does not match the expected key value in VALID_TOKEN.
+
+- If HMAC signature verification passed and the key included in the *Authorization* header is valid then we update the *SessionState* instance to indicate that HMAC signature verification is enabled, i.e. *hmac_enabled* is set to true.  We also specify the HMAC secret used for signing in the *hmac_secret* field and include the valid token in the metadata dictionary.
+
+### Integrate Plugin
+
+Update the *Dispatch* method of the *PythonDispatcher* class in your *tyk_async_server.py* file so that our authenticate function is called when the a request is made by Tyk Gateway to execute a custom authentication (*HookType.CustomKeyCheck*) plugin.
+
+```python
+class PythonDispatcher(coprocess_object_pb2_grpc.DispatcherServicer):
+    async def Dispatch(
+        self, object: coprocess_object_pb2.Object, context: grpc.aio.ServicerContext
+    ) -> coprocess_object_pb2.Object:
+        
+        logging.info(f"STATE for {object.hook_name}\n{MessageToJson(object)}\n")
+        
+        if object.hook_type == HookType.Pre:
+            logging.info(f"Pre plugin name: {object.hook_name}")
+            logging.info(f"Activated Pre Request plugin from API: {object.spec.get('APIID')}")
+        
+        elif object.hook_type == HookType.CustomKeyCheck:
+            logging.info(f"CustomAuth plugin: {object.hook_name}")
+            logging.info(f"Activated CustomAuth plugin from API: {object.spec.get('APIID')}")
+            
+            authenticate(object)
+
+        elif object.hook_type == HookType.PostKeyAuth:
+            logging.info(f"PostKeyAuth plugin name: {object.hook_name}")
+            logging.info(f"Activated PostKeyAuth plugin from API: {object.spec.get('APIID')}")
+        
+        elif object.hook_type == HookType.Post:
+            logging.info(f"Post plugin name: {object.hook_name}")
+            logging.info(f"Activated Post plugin from API: {object.spec.get('APIID')}")
+        
+        elif object.hook_type == HookType.Response:
+            logging.info(f"Response plugin name: {object.hook_name}")
+            logging.info(f"Activated Response plugin from API: {object.spec.get('APIID')}")
+            logging.info("--------\n")
+        
+        return object
+```
+
+## Test Plugin
+
+Create the following bash script, *hmac.sh*, to issue a test request to an API served by Tyk Gateway. The script computes a HMAC signature and constructs the *Authorization* and *Date* headers for a specified API. The *Authorization* header contains the HMAC signature and key for authentication.
+
+Replace the following constant values with values suitable for your environment:
+
+- **KEY** represents the key ID for the HMAC signed key that you created at the beginning of this guide.
+- **HMAC_SECRET** represents the base64 encoded value of the secret for your HMAC key that you created at the beginning of this guide.
+- **BASE_URL** represents the base URL, containing the protocol scheme, host and port number that Tyk Gateway listens to for API requests.
+- **ENDPOINT** represents the path of your API that uses HMAC signed authentication.
+
+```bash
+#!/bin/bash
+
+BASE_URL=http://localhost:8080
+ENDPOINT=/grpc-custom-auth/get
+HMAC_ALGORITHM=hmac-sha512
+HMAC_SECRET=c2VjcmV0
+KEY=eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6ImdycGNfaG1hY19rZXkiLCJoIjoibXVybXVyNjQifQ==
+REQUEST_URL=${BASE_URL}${ENDPOINT}
+
+
+function urlencode() {
+  echo -n "$1" | perl -MURI::Escape -ne 'print uri_escape($_)' | sed "s/%20/+/g"
+}
+
+# Set date in expected format
+date="$(LC_ALL=C date -u +"%a, %d %b %Y %H:%M:%S GMT")"
+
+# Generate the signature using hmac algorithm with hmac secret from created Tyk key and
+# then base64 encoded
+signature=$(echo -n "date: ${date}" | openssl sha512 -binary -hmac "${HMAC_SECRET}" | base64)
+
+# Ensure the signature is base64 encoded
+url_encoded_signature=$(echo -n "${signature}" | perl -MURI::Escape -ne 'print uri_escape($_)' | sed "s/%20/+/g")
+
+# Output the date, encoded date, signature and the url encoded signature
+echo "request: ${REQUEST_URL}"
+echo "date: $date"
+echo "signature: $signature"
+echo "url_encoded_signature: $url_encoded_signature"
+
+# Make the curl request using headers
+printf "\n\n----\n\nMaking request to  http://localhost:8080/grpc-custom-auth/get\n\n"
+set -x
+curl -v -H "Date: ${date}" \
+    -H "Authorization: Signature keyId=\"${KEY}\",algorithm=\"${HMAC_ALGORITHM}\",signature=\"${url_encoded_signature}\"" \
+    ${REQUEST_URL}
+```
+
+After creating and saving the script, ensure that it is executable by issuing the following command:
+
+```bash
+chmod +x hmac.sh
+```
+
+Issue a test request by running the script:
+
+```bash
+./hmac.sh
+```
+
+Observe the output of your gRPC server. You should see the request payload appear in the console output for the server and your custom authentication plugin should have been triggered. An illustrative example is given below:
+
+```bash
+2024-05-13 12:53:49 INFO:root:STATE for CustomHMACCheck
+2024-05-13 12:53:49 {
+2024-05-13 12:53:49   "hookType": "CustomKeyCheck",
+2024-05-13 12:53:49   "hookName": "CustomHMACCheck",
+2024-05-13 12:53:49   "request": {
+2024-05-13 12:53:49     "headers": {
+2024-05-13 12:53:49       "User-Agent": "curl/8.1.2",
+2024-05-13 12:53:49       "Date": "Mon, 13 May 2024 11:53:49 GMT",
+2024-05-13 12:53:49       "Host": "localhost:8080",
+2024-05-13 12:53:49       "Authorization": "Signature keyId=\"eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6ImdycGNfaG1hY19rZXkiLCJoIjoibXVybXVyNjQifQ==\",algorithm=\"hmac-sha512\",signature=\"e9OiifnTDgi3PW2EGJWfeQXCuhuhi6bGLiGhUTFpjEfgdKmX%2FQOFrePAQ%2FAoSFGU%2FzpP%2FCabmQi4zQDPdRh%2FZg%3D%3D\"",
+2024-05-13 12:53:49       "Accept": "*/*"
+2024-05-13 12:53:49     },
+2024-05-13 12:53:49     "url": "/grpc-custom-auth/get",
+2024-05-13 12:53:49     "returnOverrides": {
+2024-05-13 12:53:49       "responseCode": -1
+2024-05-13 12:53:49     },
+2024-05-13 12:53:49     "method": "GET",
+2024-05-13 12:53:49     "requestUri": "/grpc-custom-auth/get",
+2024-05-13 12:53:49     "scheme": "http"
+2024-05-13 12:53:49   },
+2024-05-13 12:53:49   "spec": {
+2024-05-13 12:53:49     "bundle_hash": "d41d8cd98f00b204e9800998ecf8427e",
+2024-05-13 12:53:49     "OrgID": "5e9d9544a1dcd60001d0ed20",
+2024-05-13 12:53:49     "APIID": "6c56dd4d3ad942a94474df6097df67ed"
+2024-05-13 12:53:49   }
+2024-05-13 12:53:49 }
+2024-05-13 12:53:49 
+2024-05-13 12:53:49 INFO:root:CustomAuth plugin: CustomHMACCheck
+2024-05-13 12:53:49 INFO:root:Activated CustomAuth plugin from API: 6c56dd4d3ad942a94474df6097df67ed
+2024-05-13 12:53:49 INFO:root:generating signature from: date: Mon, 13 May 2024 11:53:49 GMT
+2024-05-13 12:53:49 INFO:root:Signatures matched!
+2024-05-13 12:53:49 INFO:root:--------
+```
+
+Try changing the SECRET and/or KEY constants with invalid values and observe the output of your gRPC server. You should notice that authentication fails. An illustrative example is given below:
+
+```
+2024-05-13 12:56:37 INFO:root:STATE for CustomHMACCheck
+2024-05-13 12:56:37 {
+2024-05-13 12:56:37   "hookType": "CustomKeyCheck",
+2024-05-13 12:56:37   "hookName": "CustomHMACCheck",
+2024-05-13 12:56:37   "request": {
+2024-05-13 12:56:37     "headers": {
+2024-05-13 12:56:37       "User-Agent": "curl/8.1.2",
+2024-05-13 12:56:37       "Date": "Mon, 13 May 2024 11:56:37 GMT",
+2024-05-13 12:56:37       "Host": "localhost:8080",
+2024-05-13 12:56:37       "Authorization": "Signature keyId=\"eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6ImdycGNfaG1hY19rZXkiLCJoIjoibXVybXVyNjQifQ==\",algorithm=\"hmac-sha512\",signature=\"KXhkWOS01nbxuFfK7wEBggkydXlKJswxbukiplboJ2n%2BU6JiYOil%2Bx4OE4edWipg4EcG9T49nvY%2Fc9G0XFJcfg%3D%3D\"",
+2024-05-13 12:56:37       "Accept": "*/*"
+2024-05-13 12:56:37     },
+2024-05-13 12:56:37     "url": "/grpc-custom-auth/get",
+2024-05-13 12:56:37     "returnOverrides": {
+2024-05-13 12:56:37       "responseCode": -1
+2024-05-13 12:56:37     },
+2024-05-13 12:56:37     "method": "GET",
+2024-05-13 12:56:37     "requestUri": "/grpc-custom-auth/get",
+2024-05-13 12:56:37     "scheme": "http"
+2024-05-13 12:56:37   },
+2024-05-13 12:56:37   "spec": {
+2024-05-13 12:56:37     "bundle_hash": "d41d8cd98f00b204e9800998ecf8427e",
+2024-05-13 12:56:37     "OrgID": "5e9d9544a1dcd60001d0ed20",
+2024-05-13 12:56:37     "APIID": "6c56dd4d3ad942a94474df6097df67ed"
+2024-05-13 12:56:37   }
+2024-05-13 12:56:37 }
+2024-05-13 12:56:37 
+2024-05-13 12:56:37 INFO:root:CustomAuth plugin: CustomHMACCheck
+2024-05-13 12:56:37 INFO:root:Activated CustomAuth plugin from API: 6c56dd4d3ad942a94474df6097df67ed
+2024-05-13 12:56:37 INFO:root:generating signature from: date: Mon, 13 May 2024 11:56:37 GMT
+2024-05-13 12:56:37 ERROR:root:Signatures did not match
+2024-05-13 12:56:37 received: KXhkWOS01nbxuFfK7wEBggkydXlKJswxbukiplboJ2n+U6JiYOil+x4OE4edWipg4EcG9T49nvY/c9G0XFJcfg==
+2024-05-13 12:56:37 expected: zT17C2tgDCYBJCgFFN/mknf6XydPaV98a5gMPNUHYxZyYwYedIPIhyDRQsMF9GTVFe8khCB1FhfyhpmzrUR2Lw==
+```
+
+## Summary
+
+In this guide, we've explained how to write a Python gRPC custom authentication plugin for Tyk Gateway, using HMAC-signed authentication as a practical example. Through clear instructions and code examples, we've provided developers with insights into the process of creating custom authentication logic tailored to their specific API authentication needs.
+
+While Tyk Gateway already supports HMAC-signed authentication out of the box, this guide goes beyond basic implementation by demonstrating how to extend its capabilities through custom plugins. By focusing on HMAC-signed authentication, developers have gained valuable experience in crafting custom authentication mechanisms that can be adapted and expanded to meet diverse authentication requirements.
+
+It's important to note that the authentication mechanism implemented in this guide solely verifies the HMAC signature's validity and does not include access control checks against specific API resources. Developers should enhance this implementation by integrating access control logic to ensure authenticated requests have appropriate access permissions.
+
+By mastering the techniques outlined in this guide, developers are better equipped to address complex authentication challenges and build robust API security architectures using Tyk Gateway's extensibility features. This guide serves as a foundation for further exploration and experimentation with custom authentication plugins, empowering developers to innovate and customise API authentication solutions according to their unique requirements.
+
+---
+
+</br>

--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/getting-started-python.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/getting-started-python.md
@@ -1,0 +1,559 @@
+---
+date: 2024-05-10T11:54:00Z
+title: "Getting Started: Creating A Python gRPC Server"
+---
+
+In the realm of API integration, establishing seamless connections between services is paramount.
+
+Understanding the fundamentals of gRPC server implementation is crucial, especially when integrating with a Gateway solution like Tyk. This guide aims to provide practical insights into this process, starting with the basic principles of how to implement a Python gRPC server that integrates with Tyk Gateway.
+
+## Objectives
+
+By the end of this guide, you will be able to implement a gRPC server that will integrate with Tyk Gateway, setting the stage for further exploration in subsequent parts:
+
+- Establishing the necessary tools, Python libraries and gRPC service definition for implementing a gRPC server that integrates with Tyk Gateway.
+- Developing a basic gRPC server that echoes the request payload to the console, showcasing the core principles of integration.
+- Configuring Tyk Gateway to interact with our gRPC server, enabling seamless communication between the two services.
+
+Before implementing our first gRPC server it is first necessary to understand the service interface that defines how Tyk Gateway integrates with a gRPC server.
+
+
+## Tyk Dispatcher Service
+
+The *Dispatcher* service, defined in the [coprocess_object.proto](https://github.com/TykTechnologies/tyk/blob/master/coprocess/proto/coprocess_object.proto) file, contains the *Dispatch* RPC method, invoked by Tyk Gateway to request remote execution of gRPC plugins. Tyk Gateway dispatches accompanying data relating to the original client request and session. The service definition is listed below:
+
+```protobuf
+service Dispatcher {
+  rpc Dispatch (Object) returns (Object) {}
+  rpc DispatchEvent (Event) returns (EventReply) {}
+}
+```
+
+On the server side, we will implement the *Dispatcher* service methods and a gRPC server to handle requests from Tyk Gateway. The gRPC infrastructure decodes incoming requests, executes service methods and encodes service responses.
+
+Before we start developing our gRPC server we need to setup our development environment with the supporting libraries and tools.
+
+
+## Prerequisites
+
+Firstly, we need to download the [Tyk Protocol Buffers](https://github.com/TykTechnologies/tyk/tree/master/coprocess/proto) and install the Python protoc compiler.
+
+We are going to use the *protoc* compiler to generate the supporting classes and data structures to implement the *Dispatcher* service.
+
+
+### Tyk Protocol Buffers
+
+Issue the following command to download and extract the Tyk Protocol Buffers from the Tyk GitHub repository:
+
+```bash
+curl -sL "https://github.com/TykTechnologies/tyk/archive/master.tar.gz " -o tyk.tar.gz && \
+    mkdir tyk && \
+    tar -xzvf tyk.tar.gz --strip-components=1 -C tyk && \
+    mv tyk/coprocess/proto/* . && \
+    rm -r tyk tyk.tar.gz
+```
+
+### Install Dependencies
+
+We are going to setup a Python virtual environment and install some supporting dependencies. Assuming that you have Python [virtualenv](https://virtualenv.pypa.io/en/latest/installation.html) already installed, then issue the following commands to setup a Python virtual environment containing the grpcio and grpcio-tools libraries:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install –upgrade pip
+pip install grpcio grpcio-tools grpcio-reflection
+```
+
+The [grpcio](https://pypi.org/project/grpcio/) library offers essential functionality to support core gRPC features such as message serialisation and deserialisation. The [grpcio-tools](https://pypi.org/project/grpcio-tools/) library provides the Python *protoc* compiler that we will use to generate the supporting classes and data structures to implement our gRPC server. The [grpcio-reflection](https://pypi.org/project/grpcio-reflection/) library allows clients to query information about the services and methods provided by a gRPC server at runtime. It enables clients to dynamically discover available services, their RPC methods, in addition to the message types and field names associated with those methods.
+
+
+### Install grpcurl
+
+Follow the [installation instructions](https://github.com/fullstorydev/grpcurl?tab=readme-ov-file#installation) to install grpcurl. We will use grpcurl to send test requests to our gRPC server.
+
+
+### Generate Python Bindings
+
+We are now able to generate the Python classes and data structures to allow us to implement our gRPC server. To accomplish this we will use the Python *protoc* command as listed below:
+
+```bash
+python -m grpc_tools.protoc --proto_path=. --python_out=. --grpc_python_out=. *.proto
+```
+
+This compiles the Protocol Buffer files (*.proto) from the current working directory and generates the Python classes representing the Protocol Buffer messages and services. A series of *.py* files should now exist in the current working directory. We are interested in the *coprocess_object_pb2_grpc.py* file, containing a default implementation of *Tyk’s Dispatcher* service.
+
+Inspect the generated Python file, *coprocess_object_pb2_grpc.py*, containing the *DispatcherServicer* class:
+
+```python
+class DispatcherServicer(object):
+    """ GRPC server interface, that must be implemented by the target language """
+    def Dispatch(self, request, context):
+        """ Accepts and returns an Object message """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+    def DispatchEvent(self, request, context):
+        """ Dispatches an event to the target language """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+```
+
+This superclass contains a default stub implementation for the **Dispatch** and **DispatchEvent** RPC methods, each defining request and context parameters:
+
+The *request* parameter allows our server to access the message payload sent by Tyk Gateway. We can use this data, pertaining to the request and session, to process and generate a response.
+
+The *context* parameter provides additional information and functionalities related to the RPC call, such as timeout limits, cancellation signals etc. This is a [grpc.ServicerContext](https://grpc.github.io/grpc/python/grpc.html#grpc.ServicerContext) or a [grpc.aio.ServicerContext](https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.ServicerContext), object depending upon whether a synchronous or AsyncIO gRPC server is implemented.
+
+In the next step we will implement a subclass that will handle requests made by Tyk Gateway for remote execution of custom plugins.
+
+
+## Implement Dispatcher Service
+
+We will now develop the *Dispatcher* service, adding implementations of the *Dispatch* and *DispatchEvent* methods, to allow our gRPC server to integrate with Tyk Gateway. Before we continue, create a file, *async_server.py*, within the same folder as the generated Protocol Buffer (.proto) files. 
+
+
+### Dispatch
+
+Our implementation of the Dispatch RPC method will deserialize the request payload and output to the console as JSON format. This serves as a useful development and debugging aid, allowing inspection of the request and session state dispatched by Tyk Gateway to our gRPC server.
+
+Copy and paste the following source code into the *async_server.py* file. Notice that we have used type hinting to aid readability. The type hints are located within the type hint files (.pyi) we generated with the protoc compiler. 
+
+
+```python
+import asyncio
+import grpc
+import json
+import signal
+import logging
+from google.protobuf.json_format import MessageToJson
+from grpc_reflection.v1alpha import reflection
+import coprocess_object_pb2_grpc
+import coprocess_object_pb2
+from coprocess_common_pb2 import HookType
+from coprocess_session_state_pb2 import SessionState
+class PythonDispatcher(coprocess_object_pb2_grpc.DispatcherServicer):
+    async def Dispatch(
+        self, object: coprocess_object_pb2.Object, context: grpc.aio.ServicerContext
+    ) -> coprocess_object_pb2.Object:
+        logging.info(f"STATE for {object.hook_name}\n{MessageToJson(object)}\n")
+        if object.hook_type == HookType.Pre:
+            logging.info(f"Pre plugin name: {object.hook_name}")
+            logging.info(f"Activated Pre Request plugin from API: {object.spec.get('APIID')}")
+        elif object.hook_type == HookType.CustomKeyCheck:
+            logging.info(f"CustomAuth plugin: {object.hook_name}")
+            logging.info(f"Activated CustomAuth plugin from API: {object.spec.get('APIID')}")
+        elif object.hook_type == HookType.PostKeyAuth:
+            logging.info(f"PostKeyAuth plugin name: {object.hook_name}")
+            logging.info(f"Activated PostKeyAuth plugin from API: {object.spec.get('APIID')}")
+        elif object.hook_type == HookType.Post:
+            logging.info(f"Post plugin name: {object.hook_name}")
+            logging.info(f"Activated Post plugin from API: {object.spec.get('APIID')}")
+        elif object.hook_type == HookType.Response:
+            logging.info(f"Response plugin name: {object.hook_name}")
+            logging.info(f"Activated Response plugin from API: {object.spec.get('APIID')}")
+            logging.info("--------\n")
+        return object
+```
+
+Our *Dispatch* RPC method accepts the two parameters, *object* and *context*. The object parameter allows us to inspect the state and session of the request object dispatched by Tyk Gateway, via accessor methods. The *context* parameter can be used to set timeout limits etc. associated with the RPC call.
+
+The important takeaways from the source code listing above are:
+
+- The [MessageToJson](https://googleapis.dev/python/protobuf/latest/google/protobuf/json_format.html#google.protobuf.json_format.MessageToJson) function is used to deserialize the request payload as JSON.
+- In the context of custom plugins we access the *hook_type* and *hook_name* attributes of the *Object* message to determine which plugin to execute.
+- The ID of the API associated with the request is accessible from the spec dictionary, *object.spec.get('APIID')*.
+
+An implementation of the *Dispatch* RPC method must return the object payload received from Tyk Gateway. The payload can be modified by the service implementation, for example to add or remove headers and query parameters before the request is sent upstream.
+
+
+### DispatchEvent
+
+Our implementation of the *DispatchEvent* RPC method will deserialize and output the event payload as JSON. Append the following source code to the *async_server.py* file:
+
+```python
+   async def DispatchEvent(
+        self, event: coprocess_object_pb2.Event, context: grpc.aio.ServicerContext
+    ) -> coprocess_object_pb2.EventReply:
+        event = json.loads(event.payload)
+        http://logging.info (f"RECEIVED EVENT: {event}")
+        return coprocess_object_pb2.EventReply()
+```
+
+The *DispatchEvent* RPC method accepts the two parameters, *event* and *context*. The event parameter allows us to inspect the payload of the event dispatched by Tyk Gateway. The context parameter can be used to set timeout limits etc. associated with the RPC call.
+
+The important takeaways from the source code listing above are:
+
+- The event data is accessible from the *payload* attribute of the event parameter.
+- An implementation of the *DispatchEvent* RPC method must return an instance of  *coprocess_object_pb2.EventReply*.
+
+
+## Create gRPC Server
+
+Finally, we will implement an AsyncIO gRPC server to handle requests from Tyk Gateway to the *Dispatcher* service. We will add functions to start and stop our gRPC server. Finally, we will use *grpcurl* to issue a test payload to our gRPC server to test that it is working.
+
+
+### Develop gRPC Server
+
+Append the following source code from the listing below to the *async_server.py* file:
+
+```python
+async def serve() -> None:
+    server = grpc.aio.server()
+    coprocess_object_pb2_grpc.add_DispatcherServicer_to_server(
+        PythonDispatcher(), server
+    )
+   listen_addr = "[::]:50051"
+    SERVICE_NAMES = (
+        coprocess_object_pb2.DESCRIPTOR.services_by_name["Dispatcher"].full_name,
+        reflection.SERVICE_NAME,
+    )
+
+    reflection.enable_server_reflection(SERVICE_NAMES, server)
+    server.add_insecure_port(listen_addr)
+
+    logging.info ("Starting server on %s", listen_addr)
+
+    await server.start()
+    await server.wait_for_termination()
+
+async def shutdown_server(server) -> None:
+    http://logging.info ("Shutting down server...")
+    await server.stop(None)
+```
+
+The *serve* function starts the gRPC server, listening for requests on port 50051 with reflection enabled.
+
+Clients can use reflection to list available services, obtain their RPC methods and retrieve their message types and field names dynamically. This is particularly useful for tooling and debugging purposes, allowing clients to discover server capabilities without prior knowledge of the service definitions. 
+
+{{< note success >}}
+
+**note**
+
+A descriptor is a data structure that describes the structure of the messages, services, enums and other elements defined in a .proto file. The purpose of the descriptor is primarily metadata: it provides information about the types and services defined in the protocol buffer definition. The *coprocess_object_pb2.py* file that we generated using *protoc* contains a DESCRIPTOR field that we can use to retrieve this metadata. For further details consult the documentation for the Google's protobuf [FileDescriptor](https://googleapis.dev/python/protobuf/latest/google/protobuf/descriptor.html#google.protobuf.descriptor.FileDescriptor.services_by_name) class. 
+
+{{< /note >}}
+
+The *shutdown_server* function stops the gRPC server via the *stop* method of the server instance. 
+
+The key takeaways from the source code listing above are:
+
+- An instance of a gRPC server is created using *grpc.aio.server()*.
+- A service implementation should be registered with the gRPC server. We register our *PythonDispatcher* class via *coprocess_object_pb2_grpc.add_DispatcherServicer_to_server(PythonDispatcher(), server)*.
+- Reflection can be enabled to allow clients to dynamically discover the services available at a gRPC server. We enabled our *Dispatcher* service to be discovered via *reflection.enable_server_reflection(SERVICE_NAMES, server)*. SERVICE_NAMES is a tuple containing the full names of two gRPC services: the *Dispatcher* service obtained by using the DESCRIPTOR field within the *coprocess_object_pb2* module and the other being the standard reflection service.
+- The server instance should be started via invoking and awaiting the *start* and *wait_for_termination* methods of the server instance.
+- A port may be configured for the server. In this example we configured an insecure port of 50051 on the server instance via the [add_insecure_port function](https://grpc.github.io/grpc/python/grpc.html#grpc.Server.add_insecure_port). It is also possible to add a secure port via the [add_secure_port](https://grpc.github.io/grpc/python/grpc.html#grpc.Server.add_secure_port) method of the server instance, which accepts the port number in addition to an SSL certificate and key to enable TLS encryption.
+- The server instance can be stopped via its stop method.
+
+Finally, we will allow our server to terminate upon receipt of SIGTERM and SIGINT signals. To achieve this, append the source code listed below to the *async_server.py* file.
+
+```python
+def handle_sigterm(sig, frame) -> None:
+    asyncio.create_task(shutdown_server(server))
+
+async def handle_sigint() -> None:
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, loop.stop)
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    server = None
+    signal.signal(signal.SIGTERM, handle_sigterm)
+    try:
+        asyncio.get_event_loop().run_until_complete(serve())
+    except KeyboardInterrupt:
+        pass
+```
+
+
+### Start gRPC Server
+
+Issue the following command to start the gRPC server:
+
+```bash
+python3 -m async_server
+```
+
+A message should be output on the console, displaying the port number and confirming that the gRPC server has started.
+
+
+### Test gRPC Server
+
+To test our gRPC server is working, issue test requests to the *Dispatch* and *DispatchEvent* methods, using *grpcurl*.
+
+
+##### Send Dispatch Request
+
+Use the *grpcurl* command to send a test dispatch request to our gRPC server:
+
+```bash
+grpcurl -plaintext -d '{
+  "hookType": "Pre",
+  "hookName": "MyPreCustomPluginForBasicAuth",
+  "request": {
+    "headers": {
+      "User-Agent": "curl/8.1.2",
+      "Host": "tyk-gateway.localhost:8080",
+      "Authorization": "Basic ZGV2QHR5ay5pbzpwYXN0cnk=",
+      "Accept": "*/*"
+    },
+    "url": "/basic-authentication-valid/get",
+    "returnOverrides": {
+      "responseCode": -1
+    },
+    "method": "GET",
+    "requestUri": "/basic-authentication-valid/get",
+    "scheme": "https"
+  },
+  "spec": {
+    "bundle_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "OrgID": "5e9d9544a1dcd60001d0ed20",
+    "APIID": "04e911d3012646d97fcdd6c846fafc4b"
+  }
+}' localhost:50051 coprocess.Dispatcher/Dispatch
+```
+
+Inspect the console output of your gRPC server. It should echo the payload that you sent in the request.
+
+
+##### Send DispatchEvent Request
+
+Use the grpcurl command to send a test event payload to our gRPC server:
+
+```bash
+grpcurl -plaintext -d '{"payload": "{\"event\": \"test\"}"}' localhost:50051 coprocess.Dispatcher/DispatchEvent
+```
+
+Inspect the console output of your gRPC server. It should display a log similar to that shown below:
+
+```bash
+INFO:root:RECEIVED EVENT: {'event': 'test'}
+```
+
+The response received from the server should be an empty event reply, similar to that shown below:
+
+```bash
+grpcurl -plaintext -d '{"payload": "{\"event\": \"test\"}"}' localhost:50051 coprocess.Dispatcher/DispatchEvent
+{}
+```
+
+At this point we have tested, independently of Tyk Gateway, that our gRPC Server can handle an example request payload for gRPC plugin execution. In the next section we will create a test environment for testing that Tyk Gateway integrates with our gRPC server for API requests.
+
+
+## Configure Test Environment
+
+Now that we have implemented and started a gRPC server, Tyk Gateway needs to be configured to integrate with it. To achieve this we will enable the coprocess feature and configure the URL of the gRPC server.
+
+We will also create an API so that we can test that Tyk Gateway integrates with our gRPC server.
+
+
+### Configure Tyk Gateway
+
+Within the root of the *tyk.conf* file, add the following configuration, replacing host and port with values appropriate for your environment:
+
+```yaml
+"coprocess_options": {
+  "enable_coprocess":   true,
+  "coprocess_grpc_server": "tcp://host:port"
+}
+```
+
+Alternatively, the following environment variables can be set in your .env file:
+
+```bash
+TYK_GW_COPROCESSOPTIONS_ENABLECOPROCESS=true
+TYK_GW_COPROCESSOPTIONS_COPROCESSGRPCSERVER=tcp://host:port
+```
+
+Replace host and port with values appropriate for your environment.
+
+
+### Configure API
+
+Before testing our gRPC server we will create and configure an API with 2 plugins:
+
+- **Pre Request**: Named *MyPreRequestPlugin*.
+- **Response**: Named *MyResponsePlugin* and configured so that Tyk Gateway dispatches the session state with the request.
+
+Each plugin will be configured to use the *grpc* plugin driver.
+
+Tyk Gateway will forward details of an incoming request to the gRPC server, for each of the configured API plugins.
+
+
+##### Tyk Classic API
+
+gRPC plugins can be configured within the *custom_middleware* section of the Tyk Classic ApiDefinition, as shown in the listing below:
+
+```yaml
+{
+  "created_at": "2024-03-231T12:49:52Z",
+  "api_model": {},
+  "api_definition": {
+    ...
+    ...
+    "custom_middleware": {
+      "pre": [
+        {
+          "disabled": false,
+          "name": "MyPreRequestPlugin",
+          "path": "",
+          "require_session": false,
+          "raw_body_only": false
+        }
+      ],
+      "post": [],
+      "post_key_auth": [],
+      "auth_check": {
+        "disabled": false,
+        "name": "",
+        "path": "",
+        "require_session": false,
+        "raw_body_only": false
+      },
+      "response": [
+        {
+          "disabled": false,
+          "name": "MyResponsePlugin",
+          "path": "",
+          "require_session": true,
+          "raw_body_only": false
+        }
+      ],
+      "driver": "grpc",
+      "id_extractor": {
+        "disabled": false,
+        "extract_from": "",
+        "extract_with": "",
+        "extractor_config": {}
+      }
+    }
+}
+```
+
+In the above listing, the plugin driver parameter has been configured with a value of *grpc*. Two plugins are configured within the *custom_middleware* section: a *Pre Request* plugin and a *Response* plugin.
+
+The *Response* plugin is configured with *require_session* enabled, so that Tyk Gateway will send details for the authenticated key / user with the gRPC request. Note, this is not configured for *Pre Request* plugins that are triggered before authentication in the request lifecycle.
+
+
+##### Tyk OAS API
+
+To quickly get started, a Tyk OAS API schema can be created by importing the infamous [pet store](https://petstore3.swagger.io/api/v3/openapi.json) OAS schema. Then the [findByStatus](https://petstore3.swagger.io/api/v3/pet/findByStatus?status=available) endpoint can be used for testing.
+
+The resulting Tyk OAS API Definition contains the OAS JSON schema with an *x-tyk-api-gateway* section appended, as listed below. gRPC plugins can be configured within the middleware section of the *x-tyk-api-gateway* that is appended at the end of the OAS schema:
+
+```yaml
+"x-tyk-api-gateway": {
+  "info": {
+    "id": "6e2ae9b858734ea37eb772c666517f55",
+    "dbId": "65f457804773a600011af41d",
+    "orgId": "5e9d9544a1dcd60001d0ed20",
+    "name": "Swagger Petstore - OpenAPI 3.0 Custom Authentication",
+    "state": {
+      "active": true
+    }
+  },
+  "upstream": {
+    "url": "https://petstore3.swagger.io/api/v3/"
+  },
+  "server": {
+    "listenPath": {
+      "value": "/custom_auth",
+      "strip": true
+    },
+    "authentication": {
+      "enabled": true,
+      "custom": {
+        "enabled": true,
+        "header": {
+          "enabled": false,
+          "name": "Authorization"
+        }
+      }
+    }
+  },
+  "middleware": {
+    "global": {
+      "pluginConfig": {
+        "driver": "grpc"
+      }
+    },
+    "cors": {
+      "enabled": false,
+      "maxAge": 24,
+      "allowedHeaders": [
+        "Accept",
+        "Content-Type",
+        "Origin",
+        "X-Requested-With",
+        "Authorization"
+      ],
+      "allowedOrigins": [
+        "*"
+      ],
+      "allowedMethods": [
+        "GET",
+        "HEAD",
+        "POST"
+      ]
+    },
+    "prePlugin": {
+      "plugins": [
+        {
+          "enabled": true,
+          "functionName": "MyPreRequestPlugin",
+          "path": ""
+        }
+      ]
+    },
+    "responsePlugin": {
+      "plugins": [
+        {
+          "enabled": true,
+          "functionName": "MyResponsePlugin",
+          "path": "",
+          "requireSession": true
+        }
+      ]
+    }
+  }
+}
+```
+
+In the above listing, the plugin driver parameter has been set to *grpc*. Two plugins are configured within the middleware section: a *Pre Request* plugin and a *Response* plugin.
+
+The *Response* plugin is configured with *requireSession* enabled, so that Tyk Gateway will send details for the authenticated key / user with the gRPC request. Note, this is not configurable for *Pre Request* plugins that are triggered before authentication in the request lifecycle.
+
+Tyk Gateway will forward details of an incoming request to the gRPC server, for each plugin.
+
+
+## Test API
+
+We have implemented and configured a gRPC server to integrate with Tyk Gateway. Furthermore, we have created an API that has been configured with two gRPC plugins: a *Pre Request* and *Response* plugin.
+
+When we issue a request to our API and observe the console output of our gRPC server we should see a JSON representation of the request headers etc. echoed in the terminal.
+
+Issue a request for your API in the terminal window. For example:
+
+```bash
+curl -L http://.localhost:8080/grpc-http-bin
+```
+
+Observe the console output of your gRPC server. Tyk Gateway should have dispatched two requests to your gRPC server; a request for the *Pre Request* plugin and a request for the *Response* plugin.  
+
+The gRPC server we implemented echoes a JSON representation of the request payload dispatched by Tyk Gateway.
+
+Note that this is a useful feature for learning how to develop gRPC plugins and understanding the structure of the request payload dispatched by Tyk Gateway to the gRPC server. However, in production environments care should be taken to avoid inadvertently exposing sensitive data such as secrets in the session. 
+
+
+## Summary
+
+In this guide, we've delved into the integration of a Python gRPC server with Tyk Gateway.
+
+We have explained how to implement a Python gRPC server and equipped developers with the necessary tools, knowledge and capabilities to effectively utilise Tyk Gateway through gRPC services.
+
+The following essential groundwork has been covered:
+
+- Setting up tools, libraries and service definitions for the integration.
+- Developing a basic gRPC server with functionality to echo the request payload, received from Tyk Gateway, in JSON format.
+- Configuring Tyk Gateway for seamless communication with our gRPC server.

--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/write-grpc-plugin.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/write-grpc-plugin.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-03-24T13:32:12Z
-title: Getting Started
+title: Key Concepts
 menu:
   main:
     parent: "gRPC"

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -2172,8 +2172,12 @@ menu:
                 path: /plugins/supported-languages/rich-plugins/grpc
                 category: Page
                 show: True
-              - title: "Getting started"
+              - title: "Key Concepts"
                 path: /plugins/supported-languages/rich-plugins/grpc/write-grpc-plugin
+                category: Page
+                show: True
+              - title: "Getting Started"
+                path: /plugins/supported-languages/rich-plugins/grpc/getting-started-python
                 category: Page
                 show: True
               - title: "Tutorials"
@@ -2190,6 +2194,10 @@ menu:
                   show: True
                 - title: "Create NodeJS Custom Authentication Plugin"
                   path: /plugins/supported-languages/rich-plugins/grpc/custom-auth-nodejs
+                  category: Page
+                  show: True
+                - title: "Create Python Custom Authentication Plugin"
+                  path: /plugins/supported-languages/rich-plugins/grpc/custom-auth-python
                   category: Page
                   show: True
               - title: "Performance"


### PR DESCRIPTION
### **User description**
[DX-1293] Add Python gRPC support guides (#4672)

Release gRPC tutorials

---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1293]: https://tyktech.atlassian.net/browse/DX-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
documentation


___

### **Description**
- Added a comprehensive guide on creating a custom authentication plugin with Python for Tyk Gateway, including setup, implementation, and testing.
- Introduced a getting started guide for creating a Python gRPC server, detailing environment setup, server implementation, and Tyk Gateway configuration.
- Renamed the "Getting Started" page to "Key Concepts" in the gRPC plugin documentation.
- Updated the documentation menu to include new Python gRPC guides and reflect title changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>custom-auth-python.md</strong><dd><code>Add guide for creating custom authentication plugin with Python.</code></dd></summary>
<hr>

tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/custom-auth-python.md
<li>Added a comprehensive guide on creating a custom authentication plugin <br>with Python for Tyk Gateway.<br> <li> Included detailed steps for setting up the environment, implementing <br>the plugin, and testing it.<br> <li> Provided code snippets and explanations for HMAC-signed <br>authentication.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4755/files#diff-d1eb6bb614f7a6fc0c7ba43c0c4ff2e081023319f6a9da6144a82b353cd1e0a8">+662/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>getting-started-python.md</strong><dd><code>Add getting started guide for Python gRPC server.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/getting-started-python.md
<li>Introduced a guide for getting started with creating a Python gRPC <br>server.<br> <li> Detailed the setup of the development environment and implementation <br>of the gRPC server.<br> <li> Included instructions for configuring Tyk Gateway to integrate with <br>the gRPC server.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4755/files#diff-e756b30e63353f4fe870bedc13d6ba334536bb09d5ee9e4aa16c0b5593398dce">+559/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>write-grpc-plugin.md</strong><dd><code>Rename title to Key Concepts.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/write-grpc-plugin.md
- Changed the title from "Getting Started" to "Key Concepts".



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4755/files#diff-efbf2d8054bc1cc8ce107b77a57ae5185f3f41accbc5b8a7a4545c599dde305d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Update menu for new Python gRPC documentation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/data/menu.yaml
<li>Updated the menu to reflect new and renamed documentation pages.<br> <li> Added entries for the new Python gRPC guides.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4755/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

