### PR TITLE
Merging to release-5.3: [DX-1437] acknowledgement --> acknowledgment (#4927)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/kafka-franz.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/kafka-franz.md
@@ -64,7 +64,7 @@ output:
     sasl: [] # No default (optional)
 ```
 
-Writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating it back to the input.
+Writes a batch of messages to Kafka brokers and waits for acknowledgment before propagating it back to the input.
 
 This output often out-performs the traditional `kafka` output as well as providing more useful logs and error messages.
 

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/kafka.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/kafka.md
@@ -4,7 +4,7 @@ description: Explains an overview of configuring Kafka output
 tags: [ "Tyk Streams", "Stream Outputs", "Outputs", "Kafka" ]
 ---
 
-The kafka output type writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating it back to the input.
+The kafka output type writes a batch of messages to Kafka brokers and waits for acknowledgment before propagating it back to the input.
 
 ## Common
 
@@ -87,7 +87,7 @@ output:
       max_elapsed_time: 30s
 ```
 
-The config field `ack_replicas` determines whether we wait for acknowledgement from all replicas or just a single broker.
+The config field `ack_replicas` determines whether we wait for acknowledgment from all replicas or just a single broker.
 
 <!-- Add links to bloblang queries : Both the `key` and `topic` fields can be dynamically set using function interpolations described [here](/docs/configuration/interpolation#bloblang-queries). -->
 


### PR DESCRIPTION
### **User description**
[DX-1437] acknowledgement --> acknowledgment (#4927)

fix typo

[DX-1437]: https://tyktech.atlassian.net/browse/DX-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Corrected the spelling of 'acknowledgement' to 'acknowledgment' in Kafka Franz configuration documentation.
- Corrected the spelling of 'acknowledgement' to 'acknowledgment' in Kafka configuration documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kafka-franz.md</strong><dd><code>Fix typo in Kafka Franz configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/kafka-franz.md

- Corrected the spelling of 'acknowledgement' to 'acknowledgment'.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4928/files#diff-e8a9d3d52df71785b8d8cb3a63f35bb9118f91b108dc375c8c67c376dc9f7570">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kafka.md</strong><dd><code>Fix typo in Kafka configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/kafka.md

- Corrected the spelling of 'acknowledgement' to 'acknowledgment'.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4928/files#diff-176e49aa4ffe1b361860972ea2306e458aa04efcdbf6ae578be781b8ec90577e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

