### PR TITLE
Merging to release-5.3: [DX-1472] Overflowing text in docs badges shortcut (#4938)

### DIFF
--- a/tyk-docs/assets/scss/_docs.scss
+++ b/tyk-docs/assets/scss/_docs.scss
@@ -18,7 +18,7 @@
   border-radius: 20px;
   width: 300px;
   min-width: 200px;
-  height: 180px;
+  min-height: 160px;
   overflow: hidden;
   padding: 25px;
   padding-top: 40px;
@@ -82,7 +82,7 @@
   position: absolute;
   left: 50%;
   top: 0px;
-  width: 116px;
+  width: 130px;
   border-radius: 0 0 18px 18px;
   text-align: center;
   color: white;
@@ -90,6 +90,7 @@
   padding: 4px;
   transform: translateX(-50%);
   background-color: $brandpurple-dark;
+  justify-content: center;
 }
 
 .badge .nav.read {
@@ -176,6 +177,7 @@
   padding-top: 0 !important;
   margin-top: 10px !important;
   margin-bottom: 10px !important;
+  line-height: 22px;
 }
 
 .badge h1 a,
@@ -196,6 +198,10 @@
 .grid .badge {
   width: 98%;
   max-width: 300px;
+  white-space: normal;
+  @media (max-width: 555px) {
+  max-width: 100%;
+  }
 }
 
 .grid.mid .badge {


### PR DESCRIPTION
### **User description**
[DX-1472] Overflowing text in docs badges shortcut (#4938)

Fixed the Overflowing text in docs badges shortcut + optimised badges for mobile devices.

[DX-1472]: https://tyktech.atlassian.net/browse/DX-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Adjusted the minimum height of badges to prevent text overflow.
- Increased the width of the navigation bar in badges for better text fit.
- Added line-height to badge paragraphs for improved readability.
- Enhanced badge responsiveness for mobile devices by adjusting max-width.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_docs.scss</strong><dd><code>Fixed overflowing text and optimized badges for mobile</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/scss/_docs.scss

<li>Adjusted the minimum height of badges.<br> <li> Increased the width of the navigation bar in badges.<br> <li> Added line-height to badge paragraphs.<br> <li> Improved badge responsiveness for mobile devices.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4944/files#diff-d29767519ca2fa4d8fce78b76e949905e03684c9f9d6572ff6b4f23888480e7e">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

