### PR TITLE
Merging to release-5.3: [DX-1406] Refactor Interpolation (#4810)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/common-configuration/interpolation.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/common-configuration/interpolation.md
@@ -4,28 +4,9 @@ description: Explains an overview of Interpolation
 tags: [ "Tyk Streams", "Interpolation" ]
 ---
 
-Tyk Streams allows you to dynamically set config fields with environment variables anywhere within a config file using the syntax `${<variable-name>}` (or `${<variable-name>:<default-value>}` in order to specify a default value). This is useful for setting environment specific fields such as addresses:
-
-```yaml
-input:
-  kafka:
-    addresses: [ "${BROKERS}" ]
-    consumer_group: tyk_bridge_consumer
-    topics: [ "haha_business" ]
-```
-
-```sh
-BROKERS="foo:9092,bar:9092" tyk_streams -c ./config.yaml
-```
-
-If a literal string is required that matches this pattern (`${foo}`) you can escape it with double brackets. For example, the string `${{foo}}` is read as the literal `${foo}`.
-
-### Undefined Variables
-
-When an environment variable interpolation is found within a config, does not have a default value specified, and the environment variable is not defined a linting error will be reported. In order to avoid this it is possible to specify environment variable interpolations with an explicit empty default value by adding the colon without a following value, i.e. `${FOO:}` would be equivalent to `${FOO}` and would not trigger a linting error should `FOO` not be defined.
+Tyk Streams allows you to dynamically set config fields using Bloblang queries.
 
 ## Bloblang Queries
-
 
 ```yaml
 output:
@@ -36,7 +17,7 @@ output:
 
 A message with the contents `{"topic":"foo","message":"hello world"}` would be routed to the Kafka topic `meow-foo`.
 
-If a literal string is required that matches this pattern (`${!foo}`) then, similar to environment variables, you can escape it with double brackets. For example, the string `${{!foo}}` would be read as the literal `${!foo}`.
+If a literal string is required that matches this pattern (`${!foo}`) then you can escape it with double brackets. For example, the string `${{!foo}}` would be read as the literal `${!foo}`.
 
 <!-- //TODO:: For more in-depth details about the language [check out the docs][bloblang]. -->
 


### PR DESCRIPTION
### **User description**
[DX-1406] Refactor Interpolation (#4810)

* remove env vars section and CLI
---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1406]: https://tyktech.atlassian.net/browse/DX-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
documentation


___

### **Description**
- Refactored the interpolation documentation to replace environment variable interpolation with Bloblang queries.
- Updated examples to demonstrate the new Bloblang syntax.
- Clarified how to escape literal strings in Bloblang.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interpolation.md</strong><dd><code>Refactor Interpolation Documentation to Use Bloblang Queries</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/common-configuration/interpolation.md
<li>Removed section on environment variable interpolation.<br> <li> Introduced Bloblang queries for dynamic configuration.<br> <li> Updated examples to reflect new Bloblang syntax.<br> <li> Clarified escaping literal strings in Bloblang.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4811/files#diff-d2ce5866ac84e0520243824ebf7806eec8c2e084984f54354281db98d4a22078">+2/-21</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

