### PR TITLE
Merging to release-5.3: [DX-1407] Tyk Streams : Add JMES Path (#4869)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/jmes-path.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/jmes-path.md
@@ -1,0 +1,62 @@
+---
+title: JMESPath
+description: Explains an overview of JMESPath
+tags: [ "Tyk Streams", "Stream Processors", "Processors", "JMESPath" ]
+---
+
+Executes a [JMESPath query](http://jmespath.org/) on JSON documents and replaces the message with the resulting document.
+
+```yml
+# Config fields, showing default values
+label: ""
+jmespath:
+  query: "" # No default (required)
+```
+
+{{< note success >}}
+**Note**
+
+For better performance and improved capabilities try out native Tyk Streams mapping with the [mapping processor]({{< ref "/product-stack/tyk-streaming/configuration/processors/mapping" >}}).
+{{< /note >}}
+
+## Fields
+
+### query
+
+The JMESPath query to apply to messages.
+
+
+Type: `string`  
+
+## Examples
+
+### Mapping
+
+When receiving JSON documents of the form:
+
+```json
+{
+  "locations": [
+    {"name": "Seattle", "state": "WA"},
+    {"name": "New York", "state": "NY"},
+    {"name": "Bellevue", "state": "WA"},
+    {"name": "Olympia", "state": "WA"}
+  ]
+}
+```
+
+We could collapse the location names from the state of Washington into a field `Cities`:
+
+```json
+{"Cities": "Bellevue, Olympia, Seattle"}
+```
+
+We can achieve this using the following config:
+
+```yaml
+pipeline:
+  processors:
+    - jmespath:
+        query: "locations[?state == 'WA'].name | sort(@) | {Cities: join(', ', @)}"
+```
+

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -3976,6 +3976,10 @@ menu:
             path: /product-stack/tyk-streaming/configuration/processors/insert-part
             category: Page
             show: True
+          - title: "JMESPath"
+            path: /product-stack/tyk-streaming/configuration/processors/jmes-path
+            category: Page
+            show: True 
           - title: "Mapping"
             path: /product-stack/tyk-streaming/configuration/processors/mapping
             category: Page


### PR DESCRIPTION
### **User description**
[DX-1407] Tyk Streams : Add JMES Path (#4869)

* add JMES Path
---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1407]: https://tyktech.atlassian.net/browse/DX-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
documentation


___

### **Description**
- Added a new documentation page for JMESPath under Tyk Streams processors.
- Included detailed configuration fields and examples for using JMESPath queries.
- Updated the menu configuration to include the new JMESPath documentation page.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jmes-path.md</strong><dd><code>Add JMESPath Documentation Page with Examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/jmes-path.md
<li>Added a new documentation page for JMESPath.<br> <li> Included configuration fields and examples for JMESPath queries.<br> <li> Provided a note on performance and capabilities.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4870/files#diff-42456a3d739434b64bbaafb1723fab55b69fe42b90caf95b233870e705fe152b">+62/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Update Menu Configuration to Include JMESPath</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/data/menu.yaml
- Added JMESPath entry to the menu configuration.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4870/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

