### PR TITLE
Merging to release-5.3: Fixed small bug in demo docs (storage defaults) (#4841)

### DIFF
--- a/tyk-docs/content/getting-started/quick-start/tyk-k8s-demo.md
+++ b/tyk-docs/content/getting-started/quick-start/tyk-k8s-demo.md
@@ -148,7 +148,7 @@ Flags:
 -f, --flavor          enum     k8s environment flavor. This option can be set 'openshift' and defaults to 'vanilla'
 -e, --expose          enum     set this option to 'port-forward' to expose the services as port-forwards or to 'load-balancer' to expose the services as load balancers or 'ingress' which exposes services as a k8s ingress object
 -r, --redis           enum     the redis mode that tyk stack will use. This option can be set 'redis', 'redis-sentinel' and defaults to 'redis-cluster'
--s, --storage         enum     database the tyk stack will use. This option can be set 'postgres' and defaults to 'mongo'
+-s, --storage         enum     database the tyk stack will use. This option can be set 'mongo' and defaults to 'postgres'
 -d, --deployments     string   comma separated list of deployments to launch
 -c, --cloud           enum     stand up k8s infrastructure in 'aws', 'gcp' or 'azure'. This will require Terraform and the CLIs associate with the cloud of choice
 -l, --ssl             bool     enable ssl on deployments


### PR DESCRIPTION
### **User description**
Fixed small bug in demo docs (storage defaults) (#4841)

Fixed small bug in demo docs

Co-authored-by: Agustin Gimenez Bava <agustingimenezbava@Agustins-MBP.fibertel.com.ar>
Co-authored-by: Zaid Albirawi <zaid@tyk.io>


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Corrected the default value for the `--storage` flag in the Tyk K8s demo documentation from 'mongo' to 'postgres'.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tyk-k8s-demo.md</strong><dd><code>Fix default storage value in Tyk K8s demo documentation</code>&nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/getting-started/quick-start/tyk-k8s-demo.md
<li>Corrected the default value for the <code>--storage</code> flag from 'mongo' to <br>'postgres'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4846/files#diff-0b29f3302cf63777bd100738cdc6a75795d277cc22853d883b3048761fc39fb4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

