### PR TITLE
[TT-12306, DX-1486] Update GW Config To Replace Authorise With Authorize

### DIFF
--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -591,7 +591,7 @@ Your organisation ID to connect to the MDCB installation.
 ENV: <b>TYK_GW_SLAVEOPTIONS_APIKEY</b><br />
 Type: `string`<br />
 
-This the API key of a user used to authenticate and authorise the Gateway’s access through MDCB.
+This the API key of a user used to authenticate and authorize the Gateway’s access through MDCB.
 The user should be a standard Dashboard user with minimal privileges so as to reduce any risk if the user is compromised.
 The suggested security settings are read for Real-time notifications and the remaining options set to deny.
 
@@ -2019,7 +2019,7 @@ Sample Override Message Setting
 "override_messages": {
   "oauth.auth_field_missing" : {
    "code": 401,
-   "message": "Token is not authorised"
+   "message": "Token is not authorized"
  }
 }
 ```

--- a/tyk-docs/content/shared/x-tyk-gateway.md
+++ b/tyk-docs/content/shared/x-tyk-gateway.md
@@ -676,7 +676,7 @@ SegregateByClientId is a boolean flag. If set to `true, the policies will be app
 Tyk classic API definition: `openid_options.segregate_by_client`.
 
 **Field: `providers` ([[]Provider](#provider))**
-Providers contains a list of authorised providers, their Client IDs and matched policies.
+Providers contains a list of authorized providers, their Client IDs and matched policies.
 
 
 Tyk classic API definition: `openid_options.providers`.
@@ -1227,6 +1227,10 @@ Default value is 0, ie if regexpMatchIndex is not provided ID is matched from in
 **Field: `xPathExp` (`string`)**
 XPathExp is the xpath expression to match ID.
 
+### **EndpointPostPlugins**
+
+Type defined as array of `EndpointPostPlugin` values, see [EndpointPostPlugin](#endpointpostplugin) definition.
+
 ### **OAuthProvider**
 
 **Field: `jwt` ([JWTValidation](#jwtvalidation))**
@@ -1298,10 +1302,6 @@ For introspection caching, it is suggested to use a short interval.
 
 **Field: `providers` ([[]OAuthProvider](#oauthprovider))**
 
-
-### **EndpointPostPlugins**
-
-Type defined as array of `EndpointPostPlugin` values, see [EndpointPostPlugin](#endpointpostplugin) definition.
 
 ### **Allowance**
 


### PR DESCRIPTION
### **User description**
Triggered by: andrei-tyk

Included:

Tyk Gateway: true
Tyk Dashboard: true
Tyk MDCB false
Tyk Pump false

Intended for: master
Changes sourced from: master
Config info generator branch: main

Note: latest docs updates (branch suffix: docs)

JIRA: https://tyktech.atlassian.net/browse/TT-12306


___

### **PR Type**
Documentation


___

### **Description**
- Corrected spelling from 'authorise' to 'authorize' in multiple instances.
- Updated example message text for consistency in `gateway-config.md`.
- Reorganized the `EndpointPostPlugins` section for better logical flow in `x-tyk-gateway.md`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-config.md</strong><dd><code>Correct spelling and update example message text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/gateway-config.md

<li>Corrected spelling from 'authorise' to 'authorize'.<br> <li> Updated example message text for consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4980/files#diff-0a53845669feaeb0d62d4b17d24bfee5fc23482ec7562bd52e23db03373f14d0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-gateway.md</strong><dd><code>Correct spelling and reorganize sections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/x-tyk-gateway.md

<li>Corrected spelling from 'authorised' to 'authorized'.<br> <li> Moved <code>EndpointPostPlugins</code> section for better organization.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4980/files#diff-c4c21855fe9a7bb5c25d2f53fd19b2c5afec3ef3f8ca54c0105d8bfe197ff31c">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

