### PR TITLE
Revert "recognise ==> recognize", pushed to master by mistake

### DIFF
--- a/scripts/uk_us_conversion/uk_us_mapping.csv
+++ b/scripts/uk_us_conversion/uk_us_mapping.csv
@@ -1,3 +1,3 @@
-Recognise,Recognize
-recognise,recognize
-UK, US
+Monetise,Monetize
+monetise,monetize
+

--- a/scripts/uk_us_conversion/uk_us_mapping.csv.full-list
+++ b/scripts/uk_us_conversion/uk_us_mapping.csv.full-list
@@ -13,9 +13,9 @@ Optimise,Optimize
 Organisation,Organization
 Practise,Practice
 Programme,Program
-+ Prioritisation,Prioritization
-+ Realise,Realize
-+ Recognise,Recognize
+Prioritisation,Prioritization
+Realise,Realize
+Recognise,Recognize
 Utilise,Utilize
 Utilisation, Utilization
 Analyse,Analyze

--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/custom-auth-python.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/custom-auth-python.md
@@ -3,42 +3,27 @@ date: 2024-05-12T17:00:00Z
 title: "Create Custom Authentication Plugin With Python"
 ---
 
-In the realm of API security, HMAC-signed authentication serves as a foundational concept. In this developer-focused
-blog post, we'll use HMAC-signed authentication as the basis for learning how to write gRPC custom authentication
-plugins with Tyk Gateway. Why learn how to write Custom Authentication Plugins?
+In the realm of API security, HMAC-signed authentication serves as a foundational concept. In this developer-focused blog post, we'll use HMAC-signed authentication as the basis for learning how to write gRPC custom authentication plugins with Tyk Gateway. Why learn how to write Custom Authentication Plugins?
 
-- **Foundational knowledge**: Writing custom authentication plugins provides foundational knowledge of Tyk's
-extensibility and customisation capabilities.
-- **Practical experience**: Gain hands-on experience in implementing custom authentication logic tailored to specific
-use cases, starting with HMAC-signed authentication.
-- **Enhanced control**: Exercise greater control over authentication flows and response handling, empowering developers
-to implement advanced authentication mechanisms beyond built-in features.
+- **Foundational knowledge**: Writing custom authentication plugins provides foundational knowledge of Tyk's extensibility and customisation capabilities.
+- **Practical experience**: Gain hands-on experience in implementing custom authentication logic tailored to specific use cases, starting with HMAC-signed authentication.
+- **Enhanced control**: Exercise greater control over authentication flows and response handling, empowering developers to implement advanced authentication mechanisms beyond built-in features.
 
-While Tyk Gateway offers built-in support for HMAC-signed authentication, this tutorial serves as a practical guide for
-developers looking to extend Tyk's capabilities through custom authentication plugins. It extends the gRPC server that
-we developed in our [getting started guide]({{< ref "getting-started-python" >}}).
+While Tyk Gateway offers built-in support for HMAC-signed authentication, this tutorial serves as a practical guide for developers looking to extend Tyk's capabilities through custom authentication plugins. It extends the gRPC server that we developed in our [getting started guide]({{< ref "getting-started-python" >}}).
 
-We will develop a basic gRPC server that implements the Tyk Dispatcher service with a custom authentication plugin to
-handle authentication keys, signed using the HMAC SHA512 algorithm. Subsequently, you will be able to make a request to
-your API with a HMAC signed authentication key in the *Authorization* header. Tyk Gateway will intercept the request and
-forward it to your Python gRPC server for HMAC signature and token verification.
+We will develop a basic gRPC server that implements the Tyk Dispatcher service with a custom authentication plugin to handle authentication keys, signed using the HMAC SHA512 algorithm. Subsequently, you will be able to make a request to your API with a HMAC signed authentication key in the *Authorization* header. Tyk Gateway will intercept the request and forward it to your Python gRPC server for HMAC signature and token verification.
 
-Our plugin will only verify the key against an expected value. In a production environment it will be necessary to verify
-the key against Redis storage.
+Our plugin will only verify the key against an expected value. In a production environment it will be necessary to verify the key against Redis storage.
 
 Before we continue ensure that you have:
 
-- Read and completed our getting started guide that explains how to implement a basic Python gRPC server to echo the
-request payload received from Tyk Gateway. This tutorial extends the source code of the tyk_async_server.py file to
-implement a custom authentication plugin for a HMAC signed authentication key.
-- Read our HMAC signatures documentation for an explanation of HMAC signed authentication  with Tyk Gateway. A brief
-summary is given in the HMAC Signed Authentication section below.
+- Read and completed our getting started guide that explains how to implement a basic Python gRPC server to echo the request payload received from Tyk Gateway. This tutorial extends the source code of the tyk_async_server.py file to implement a custom authentication plugin for a HMAC signed authentication key.
+- Read our HMAC signatures documentation for an explanation of HMAC signed authentication  with Tyk Gateway. A brief summary is given in the HMAC Signed Authentication section below. 
 
 
 ## HMAC Signed Authentication
 
-Before diving in further, we will give a brief overview of HMAC signed authentication using our custom authentication
-plugin.
+Before diving in further, we will give a brief overview of HMAC signed authentication using our custom authentication plugin.
 
 - **Client request**: The journey begins with a client requesting access to a protected resource on the Tyk API.
 - **HMAC signing**: Before dispatching the request, the client computes an HMAC signature using a secret key and request date, ensuring the payload's integrity.
@@ -61,8 +46,7 @@ From the above example, it should be noted that:
 
     - **keyId** is a Tyk authentication key.
     - **algorithm** is the HMAC algorithm used to sign the signature, *hmac-sha512* or *hmac-sha256*. 
-    - **signature** is the HAMC signature calculated with the date string from the *Date* header, signed with a base64
-    encoded secret value, using the specified HMAC algorithm. The HMAC signature is then encoded as base64.
+    - **signature** is the HAMC signature calculated with the date string from the *Date* header, signed with a base64 encoded secret value, using the specified HMAC algorithm. The HMAC signature is then encoded as base64.
 
 ## Prerequisites
 
@@ -71,8 +55,7 @@ Firstly, we need to create the following:
 - An API configured to use a custom authentication plugin.
 - A HMAC enabled key with a configured secret for signing.
 
-This will enable us to issue a request to test that Tyk Gateway integrates with our custom authentication plugin on the
-gRPC server.
+This will enable us to issue a request to test that Tyk Gateway integrates with our custom authentication plugin on the gRPC server.
 
 #### Create API
 
@@ -80,14 +63,11 @@ We will create an API served by Tyk Gateway, that will forward requests upstream
 
 The API will have the following parameters configured:
 
-- **Listen path**: Tyk Gateway will listen to API requests on */grpc-custom-auth/* and will strip the listen path for
-upstream requests.
+- **Listen path**: Tyk Gateway will listen to API requests on */grpc-custom-auth/* and will strip the listen path for upstream requests.
 - **Target URL**: The target URL will be configured to send requests to *http://httpbin/*.
-- **Authentication Mode**: The authentication mode will be configured for custom authentication. This is used to trigger
-CoProcess (gRPC), Python or JSVM plugins to handle custom authentication.
+- **Authentication Mode**: The authentication mode will be configured for custom authentication. This is used to trigger CoProcess (gRPC), Python or JSVM plugins to handle custom authentication.
 
-You can use the following Tyk Classic API definition to get you started, replacing the *org_id* with the ID of your
-organisation.
+You can use the following Tyk Classic API definition to get you started, replacing the *org_id* with the ID of your organisation.
 
 ```json
 {
@@ -128,9 +108,7 @@ organisation.
 }
 ```
 
-The Tyk API definition above can be imported via Tyk Dashboard. Alternatively, if using Tyk Gateway OSS, a POST request
-can be made to the *api/apis* endpoint of Tyk Gateway. Consult the
-[Tyk Gateway Open API Specification documentation]({{< ref "tyk-gateway-api" >}}) for usage.
+The Tyk API definition above can be imported via Tyk Dashboard. Alternatively, if using Tyk Gateway OSS, a POST request can be made to the *api/apis* endpoint of Tyk Gateway. Consult the [Tyk Gateway Open API Specification documentation]({{< ref "tyk-gateway-api" >}}) for usage.
 
 An illustrative example using *curl* is given below. Please note that you will need to:
 
@@ -193,8 +171,7 @@ A response similar to that given below will be returned by Tyk Gateway:
 
 #### Create HMAC Key
 
-We will create an key configured to use HMAC signing, with a secret of *secret*. The key will configured to have access
-to our test API.
+We will create an key configured to use HMAC signing, with a secret of *secret*. The key will configured to have access to our test API.
 
 You can use the following configuration below, replacing the value of the *org_id* with the ID of your organisation.
 
@@ -229,8 +206,7 @@ You can use the following configuration below, replacing the value of the *org_i
 }
 ```
 
-You can use Tyk Gateway’s API to create the key by issuing a POST request to the *tyk/keys* endpoint. Consult the
-[Tyk Gateway Open API Specification documentation]({{< ref "tyk-gateway-api" >}}) for usage.
+You can use Tyk Gateway’s API to create the key by issuing a POST request to the *tyk/keys* endpoint. Consult the [Tyk Gateway Open API Specification documentation]({{< ref "tyk-gateway-api" >}}) for usage.
 
 An illustrative example using *curl* is given below. Please note that you will need to:
 
@@ -300,17 +276,11 @@ Our custom authentication plugin will perform the following tasks:
 - Extract the *Authorization* and *Date* headers from the request object.
 - Parse the *Authorization* header to extract the *keyId*, *algorithm* and *signature* attributes.
 - Compute the HMAC signature using the specific algorithm and date included in the header.
-- Verify that the computed HMAC signature matches the signature included in the *Authorization* header. A 401 error
-response will be returned if verification fails. Our plugin will only verify the key against an expected value. In a
-production environment it will be necessary to verify the key against Redis storage.
-- Verify that the *keyId* matches an expected value (VALID_TOKEN). A 401 error response will be returned to Tyk Gateway
-if verification fails.
-- If verification of the signature and key passes then update the session with HMAC enabled and set the HMAC secret.
-Furthermore, add the key to the *Object* metadata.
+- Verify that the computed HMAC signature matches the signature included in the *Authorization* header. A 401 error response will be returned if verification fails. Our plugin will only verify the key against an expected value. In a production environment it will be necessary to verify the key against Redis storage.
+- Verify that the *keyId* matches an expected value (VALID_TOKEN). A 401 error response will be returned to Tyk Gateway if verification fails.
+- If verification of the signature and key passes then update the session with HMAC enabled and set the HMAC secret. Furthermore, add the key to the *Object* metadata.
 
-Return the request *Object* containing the updated session back to Tyk Gateway. When developing custom authentication
-plugins it is the responsibility of the developer to update the session state with the token, in addition to setting the
-appropriate response status code and error message when authentication fails.
+Return the request *Object* containing the updated session back to Tyk Gateway. When developing custom authentication plugins it is the responsibility of the developer to update the session state with the token, in addition to setting the appropriate response status code and error message when authentication fails.
 
 ### Import Python Modules
 
@@ -348,14 +318,11 @@ VALID_TOKEN = "eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6ImdycGNfaG1hY
 - **SECRET** is a base64 representation of the secret used for HMAC signing.
 - **VALID_TOKEN** is the key ID that we will authenticate against.
 
-The values listed above are designed to align with the examples provided in the *Prerequisites* section, particularly
-those related to HMAC key generation. If you've made adjustments to the HMAC secret or you've modified the key alias
-referred to in the endpoint path (for instance, *grpc_hmac_key*), you'll need to update these constants accordingly.
+The values listed above are designed to align with the examples provided in the *Prerequisites* section, particularly those related to HMAC key generation. If you've made adjustments to the HMAC secret or you've modified the key alias referred to in the endpoint path (for instance, *grpc_hmac_key*), you'll need to update these constants accordingly.
 
 ### Extract headers
 
-Add the following function to your *tyk_async_server.py* file to extract a dictionary of the key value pairs from the
-*Authorization* header. We will use a regular expression to extract the key value pairs.
+Add the following function to your *tyk_async_server.py* file to extract a dictionary of the key value pairs from the *Authorization* header. We will use a regular expression to extract the key value pairs.
 
 ```python
 def parse_auth_header(auth_header: str) -> dict[str,str]:
@@ -392,15 +359,11 @@ def generate_hmac_signature(algorithm: str, date_string: str, secret_key: str) -
 
 Our function accepts three parameters:
 
-- **algorithm** is the HMAC algorithm to use for signing. We will use HMAC SHA256 or HMAC SHA512 in our custom
-authentication plugin
+- **algorithm** is the HMAC algorithm to use for signing. We will use HMAC SHA256 or HMAC SHA512 in our custom authentication plugin
 - **date_string** is the date extracted from the date header in the request sent by Tyk Gateway.
 - **secret_key** is the value of the secret used for signing.
 
-The function computes and returns the HMAC signature for a string formatted as *date: date_string*, where *date_string*
-corresponds to the value of the *date_string* parameter. The signature is computed using the secret value given in the
-*secret_key* parameter and the HMAC algorithm given in the *algorithm* parameter. A *ValueError* is raised if the hash
-algorithm is unrecognized.
+The function computes and returns the HMAC signature for a string formatted as *date: date_string*, where *date_string* corresponds to the value of the *date_string* parameter. The signature is computed using the secret value given in the *secret_key* parameter and the HMAC algorithm given in the *algorithm* parameter. A *ValueError* is raised if the hash algorithm is unrecognised. 
 
 We use the following Python modules in our implementation:
 
@@ -428,19 +391,16 @@ def verify_hmac_signature(algorithm: str, signature: str, source_string) -> bool
 
 Our function accepts three parameters:
 
-- **algorithm** is the HMAC algorithm to use for signing. We will use hmac-sha256 or hmac-sha512 in our custom
-authentication plugin.
+- **algorithm** is the HMAC algorithm to use for signing. We will use hmac-sha256 or hmac-sha512 in our custom authentication plugin.
 - **signature** is the signature string extracted from the *Authorization* header.
 - **source_string** is the date extracted from the date header in the request sent by Tyk Gateway.
 - **secret_key** is the value of the secret used for signing.
 
-The function calls *generate_hmac_signature* to verify the signatures match. It returns true if the computed and client
-HMAC signatures match, otherwise false is returned.
+The function calls *generate_hmac_signature* to verify the signatures match. It returns true if the computed and client HMAC signatures match, otherwise false is returned.
 
 ### Set Error Response
 
-Add the following helper function to *tyk_async_server.py* to allow us to set the response status and error message if
-authentication fails.
+Add the following helper function to *tyk_async_server.py* to allow us to set the response status and error message if authentication fails.
 
 ```python
 def set_response_error(object: coprocess_object_pb2.Object, code: int, message: str) -> None:
@@ -454,13 +414,11 @@ Our function accepts the following three parameters:
 - **code** is the HTTP status code to return in the response.
 - **message** is the response message.
 
-The function modifies the *return_overrides* attribute of the request, updating the response status code and error
-message. The *return_overrides* attribute is an instance of a [ReturnOverrides]({{< ref "plugins/supported-languages/rich-plugins/rich-plugins-data-structures#returnoverrides" >}}) message that can be used to override the response of a given HTTP request. When this attribute is modified the request is terminated and is not sent upstream.
+The function modifies the *return_overrides* attribute of the request, updating the response status code and error message. The *return_overrides* attribute is an instance of a [ReturnOverrides]({{< ref "plugins/supported-languages/rich-plugins/rich-plugins-data-structures#returnoverrides" >}}) message that can be used to override the response of a given HTTP request. When this attribute is modified the request is terminated and is not sent upstream.
 
 ### Authenticate
 
-Add the following to your *tyk_async_server.py* file to implement the main custom authentication function. This parses
-the headers to extract the signature and date from the request, in addition to verifying the HMAC signature and key:
+Add the following to your *tyk_async_server.py* file to implement the main custom authentication function. This parses the headers to extract the signature and date from the request, in addition to verifying the HMAC signature and key:
 
 ```python
 def authenticate(object: coprocess_object_pb2.Object) -> coprocess_object_pb2.Object:
@@ -506,7 +464,7 @@ The *Object* payload received from the Gateway is updated and returned as a resp
 Specifically, our function performs the following tasks:
 
 - Extracts the *Date* and *Authorization* headers from the request and verifies that the *Authorization* header is structured correctly, using our *parse_auth_header* function. We store the extracted *Authorization* header fields in the *parse_dict* dictionary. If the structure is invalid then a 400 bad request response is returned to Tyk Gateway, using our *set_response_error* function.
-- We use our *verify_hmac_signature* function to compute and verify the HMAC signature. A 400 bad request error is returned to the Gateway if HMAC signature verification fails, due to an unrecognized HMAC algorithm.
+- We use our *verify_hmac_signature* function to compute and verify the HMAC signature. A 400 bad request error is returned to the Gateway if HMAC signature verification fails, due to an unrecognised HMAC algorithm.
 - A 401 unauthorised error response is returned to the Gateway under the following conditions:
 
     - The client HMAC signature and the computed HMAC signature do not match.

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.2.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.2.md
@@ -254,7 +254,7 @@ Added a new Dashboard configuration option `allow_unsafe_oas`. This permits the 
 <details>
 <summary>Fixed security policy grant permissions issue encountered with MongoDB</summary>
 
-Fixed an issue when using MongoDB and [Tyk Security Policies]({{< ref "getting-started/key-concepts/what-is-a-security-policy" >}}) where Tyk could incorrectly grant access to an API after that API had been deleted from the associated policy. This was due to the policy cleaning operation that is triggered when an API is deleted from a policy in a MongoDB installation. With this fix, the policy cleaning operation will not remove the final (deleted) API from the policy; Tyk recognizes that the API record is invalid and denies granting access rights to the key.
+Fixed an issue when using MongoDB and [Tyk Security Policies]({{< ref "getting-started/key-concepts/what-is-a-security-policy" >}}) where Tyk could incorrectly grant access to an API after that API had been deleted from the associated policy. This was due to the policy cleaning operation that is triggered when an API is deleted from a policy in a MongoDB installation. With this fix, the policy cleaning operation will not remove the final (deleted) API from the policy; Tyk recognises that the API record is invalid and denies granting access rights to the key.
 </details>
 </li>
 <li>

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-classic.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-classic.md
@@ -62,7 +62,7 @@ For example:
 
 In this example the allow list middleware has been configured for HTTP `GET` and `PUT` requests to the `/status/200` endpoint. Requests to any other endpoints will be rejected with `HTTP 403 Forbidden`, unless they also have the allow list middleware enabled.
 Note that the allow list has been configured to be case sensitive, so calls to `GET /Status/200` will also be rejected.
-Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /status/200/foobar` will be allowed as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware#endpoint-parsing" >}}) will recognize this as `GET /status/200`.
+Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /status/200/foobar` will be allowed as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware#endpoint-parsing" >}}) will recognise this as `GET /status/200`.
 
 ## Configuring the Allow List in the API Designer
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-oas.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-oas.md
@@ -88,7 +88,7 @@ For example:
 
 In this example the allow list middleware has been configured for requests to the `GET /anything` and `PUT /anything` endpoints. Requests to any other endpoints will be rejected with `HTTP 403 Forbidden`, unless they also have the allow list middleware enabled.
 Note that the allow list has been configured to be case insensitive, so calls to `GET /Anything` will be allowed
-Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /anything/foobar` will be allowed as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware#endpoint-parsing" >}}) will recognize this as `GET /anything`.
+Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /anything/foobar` will be allowed as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware#endpoint-parsing" >}}) will recognise this as `GET /anything`.
 
 The configuration above is a complete and valid Tyk OAS API Definition that you can import into Tyk to try out the allow list feature.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-classic.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-classic.md
@@ -62,7 +62,7 @@ For example:
 
 In this example the block list middleware has been configured for HTTP `GET` and `PUT` requests to the `/status/200` endpoint. Requests to these endpoints will be rejected with `HTTP 403 Forbidden`.
 Note that the block list has been configured to be case sensitive, so calls to `GET /Status/200` will not be rejected.
-Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /status/200/foobar` will be rejected as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware#endpoint-parsing" >}}) will recognize this as `GET /status/200`.
+Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /status/200/foobar` will be rejected as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware#endpoint-parsing" >}}) will recognise this as `GET /status/200`.
 
 ## Configuring the Block List in the API Designer
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-oas.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-oas.md
@@ -88,7 +88,7 @@ For example:
 
 In this example the block list middleware has been configured for requests to the `GET /anything` and `PUT /anything` endpoints. Requests to these endpoints will be rejected with `HTTP 403 Forbidden`.
 Note that the block list has been configured to be case insensitive, so calls to `GET /Anything` will also be blocked.
-Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /anything/foobar` will be rejected as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware#endpoint-parsing" >}}) will recognize this as `GET /anything`.
+Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /anything/foobar` will be rejected as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware#endpoint-parsing" >}}) will recognise this as `GET /anything`.
 
 The configuration above is a complete and valid Tyk OAS API Definition that you can import into Tyk to try out the block list feature.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
@@ -278,7 +278,7 @@ Fixed an issue where [enforced timeouts]({{< ref "planning-for-production/ensure
 <details>
 <summary>Incorrect access privileges were granted in security policies</summary>
 
-Fixed an issue when using MongoDB and [Tyk Security Policies]({{< ref "getting-started/key-concepts/what-is-a-security-policy" >}}) where Tyk could incorrectly grant access to an API after that API had been deleted from the associated policy. This was due to the policy cleaning operation that is triggered when an API is deleted from a policy in a MongoDB installation. With this fix, the policy cleaning operation will not remove the final (deleted) API from the policy; Tyk recognizes that the API record is invalid and denies granting access rights to the key.
+Fixed an issue when using MongoDB and [Tyk Security Policies]({{< ref "getting-started/key-concepts/what-is-a-security-policy" >}}) where Tyk could incorrectly grant access to an API after that API had been deleted from the associated policy. This was due to the policy cleaning operation that is triggered when an API is deleted from a policy in a MongoDB installation. With this fix, the policy cleaning operation will not remove the final (deleted) API from the policy; Tyk recognises that the API record is invalid and denies granting access rights to the key.
 </details>
 </li>
 <li>


### PR DESCRIPTION
### **User description**
This reverts commit 71811e0408e7f6ea9253d18b054693c920e0fab3.

### For internal users - Please add a Jira DX PR ticket to the subject!
<br>

---

### Preview Link
<!-- Add a direct preview link to make it easier for the reviewer to review. Best to add a few direct links to the pages in the PR -->
<br>

### Description
<!-- 1. Describe your changes in detail. Why is this change required? What problem does it solve?
     2. Please explain the change to the reviewer. Pay special attention to changes that are hard to spot, 
       for example:
       2.1. Name change in the file name or directory name - please flag it out since it’s hard 
            to compare text after such a change 
       2.2. Terminology change - flag it out to make sure the reviewer is aware before approving
     3. @mentions of the person to review the proposed changes. They need to be able to know the topic well in order to approve it.
-->
<br>

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have added a **preview link** to the PR description.
- [ ] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [ ] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [ ] Make sure you have started *your change* off *our latest `master`*.
- [ ] I **labelled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->


___

### **PR Type**
documentation


___

### **Description**
- Reverted changes to UK to US spelling mappings in `uk_us_mapping.csv.full-list`.
- Reverted formatting changes in the custom authentication plugin guide for Python.
- Reverted spelling changes from "recognizes" to "recognises" in multiple documentation files, including release notes and middleware documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uk_us_mapping.csv.full-list</strong><dd><code>Revert UK to US spelling mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/uk_us_conversion/uk_us_mapping.csv.full-list
<li>Reverted changes to UK to US spelling mappings.<br> <li> Removed lines for "Prioritisation", "Realise", and "Recognise".<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4898/files#diff-e3640788fd8bd7a8a8b4748bdbd46a42296b5a4d08eace27fa4742d0ddb52df1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>custom-auth-python.md</strong><dd><code>Revert formatting changes in custom auth plugin guide</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/custom-auth-python.md
<li>Reverted changes to line formatting.<br> <li> Reverted changes to paragraph formatting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4898/files#diff-d1eb6bb614f7a6fc0c7ba43c0c4ff2e081023319f6a9da6144a82b353cd1e0a8">+33/-75</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version-5.2.md</strong><dd><code>Revert spelling change in dashboard release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.2.md
- Reverted spelling change from "recognizes" to "recognises".



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4898/files#diff-c38cb3b1fa171a37b1cbef7bd921234fa47827692ee3171aa3a243e54cd7afba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>allow-list-tyk-classic.md</strong><dd><code>Revert spelling change in allow list middleware documentation</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-classic.md
- Reverted spelling change from "recognize" to "recognise".



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4898/files#diff-cecc51e27b2ad48c72c18e637d5f8f3a791b2a9e031dcff2a60506683efbefa5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>allow-list-tyk-oas.md</strong><dd><code>Revert spelling change in allow list OAS documentation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-oas.md
- Reverted spelling change from "recognize" to "recognise".



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4898/files#diff-e093b781849fc6bf2906079ffe58a90da02ca2bacd2d9cb73a9bac8c1bde5e5c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block-list-tyk-classic.md</strong><dd><code>Revert spelling change in block list middleware documentation</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-classic.md
- Reverted spelling change from "recognize" to "recognise".



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4898/files#diff-fa1759a8a4acde261b0666ef109b1c3c711a4a2216e407c608ca0e6670d4dd9c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block-list-tyk-oas.md</strong><dd><code>Revert spelling change in block list OAS documentation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-oas.md
- Reverted spelling change from "recognize" to "recognise".



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4898/files#diff-ca354f3751407d04336f4f43dc2d839dc0d8e047450db3f7aa0f3bf083d4bcd4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version-5.2.md</strong><dd><code>Revert spelling change in gateway release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
- Reverted spelling change from "recognizes" to "recognises".



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4898/files#diff-b6aafe51c3462aa4b79bcc868277e2224ec67ccd562a24716ddcae0401cda8bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

