### PR TITLE
[TT-12279] Update documentation for master

### DIFF
--- a/tyk-docs/assets/others/mdcb-swagger.yml
+++ b/tyk-docs/assets/others/mdcb-swagger.yml
@@ -1,0 +1,183 @@
+openapi: 3.0.0
+info:
+  contact:
+    email: support@tyk.io
+    name: Tyk Technologies
+    url: https://tyk.io/contact
+  version: 1.0.0
+  title: MDCB Data Planes and Diagnostics API
+  description: >
+    This API provides operations for monitoring Data Planes connected to MDCB and accessing diagnostic data. 
+    It includes endpoints for retrieving connected data plane details, performing health checks, 
+    and accessing Go's built-in pprof diagnostics for advanced performance profiling.
+servers:
+  - url: https://{tenant}
+    variables:
+      tenant:
+        default: localhost:8181
+        description: Your MDCB host
+security:
+  - api_key: []
+paths:
+  /dataplanes:
+    get:
+      summary: Retrieve information of all the connected data plane nodes.
+      description: Provides a list of all the data plane nodes connected to MDCB. Data plane nodes are Tyk Gateways that make your APIs available to your consumers. MDCB offers centralised management of your data plane nodes. This endpoint offers metadata and status for all connected data plane nodes, allowing for monitoring and troubleshooting.
+      operationId: dataplanesGet
+      parameters:
+        - in: header
+          name: x-tyk-authorization
+          description: Secret value set in sink.conf
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful retrieval of the connected data planes.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/Node"
+        "403":
+          description: Forbidden access due to invalid or missing administrative key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /health:
+    get:
+      summary: Health Check
+      description: Returns OK if the service is up and running.
+      operationId: healthGet
+      responses:
+        "200":
+          description: Service is up and running.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "OK"
+  /debug/pprof/profile:
+    get:
+      summary: CPU Profiling data
+      description: Returns CPU profiling data. Available only when HTTPProfile is enabled in sink.conf.
+      operationId: debugPprofProfileGet
+      responses:
+        "200":
+          description: CPU profiling data.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+  /debug/pprof/{profileType}:
+    get:
+      summary: pprof data
+      description: >
+        Serves various pprof data like heap, goroutine, threadcreate, block, and so on. The `{profileType}` path parameter can accept various profiling types as well as more complex patterns. Available only when HTTPProfile is enabled in sink.conf.
+      operationId: debugPprofProfileTypeGet
+      parameters:
+        - in: path
+          name: profileType
+          required: true
+          description: The specific pprof data to retrieve (heap, goroutine, threadcreate, block, etc.), or a pattern matching multiple types.
+          schema:
+            type: string
+            example: heap
+      responses:
+        "200":
+          description: pprof data.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        node_id:
+          type: string
+          example: "solo-uid"
+        api_key:
+          type: string
+          example: "c5e9b9ed8dee42fb668f81cef7f905bb"
+        group_id:
+          type: string
+          example: "Redis Cluster Slave 1"
+        node_version:
+          type: string
+          example: "v5.3.0-dev"
+        ttl:
+          type: integer
+          example: 10
+        tags:
+          type: array
+          items:
+            type: string
+          example: ["tag1", "tag2"]
+        health:
+          $ref: "#/components/schemas/Health"
+        stats:
+          $ref: "#/components/schemas/Stats"
+        host_details:
+          $ref: "#/components/schemas/HostDetails"
+    Health:
+      type: object
+      properties:
+        redis:
+          $ref: "#/components/schemas/ComponentStatus"
+        rpc:
+          $ref: "#/components/schemas/ComponentStatus"
+    ComponentStatus:
+      type: object
+      properties:
+        status:
+          type: string
+          example: "pass"
+        componentType:
+          type: string
+          example: "datastore"
+        time:
+          type: string
+          format: date-time
+          example: "2024-02-23T08:51:23-03:00"
+    Stats:
+      type: object
+      properties:
+        apis_count:
+          type: integer
+          example: 1
+        policies_count:
+          type: integer
+          example: 0
+    HostDetails:
+      type: object
+      properties:
+        Hostname:
+          type: string
+          example: "Peter-MacBook-Pro.local"
+        PID:
+          type: integer
+          example: 62663
+        Address:
+          type: string
+          example: "203.0.113.0"
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+          example: "Attempted administrative access with invalid or missing key!"
+
+    
+  securitySchemes:
+    api_key:
+      in: header
+      name: X-Tyk-Authorization
+      type: apiKey

--- a/tyk-docs/content/shared/mdcb-config.md
+++ b/tyk-docs/content/shared/mdcb-config.md
@@ -9,6 +9,17 @@ ENV: <b>TYK_MDCB_HEALTHCHECKPORT</b><br />
 Type: `int`<br />
 
 This port lets MDCB allow standard health checks.<br>If this value is not set, the MDCB component will apply a default value of 8181.
+Deprecated: Use `http_port` instead.
+
+### http_port
+ENV: <b>TYK_MDCB_HTTPPORT</b><br />
+Type: `int`<br />
+
+The HTTP port exposes different endpoints for monitoring and debugging MDCB. The default value is 8181.
+Exposed endpoints include:
+* /health - Provides the health status of MDCB.
+* /dataplanes - Provides information about the dataplanes connected to MDCB (`security.enable_http_secure_endpoints` must be enabled).
+* /debug/pprof/* - Provides profiling information (`enable_http_profiler` must be enabled).
 
 ### enable_http_profiler
 ENV: <b>TYK_MDCB_HTTPPROFILE</b><br />
@@ -60,7 +71,7 @@ SSL certificates used by your MDCB server. A list of certificate IDs or path to 
 
 ### http_server_options
 HTTPServerOptions configures SSL/TLS for the HTTP server, affecting security settings.
-It applies to endpoints like /health for health checks
+It applies to endpoints like /health for health checks, /dataplanes for node information
 and /debug/pprof/ for performance profiling.
 
 ### http_server_options.use_ssl
@@ -109,7 +120,7 @@ Type: `string`<br />
 Allows MDCB to use Mutual TLS. This requires to set `server_options.use_ssl` to true. See [Mutual TLS]({{< ref "basic-config-and-security/security/mutual-tls" >}}) for more details.
 
 ### storage
-This section describes your centralised Redis DB. This will act as your master key store for all of your clusters.
+This section describes your centralised Redis DB. This will act as your main key store for all of your clusters.
 
 ### storage.type
 ENV: <b>TYK_MDCB_STORAGE_TYPE</b><br />
@@ -473,7 +484,7 @@ Set to true to disable the Mongo storages default index creation. More detailed 
 ENV: <b>TYK_MDCB_ENABLESEPERATEANALYTICSSTORE</b><br />
 Type: `bool`<br />
 
-Set it to true if you are using a separated analytic storage in the master gateway. If `forward_analytics_to_pump` is true, it will forward the analytics to the separated storage specified in `analytics_storage`.
+Set it to true if you are using a separated analytic storage in the Control Plane Gateway. If `forward_analytics_to_pump` is true, it will forward the analytics to the separated storage specified in `analytics_storage`.
 
 ### analytics_storage
 This section describes your separated analytic Redis DB. It has the same fields as `storage`. It requires `enable_separate_analytics_store` set to true.


### PR DESCRIPTION
### **User description**
Triggered by: sredxny

Included:

Tyk Gateway: false
Tyk Dashboard: false
Tyk MDCB true
Tyk Pump false

Intended for: master
Changes sourced from: master
Config info generator branch: main

Note: <none> (branch suffix: docs-test)

JIRA: https://tyktech.atlassian.net/browse/TT-12279


___

### **PR Type**
Documentation


___

### **Description**
- Added OpenAPI 3.0.0 specification for MDCB Data Planes and Diagnostics API, including endpoints for monitoring and diagnostics.
- Deprecated `health_check_port` in favor of `http_port` in MDCB configuration documentation.
- Documented new `http_port` and its exposed endpoints in MDCB configuration.
- Updated descriptions for `http_server_options` and `enable_separate_analytics_store` in MDCB configuration documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mdcb-swagger.yml</strong><dd><code>Add OpenAPI specification for MDCB Data Planes and Diagnostics API</code></dd></summary>
<hr>

tyk-docs/assets/others/mdcb-swagger.yml
<li>Added OpenAPI 3.0.0 specification for MDCB Data Planes and Diagnostics <br>API.<br> <li> Defined endpoints for retrieving connected data plane details, <br>performing health checks, and accessing Go's built-in pprof <br>diagnostics.<br> <li> Included schemas for Node, Health, ComponentStatus, Stats, <br>HostDetails, and Error.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4769/files#diff-9083957d803226360a4dd3329833ce9d5b7101978dce765b9e6603d79500143f">+183/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mdcb-config.md</strong><dd><code>Update MDCB configuration documentation with new endpoints and </code><br><code>deprecations</code></dd></summary>
<hr>

tyk-docs/content/shared/mdcb-config.md
<li>Deprecated <code>health_check_port</code> in favor of <code>http_port</code>.<br> <li> Added documentation for <code>http_port</code> and its exposed endpoints.<br> <li> Updated descriptions for <code>http_server_options</code> and <br><code>enable_separate_analytics_store</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4769/files#diff-4dc7d90d096907b83b780b481a0de5552fb107c44ec34d9e9f75099ae2ec77d4">+14/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

