### PR TITLE
Merging to release-5.3: [DX-1383] Right side nav won't expand while scrolling (#4878)

### DIFF
--- a/tyk-docs/static/js/docs-table-of-contents.js
+++ b/tyk-docs/static/js/docs-table-of-contents.js
@@ -186,23 +186,28 @@ function activeTocToggle() {
 
 
 function highlightAnchor() {
-    var contentTitles = $("h2, h3, h4, h5", "#main-content");
-    var currentSectionId;
-    var sectionPosition = 0;
+    const contentTitles = $("h2, h3, h4, h5");
 
     contentTitles.each(function () {
-        sectionPosition = $(this).offset().top;
-        currentSectionId = $(this).attr("id");
+        const sectionPosition = $(this).offset().top;
+        const currentSectionId = $(this).attr("id");
 
-        if (sectionPosition > 120 && sectionPosition < (120 + ($(this).outerHeight() * 2))) {
-            $('.toc__item,.sub_toc__item,.sub-sub-toc-item,.sub-sub-sub-toc-item').removeClass("js-active");
-            $('.toc__item[href*="#' + currentSectionId + '"],.sub_toc__item[href*="#' + currentSectionId + '"],.sub-sub-toc-item[href*="#' + currentSectionId + '"],.sub-sub-sub-toc-item[href*="#' + currentSectionId + '"]').addClass("js-active");
+        if (sectionPosition > 120 && sectionPosition < 120 + $(this).outerHeight() * 2) {
+            $(".toc__item, .sub_toc__item, .sub-sub-toc-item, .sub-sub-sub-toc-item").removeClass("js-active accordion-up");
+            $(`.toc__item[href*="#${currentSectionId}"], .sub_toc__item[href*="#${currentSectionId}"], .sub-sub-toc-item[href*="#${currentSectionId}"], .sub-sub-sub-toc-item[href*="#${currentSectionId}"]`).addClass("js-active accordion-up");
 
-            return;
+            $('.accordion-up').each(function() {
+                $(this).siblings('.accordion-content').show();
+                $(this).siblings('.sub-accordion-content').show();
+            });
+          
+            return false; 
         }
+        $('.sub_toc__item.accordion-up').click(function() {
+            $(this).siblings('.sub-accordion-content').hide();
+        });
     });
 }
-
 
 /**
  * Functionality to make TOC sidebar sticky


### PR DESCRIPTION
### **User description**
[DX-1383] Right side nav won't expand while scrolling (#4878)

* Updated _side-menu.scss

Fixed weird sidebar navigation jumping on element hover.

* [DX-1383] Right side nav won't expand while scrolling

Updated docs-table-of-contents.js file.

Now on the mouse scroll right side navigation sidebar will expand when it meet the element section position.

---------

Co-authored-by: itachi sasuke <8012032+Keithwachira@users.noreply.github.com>

[DX-1383]: https://tyktech.atlassian.net/browse/DX-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1383]: https://tyktech.atlassian.net/browse/DX-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Refactored variable declarations to use `const` instead of `var` for better scoping.
- Enhanced the right side navigation to expand on scroll when the section position is met.
- Improved the handling of accordion content visibility by adding and removing classes dynamically.
- Removed redundant code and improved overall readability and maintainability of the script.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs-table-of-contents.js</strong><dd><code>Enhance right side navigation and improve code readability</code></dd></summary>
<hr>

tyk-docs/static/js/docs-table-of-contents.js
<li>Refactored variable declarations to use <code>const</code> instead of <code>var</code>.<br> <li> Added logic to expand right side navigation on scroll.<br> <li> Improved handling of accordion content visibility.<br> <li> Removed redundant code and improved readability.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4885/files#diff-40b5987da19f3922c5bb623c69fab23fe13bf09c588f5a95852e49542a62440e">+15/-10</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

