### PR TITLE
[DX-1388] Update docs for kv body transforms env vars

### DIFF
--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -137,7 +137,7 @@ When the Gateway starts, Tyk will read the *Value* from the environment variable
 {{< note success >}}
 **Note** 
 
-Prior to Tyk Gateway v5.3.0, <b>environment variables</b> to be used for Target URL or Listen Path had to be named `TYK_SECRET_{KEY_NAME}` and would then be referred to using `env://{KEY_NAME}`, i.e. the `TYK_SECRET_` part would not be included in the API definition.
+Prior to Tyk Gateway v5.3.0, **environment variables** to be used for Target URL or Listen Path had to be named `TYK_SECRET_{KEY_NAME}` and would then be referred to using `env://{KEY_NAME}`, i.e. the `TYK_SECRET_` part would not be included in the API definition.
 <br><br>
 From v5.3.0 onward, the environment variables can be given any `KEY_NAME` name and the full name should be provided in the API definition reference. The pre-5.3.0 naming method is still supported for backward compatibility, just for these two fields.
 {{< /note >}}

--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -137,7 +137,7 @@ When the Gateway starts, Tyk will read the *Value* from the environment variable
 {{< note success >}}
 **Note** 
 
-Prior to Tyk Gateway v5.3.0, **environment variables** to be used for Target URL or Listen Path had to be named `TYK_SECRET_{KEY_NAME}` and would then be referred to using `env://{KEY_NAME}`, i.e. the `TYK_SECRET_` part would not be included in the API definition.
+Prior to Tyk Gateway v5.3.0, **environment variables** used for the Target URL or Listen Path had to be named `TYK_SECRET_{KEY_NAME}`. They were referred to in the API definition using `env://{KEY_NAME}` excluding the `TYK_SECRET_` prefix.
 <br><br>
 From v5.3.0 onward, the environment variables can be given any `KEY_NAME` name and the full name should be provided in the API definition reference. The pre-5.3.0 naming method is still supported for backward compatibility, just for these two fields.
 {{< /note >}}

--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -182,6 +182,19 @@ When a call is made to `GET /anything`, Tyk will retrieve the *Value* assigned t
 
 These references are read (and replaced with the values read from the KV location) during the processing of the API request or response.
 
+{{< note success >}}
+**Note** 
+
+Environment variables to be used for transformation middleware should be named `TYK_SECRET_{KEY_NAME}` and should then be referenced using `$secret_env.{KEY_NAME}`, i.e. the `TYK_SECRET_` part should not be included.
+{{< /note >}}
+
+For example, if you create a gateway environment variable `TYK_SECRET_MYSECRETKEY=12345-6789`, in a request body transform middleware, you would reference as follows ...
+```json
+{
+  "api_key": "$secret_env.MYSECRETKEY"
+}
+```
+
 #### Other `string` fields
 
 To reference the *Value* assigned to a *Key* in one of the KV stores from the API Definition use the following notation:

--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -188,7 +188,7 @@ These references are read (and replaced with the values read from the KV locatio
 Environment variables to be used for transformation middleware should be named `TYK_SECRET_{KEY_NAME}` and should then be referenced using `$secret_env.{KEY_NAME}`, i.e. the `TYK_SECRET_` prefix should not be included.
 {{< /note >}}
 
-For example, if you create a gateway environment variable `TYK_SECRET_MYSECRETKEY=12345-6789`, in a request body transform middleware, you would reference as follows:
+For example, if you create a Gateway environment variable `TYK_SECRET_MYSECRETKEY=12345-6789`, in a request body transform middleware, you would reference as follows:
 
 ```json
 {

--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -203,7 +203,7 @@ For example, if you create a Gateway environment variable `TYK_SECRET_NEW_UPSTRE
 }
 ```
 
-whilst to configure the URL rewrite `rewriteTo` field using this variable you could use either:
+To configure the URL rewrite `rewriteTo` field using this variable you could use either:
 
 ````json
 {

--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -139,7 +139,8 @@ When the Gateway starts, Tyk will read the *Value* from the environment variable
 
 Prior to Tyk Gateway v5.3.0, **environment variables** used for the Target URL or Listen Path had to be named `TYK_SECRET_{KEY_NAME}`. They were referred to in the API definition using `env://{KEY_NAME}` excluding the `TYK_SECRET_` prefix.
 <br><br>
-From v5.3.0 onward, the environment variables can be given any `KEY_NAME` name and the full name should be provided in the API definition reference. The pre-5.3.0 naming method is still supported for backward compatibility, just for these two fields.
+From v5.3.0 onward, environment variables can have any `KEY_NAME`, and the full name should be provided in the API definition reference. The pre-v5.3.0 naming convention is still supported for backward compatibility, but only for these two fields.
+
 {{< /note >}}
 
 #### Transformation middleware

--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -185,7 +185,7 @@ These references are read (and replaced with the values read from the KV locatio
 {{< note success >}}
 **Note** 
 
-Environment variables to be used for transformation middleware should be named `TYK_SECRET_{KEY_NAME}` and should then be referenced using `$secret_env.{KEY_NAME}`, i.e. the `TYK_SECRET_` part should not be included.
+Environment variables to be used for transformation middleware should be named `TYK_SECRET_{KEY_NAME}` and should then be referenced using `$secret_env.{KEY_NAME}`, i.e. the `TYK_SECRET_` prefix should not be included.
 {{< /note >}}
 
 For example, if you create a gateway environment variable `TYK_SECRET_MYSECRETKEY=12345-6789`, in a request body transform middleware, you would reference as follows ...

--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -188,7 +188,7 @@ These references are read (and replaced with the values read from the KV locatio
 Environment variables to be used for transformation middleware should be named `TYK_SECRET_{KEY_NAME}` and should then be referenced using `$secret_env.{KEY_NAME}`, i.e. the `TYK_SECRET_` prefix should not be included.
 {{< /note >}}
 
-For example, if you create a Gateway environment variable `TYK_SECRET_MYSECRETKEY=12345-6789`, in a request body transform middleware, you would reference as follows:
+For example, if you create a Gateway environment variable `TYK_SECRET_MYSECRETKEY=12345-6789`, in a request body transform middleware, you would reference it as follows:
 
 ```json
 {

--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -188,7 +188,8 @@ These references are read (and replaced with the values read from the KV locatio
 Environment variables to be used for transformation middleware should be named `TYK_SECRET_{KEY_NAME}` and should then be referenced using `$secret_env.{KEY_NAME}`, i.e. the `TYK_SECRET_` prefix should not be included.
 {{< /note >}}
 
-For example, if you create a gateway environment variable `TYK_SECRET_MYSECRETKEY=12345-6789`, in a request body transform middleware, you would reference as follows ...
+For example, if you create a gateway environment variable `TYK_SECRET_MYSECRETKEY=12345-6789`, in a request body transform middleware, you would reference as follows:
+
 ```json
 {
   "api_key": "$secret_env.MYSECRETKEY"


### PR DESCRIPTION
### **User description**
### Preview Link
<!-- Add a direct preview link to make it easier for the reviewer to review. Best to add a few direct links to the pages in the PR -->

[preview](https://deploy-preview-4819--tyk-docs.netlify.app/docs/nightly/tyk-configuration-reference/kv-store)

### Description
Tyk supports external key value storage, which includes using env vars for middleware, including Body Transforms.  Right now it’s not clear in the docs what format the env var should take or how to reference in a Body Transform.  This PR provides clearer guidance, specifically the env var prefix required, and an example on how to use.
<br>


___

### **PR Type**
Documentation


___

### **Description**
- Clarified the use of environment variables with transformation middleware, specifying the formats supported by different transformation types.
- Added detailed examples demonstrating how to reference environment variables in request body transforms and URL rewrites.
- Improved formatting and wording for better readability and understanding.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kv-store.md</strong><dd><code>Clarify environment variable usage in transformation middleware</code></dd></summary>
<hr>

tyk-docs/content/tyk-configuration-reference/kv-store.md

<li>Clarified the use of environment variables with transformation <br>middleware.<br> <li> Added detailed examples for using environment variables in request <br>body transforms and URL rewrites.<br> <li> Updated formatting and wording for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4819/files#diff-8a6fc823903007c8abf92aa051b1748f306331c957d3dc2a94a28ef0e75a1838">+40/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

