### PR TITLE
Merging to release-5.3: [DX-1474] Update broken anchor link in Mutual TLS To Trusted Certificates (#4945)

### DIFF
--- a/tyk-docs/content/basic-config-and-security/security.md
+++ b/tyk-docs/content/basic-config-and-security/security.md
@@ -31,7 +31,7 @@ Tyk supports TLS connections and Mutual TLS. All TLS connections also support HT
 
 ### Trusted Certificates
 
-As part of using Mutual TLS, you can create a list of trusted certificates. See [Authorisation]({{< ref "basic-config-and-security/security/mutual-tls#authorisation" >}}) for more details.
+As part of using Mutual TLS, you can create a list of [trusted certificates]({{< ref "basic-config-and-security/security/mutual-tls/concepts#certificates" >}}).
 
 ### Certificate Pinning
 


### PR DESCRIPTION
### **User description**
[DX-1474] Update broken anchor link in Mutual TLS To Trusted Certificates (#4945)

update to broken anchor link

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1474]: https://tyktech.atlassian.net/browse/DX-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Fixed a broken anchor link in the Mutual TLS section of the security documentation.
- Updated the reference from "Authorisation" to "trusted certificates" to provide accurate information.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security.md</strong><dd><code>Fix broken anchor link in Mutual TLS documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/basic-config-and-security/security.md

<li>Updated broken anchor link for trusted certificates in Mutual TLS <br>section.<br> <li> Changed reference from "Authorisation" to "trusted certificates".<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4950/files#diff-1b1bafacc3e85973159ebdcf105cc4cd59f016da187bf44a0f388d5d47bf36d4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

