### PR TITLE
Merging to release-5.3: [DX-1406] Redis PubSub (#4794)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/inputs/kafka-franz.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/inputs/kafka-franz.md
@@ -179,7 +179,7 @@ Whether messages that are rejected (nacked) at the output level should be automa
 Type: `bool`  
 Default: `true`  
 
-### `commit_period`
+### commit_period
 
 The period of time between each commit of the current partition offsets. Offsets are always committed during shutdown.
 

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/inputs/redis-pubsub.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/inputs/redis-pubsub.md
@@ -1,0 +1,273 @@
+---
+title: Redis PubSub
+description: Explains an overview of configuring Redis PubSub input
+tags: [ "Tyk Streams", "Stream Inputs", "Inputs", "Redis PubSub" ]
+---
+
+Consume from a Redis publish/subscribe channel using either the SUBSCRIBE or PSUBSCRIBE commands.
+
+## Common
+
+```yml
+# Common config fields, showing default values
+input:
+  label: ""
+  redis_pubsub:
+    url: redis://:6397 # No default (required)
+    channels: [] # No default (required)
+    use_patterns: false
+    auto_replay_nacks: true
+```
+
+## Advanced
+
+```yml
+# All config fields, showing default values
+input:
+  label: ""
+  redis_pubsub:
+    url: redis://:6397 # No default (required)
+    kind: simple
+    master: ""
+    tls:
+      enabled: false
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: ""
+      root_cas_file: ""
+      client_certs: []
+    channels: [] # No default (required)
+    use_patterns: false
+    auto_replay_nacks: true
+```
+
+In order to subscribe to channels using the `PSUBSCRIBE` command set the field `use_patterns` to `true`, then you can include glob-style patterns in your channel names. For example:
+
+- `h?llo` subscribes to hello, hallo and hxllo
+- `h*llo` subscribes to hllo and heeeello
+- `h[ae]llo` subscribes to hello and hallo, but not hillo
+
+Use `\` to escape special characters if you want to match them verbatim.
+
+## Fields
+
+### url
+
+The URL of the target Redis server. Database is optional and is supplied as the URL path.
+
+
+Type: `string`  
+
+```yml
+# Examples
+
+url: redis://:6397
+
+url: redis://localhost:6379
+
+url: redis://foousername:foopassword@redisplace:6379
+
+url: redis://:foopassword@redisplace:6379
+
+url: redis://localhost:6379/1
+
+url: redis://localhost:6379/1,redis://localhost:6380/1
+```
+
+### kind
+
+Specifies a simple, cluster-aware, or failover-aware redis client.
+
+
+Type: `string`  
+Default: `"simple"`  
+Options: `simple`, `cluster`, `failover`.
+
+### master
+
+Name of the redis master when `kind` is `failover`
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+master: mymaster
+```
+
+### tls
+
+Custom TLS settings can be used to override system defaults.
+
+**Troubleshooting**
+
+Some cloud hosted instances of Redis (such as Azure Cache) might need some hand holding in order to establish stable connections. Unfortunately, it is often the case that TLS issues will manifest as generic error messages such as "i/o timeout". If you're using TLS and are seeing connectivity problems consider setting `enable_renegotiation` to `true`, and ensuring that the server supports at least TLS version 1.2.
+
+
+Type: `object`  
+
+### tls.enabled
+
+Whether custom TLS settings are enabled.
+
+
+Type: `bool`  
+Default: `false`  
+
+### tls.skip_cert_verify
+
+Whether to skip server side certificate verification.
+
+
+Type: `bool`  
+Default: `false`  
+
+### tls.enable_renegotiation
+
+Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+
+
+Type: `bool`  
+Default: `false`  
+
+### tls.root_cas
+
+An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+{{< warning >}}
+**Note**
+
+This field contains sensitive information that usually shouldn't be added to a config directly
+{{< /warning >}}
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+### tls.root_cas_file
+
+An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+### tls.client_certs
+
+A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+
+
+Type: `array`  
+Default: `[]`  
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+### tls.client_certs[].cert
+
+A plain text certificate to use.
+
+
+Type: `string`  
+Default: `""`  
+
+### tls.client_certs[].key
+
+A plain text certificate key to use.
+
+{{< warning >}}
+**Note**
+
+This field contains sensitive information that usually shouldn't be added to a config directly.
+{{< /warning >}}
+
+Type: `string`  
+Default: `""`  
+
+### tls.client_certs[].cert_file
+
+The path of a certificate to use.
+
+
+Type: `string`  
+Default: `""`  
+
+### tls.client_certs[].key_file
+
+The path of a certificate key to use.
+
+
+Type: `string`  
+Default: `""`  
+
+### tls.client_certs[].password
+
+A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format. Warning: Since it does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+
+{{< warning >}}
+**Note**
+
+This field contains sensitive information that usually shouldn't be added to a config directly.
+{{< /warning >}}
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
+```
+
+### channels
+
+A list of channels to consume from.
+
+
+Type: `array`  
+
+### use_patterns
+
+Whether to use the PSUBSCRIBE command, allowing for glob-style patterns within target channel names.
+
+
+Type: `bool`  
+Default: `false`  
+
+### auto_replay_nacks
+
+Whether messages that are rejected (nacked) at the output level should be automatically replayed indefinitely, eventually resulting in back pressure if the cause of the rejections is persistent. If set to `false` these messages will instead be deleted. Disabling auto replays can greatly improve memory efficiency of high throughput streams as the original shape of the data can be discarded immediately upon consumption and mutation.
+
+
+Type: `bool`  
+Default: `true`  
+

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/redis-pubsub.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/redis-pubsub.md
@@ -1,0 +1,353 @@
+---
+title: Redis PubSub
+description: Explains an overview of configuring Redis PubSub output
+tags: [ "Tyk Streams", "Stream Outputs", "Outputs", "Redis PubSub" ]
+---
+
+Publishes messages through the Redis PubSub model. It is not possible to guarantee that messages have been received.
+
+
+## Common
+
+```yml
+# Common config fields, showing default values
+output:
+  label: ""
+  redis_pubsub:
+    url: redis://:6397 # No default (required)
+    channel: "" # No default (required)
+    max_in_flight: 64
+    batching:
+      count: 0
+      byte_size: 0
+      period: ""
+      check: ""
+```
+
+## Advanced
+
+```yml
+# All config fields, showing default values
+output:
+  label: ""
+  redis_pubsub:
+    url: redis://:6397 # No default (required)
+    kind: simple
+    master: ""
+    tls:
+      enabled: false
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: ""
+      root_cas_file: ""
+      client_certs: []
+    channel: "" # No default (required)
+    max_in_flight: 64
+    batching:
+      count: 0
+      byte_size: 0
+      period: ""
+      check: ""
+      processors: [] # No default (optional)
+```
+
+This output will interpolate functions within the channel field, you can find a list of functions [here]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/interpolation#bloblang-queries" >}}).
+
+## Performance
+
+This output benefits from sending multiple messages in flight in parallel for improved performance. You can tune the max number of in flight messages (or message batches) with the field `max_in_flight`.
+
+This output benefits from sending messages as a batch for improved performance. Batches can be formed at both the input and output level. <!-- TODO: add link to batching You can find out more [in this doc](/docs/configuration/batching) -->
+
+## Fields
+
+### url
+
+The URL of the target Redis server. Database is optional and is supplied as the URL path.
+
+
+Type: `string`  
+
+```yml
+# Examples
+
+url: redis://:6397
+
+url: redis://localhost:6379
+
+url: redis://foousername:foopassword@redisplace:6379
+
+url: redis://:foopassword@redisplace:6379
+
+url: redis://localhost:6379/1
+
+url: redis://localhost:6379/1,redis://localhost:6380/1
+```
+
+### kind
+
+Specifies a simple, cluster-aware, or failover-aware redis client.
+
+
+Type: `string`  
+Default: `"simple"`  
+Options: `simple`, `cluster`, `failover`.
+
+### master
+
+Name of the redis master when `kind` is `failover`
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+master: mymaster
+```
+
+### tls
+
+Custom TLS settings can be used to override system defaults.
+
+**Troubleshooting**
+
+Some cloud hosted instances of Redis (such as Azure Cache) might need some hand holding in order to establish stable connections. Unfortunately, it is often the case that TLS issues will manifest as generic error messages such as "i/o timeout". If you're using TLS and are seeing connectivity problems consider setting `enable_renegotiation` to `true`, and ensuring that the server supports at least TLS version 1.2.
+
+
+Type: `object`  
+
+### tls.enabled
+
+Whether custom TLS settings are enabled.
+
+
+Type: `bool`  
+Default: `false`  
+
+### tls.skip_cert_verify
+
+Whether to skip server side certificate verification.
+
+
+Type: `bool`  
+Default: `false`  
+
+### tls.enable_renegotiation
+
+Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+
+
+Type: `bool`  
+Default: `false`  
+
+### tls.root_cas
+
+An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+### tls.root_cas_file
+
+An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+### tls.client_certs
+
+A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+
+
+Type: `array`  
+Default: `[]`  
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+### tls.client_certs[].cert
+
+A plain text certificate to use.
+
+
+Type: `string`  
+Default: `""`  
+
+### tls.client_certs[].key
+
+A plain text certificate key to use.
+
+
+Type: `string`  
+Default: `""`  
+
+### tls.client_certs[].cert_file
+
+The path of a certificate to use.
+
+
+Type: `string`  
+Default: `""`  
+
+### tls.client_certs[].key_file
+
+The path of a certificate key to use.
+
+
+Type: `string`  
+Default: `""`  
+
+### tls.client_certs[].password
+
+A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format. Warning: Since it does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
+```
+
+### channel
+
+The channel to publish messages to.
+This field supports [interpolation functions]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/interpolation.mdinterpolation#bloblang-queries" >}}).
+
+
+Type: `string`  
+
+### max_in_flight
+
+The maximum number of messages to have in flight at a given time. Increase this to improve throughput.
+
+
+Type: `int`  
+Default: `64`  
+
+### batching
+
+Allows you to configure a batching policy. <!-- TODO: Add link to batching policy -->
+
+
+Type: `object`  
+
+```yml
+# Examples
+
+batching:
+  byte_size: 5000
+  count: 0
+  period: 1s
+
+batching:
+  count: 10
+  period: 1s
+
+batching:
+  check: this.contains("END BATCH")
+  count: 0
+  period: 1m
+```
+
+### batching.count
+
+A number of messages at which the batch should be flushed. If `0` disables count based batching.
+
+
+Type: `int`  
+Default: `0`  
+
+### batching.byte_size
+
+An amount of bytes at which the batch should be flushed. If `0` disables size based batching.
+
+
+Type: `int`  
+Default: `0`  
+
+### batching.period
+
+A period in which an incomplete batch should be flushed regardless of its size.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+period: 1s
+
+period: 1m
+
+period: 500ms
+```
+
+### batching.check
+
+A Bloblang query that should return a boolean value indicating whether a message should end a batch.
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+check: this.type == "end_of_transaction"
+```
+
+### batching.processors
+
+A list of processors to apply to a batch as it is flushed. This allows you to aggregate and archive the batch however you see fit. Please note that all resulting messages are flushed as a single batch, therefore splitting the batch into smaller batches using these processors is a no-op.
+
+
+Type: `array`  
+
+```yml
+# Examples
+
+processors:
+  - archive:
+      format: concatenate
+
+processors:
+  - archive:
+      format: lines
+
+processors:
+  - archive:
+      format: json_array
+```

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -3872,6 +3872,10 @@ menu:
             path: /product-stack/tyk-streaming/configuration/inputs/nats
             category: Page
             show: True
+          - title: "Redis PubSub"
+            path: /product-stack/tyk-streaming/configuration/inputs/redis-pubsub
+            category: Page
+            show: True
         - title: "Outputs"
           category: Directory
           show: True
@@ -3910,6 +3914,10 @@ menu:
             show: True
           - title: "MQTT"
             path: /product-stack/tyk-streaming/configuration/outputs/mqtt
+            category: Page
+            show: True
+          - title: "Redis PubSub"
+            path: /product-stack/tyk-streaming/configuration/outputs/redis-pubsub
             category: Page
             show: True
           - title: "Retry"


### PR DESCRIPTION
### **User description**
[DX-1406] Redis PubSub (#4794)

Add Redis PubSub

---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1406]: https://tyktech.atlassian.net/browse/DX-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Added new documentation for Redis PubSub input configuration, including common and advanced settings, field descriptions, and examples.
- Added new documentation for Redis PubSub output configuration, including common and advanced settings, field descriptions, and examples.
- Updated the menu to include Redis PubSub entries under both inputs and outputs.
- Made a minor formatting change in the Kafka Franz configuration documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kafka-franz.md</strong><dd><code>Formatting change in Kafka Franz configuration documentation</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/inputs/kafka-franz.md
- Removed backticks from the `commit_period` heading.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4807/files#diff-fc81b40fe8f64f8260637b026ef44bafdfcb2175e18f1d9d86fb41b3c6430b31">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redis-pubsub.md</strong><dd><code>Add Redis PubSub input configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/inputs/redis-pubsub.md
<li>Added new documentation for Redis PubSub input configuration.<br> <li> Included sections for common and advanced configurations.<br> <li> Detailed fields and examples for Redis PubSub input.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4807/files#diff-9b1bfa367bc0f3f74290ae21dea743ec242e78ddf9facb01707e7d1e96712094">+273/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis-pubsub.md</strong><dd><code>Add Redis PubSub output configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/redis-pubsub.md
<li>Added new documentation for Redis PubSub output configuration.<br> <li> Included sections for common and advanced configurations.<br> <li> Detailed fields and examples for Redis PubSub output.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4807/files#diff-8e83381560810874536889d0659c04e044a0f4ebfe464057b354e5350659c1d1">+353/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Update menu to include Redis PubSub documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/data/menu.yaml
<li>Added Redis PubSub entries to the menu for both inputs and outputs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4807/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

