### PR TITLE
Merging to release-5.3: [DX-1445] The links to prev and next should be side by side (#4914)

### DIFF
--- a/tyk-docs/assets/scss/_docs.scss
+++ b/tyk-docs/assets/scss/_docs.scss
@@ -524,11 +524,22 @@ iframe {
   margin-top: 10px;
   border-top: 1px solid rgba(122, 121, 161, 0.4);
   display: none;
+
 }
 
 .hasSidebar .docs-navigation {
   display: block;
-
+  @media (max-width: 1024px) {
+    display: flex;
+    justify-content: center;
+    flex-direction: row;
+  }
+  #previousArticle, #nextArticle{
+    @media (max-width: 1024px) {
+      max-width: 160px;
+      margin: auto;
+    }
+  }
   @include breakpoint(xlarge) {
     background: url("../img/nav-center.png") 50% center no-repeat;
     background-size: 20%;


### PR DESCRIPTION
### **User description**
[DX-1445] The links to prev and next should be side by side (#4914)

* Updated _side-menu.scss

[DX-1445]: https://tyktech.atlassian.net/browse/DX-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced the layout of the previous and next article links to be side by side on small screens.
- Updated the `.docs-navigation` class to use flexbox and center content when the screen width is 1024px or less.
- Adjusted `#previousArticle` and `#nextArticle` to have a max-width of 160px and centered margins on small screens.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_docs.scss</strong><dd><code>Enhance navigation links layout for small screens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/scss/_docs.scss

<li>Added media query for <code>.docs-navigation</code> to display flex and center <br>content on small screens.<br> <li> Adjusted <code>#previousArticle</code> and <code>#nextArticle</code> to have a max-width and <br>centered margin on small screens.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4915/files#diff-d29767519ca2fa4d8fce78b76e949905e03684c9f9d6572ff6b4f23888480e7e">+12/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

