### PR TITLE
Fixed small bug in demo docs (storage defaults)

### DIFF
--- a/tyk-docs/content/getting-started/quick-start/tyk-k8s-demo.md
+++ b/tyk-docs/content/getting-started/quick-start/tyk-k8s-demo.md
@@ -148,7 +148,7 @@ Flags:
 -f, --flavor          enum     k8s environment flavor. This option can be set 'openshift' and defaults to 'vanilla'
 -e, --expose          enum     set this option to 'port-forward' to expose the services as port-forwards or to 'load-balancer' to expose the services as load balancers or 'ingress' which exposes services as a k8s ingress object
 -r, --redis           enum     the redis mode that tyk stack will use. This option can be set 'redis', 'redis-sentinel' and defaults to 'redis-cluster'
--s, --storage         enum     database the tyk stack will use. This option can be set 'postgres' and defaults to 'mongo'
+-s, --storage         enum     database the tyk stack will use. This option can be set 'mongo' and defaults to 'postgres'
 -d, --deployments     string   comma separated list of deployments to launch
 -c, --cloud           enum     stand up k8s infrastructure in 'aws', 'gcp' or 'azure'. This will require Terraform and the CLIs associate with the cloud of choice
 -l, --ssl             bool     enable ssl on deployments


### PR DESCRIPTION
### **User description**
### Description
In https://tyk.io/docs/getting-started/quick-start/tyk-k8s-demo/ and up.sh script it is determined that the database implemented by default is mongo but the values.yaml (this one I am modifying) says postgres.

Command:
Usage:
./up.sh [flags] [command]

Available Commands:
tyk-stack
tyk-cp
tyk-dp
tyk-gateway

Flags:
-s, --storage enum database the tyk stack will use. This option can be set 'postgres' and defaults to 'mongo'
<br>

#### Screenshots (if appropriate)
<br>

## Checklist

- [ ] I have added a **preview link** to the PR description.
- [x ] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [ x] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [x ] Make sure you have started *your change* off *our latest `master`*.
- [x ] I **labelled** the PR


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Corrected the default database storage option in the Tyk Kubernetes demo documentation from 'mongo' to 'postgres'.
- Updated the `--storage` flag description to accurately reflect the default database setting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tyk-k8s-demo.md</strong><dd><code>Fix default database storage option in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/getting-started/quick-start/tyk-k8s-demo.md
<li>Corrected the default database storage option from 'mongo' to <br>'postgres'.<br> <li> Updated the description for the <code>--storage</code> flag to reflect the correct <br>default database.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4841/files#diff-0b29f3302cf63777bd100738cdc6a75795d277cc22853d883b3048761fc39fb4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

