### PR TITLE
Merging to release-5.4: [DX-1437] cancell --> cancel, capitalise --> capitalize (#4979)

### DIFF
--- a/tyk-docs/content/advanced-configuration/transform-traffic/response-headers.md
+++ b/tyk-docs/content/advanced-configuration/transform-traffic/response-headers.md
@@ -41,7 +41,7 @@ The response header transform can be applied per-API or per-endpoint; each has a
 
 The middleware is configured with a list of headers to delete from the response and a list of headers to add to the response. Each header to be added to the response is configured as a key:value pair.
 - the "delete header" functionality is intended to ensure that any header in the delete list is not present once the middleware completes. If a header in the delete list is not present in the upstream response, the middleware will ignore the omission
-- the "add header" functionality will capitalise any header name provided. For example, if you configure the middleware to append `x-request-id` it will be added to the response as `X-Request-Id`
+- the "add header" functionality will capitalize any header name provided. For example, if you configure the middleware to append `x-request-id` it will be added to the response as `X-Request-Id`
 
 In the response middleware chain, the endpoint-level transform is applied before the API-level transform. Subsequently, if both middleware are enabled, the API-level transform will operate on the headers that have been added by the endpoint-level transform (and will not have access to those that have been deleted by it).
 

--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/getting-started-python.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/getting-started-python.md
@@ -103,7 +103,7 @@ This superclass contains a default stub implementation for the **Dispatch** and 
 
 The *request* parameter allows our server to access the message payload sent by Tyk Gateway. We can use this data, pertaining to the request and session, to process and generate a response.
 
-The *context* parameter provides additional information and functionalities related to the RPC call, such as timeout limits, cancellation signals etc. This is a [grpc.ServicerContext](https://grpc.github.io/grpc/python/grpc.html#grpc.ServicerContext) or a [grpc.aio.ServicerContext](https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.ServicerContext), object depending upon whether a synchronous or AsyncIO gRPC server is implemented.
+The *context* parameter provides additional information and functionalities related to the RPC call, such as timeout limits, cancelation signals etc. This is a [grpc.ServicerContext](https://grpc.github.io/grpc/python/grpc.html#grpc.ServicerContext) or a [grpc.aio.ServicerContext](https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.ServicerContext), object depending upon whether a synchronous or AsyncIO gRPC server is implemented.
 
 In the next step we will implement a subclass that will handle requests made by Tyk Gateway for remote execution of custom plugins.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/advanced-configurations/plugins/otel-plugins.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/advanced-configurations/plugins/otel-plugins.md
@@ -68,7 +68,7 @@ In this case, we are using our own OpenTelemetry library for convenience. You ca
 
 The function takes three parameters:
 
-1. `Context`: This is usually the current request’s context. However, you can also derive a new context from it, complete with timeouts and cancellations, to suit your specific needs.
+1. `Context`: This is usually the current request’s context. However, you can also derive a new context from it, complete with timeouts and cancelations, to suit your specific needs.
 2. `TracerName`: This is the identifier of the tracer that will be used to create the span. If you do not provide a name, the function will default to using the `tyk` tracer.
 3. `SpanName`: This parameter is used to set an initial name for the child span that is created. This name can be helpful for later identifying and referencing the span.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/url-rewrite-middleware.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/url-rewrite-middleware.md
@@ -29,7 +29,7 @@ Keys can be located in the following elements of the request:
 Note that there is no key name when using the request body location, as the entire body (payload) of the request is used as the key value.
 {{< /note >}}
 
-When using the request header location, the key name is the normalised form of the header name: with capitalisation and use of `-` as separator. For example, the header name`customer_identifier` would be identified in a rule via the key name `Customer-Identifier`.
+When using the request header location, the key name is the normalised form of the header name: with capitalization and use of `-` as separator. For example, the header name`customer_identifier` would be identified in a rule via the key name `Customer-Identifier`.
 
 When using the request path location, you can use wildcards in the key name (which is the URL path) - for example `/asset/{type}/author/`. The URL rewrite middleware will treat the wildcard as a `(.*)` regex so that any value matches. The wildcard value itself will be ignored, is not extracted from the key, and is not available for use in constructing the [rewrite path](#creating-the-rewrite-path).
 

--- a/tyk-docs/content/transform-traffic/request-headers.md
+++ b/tyk-docs/content/transform-traffic/request-headers.md
@@ -45,7 +45,7 @@ The middleware is configured with a list of headers to delete from the request a
 
 The "delete header" functionality is intended to ensure that any header in the delete list is not present once the middleware completes - so if a header is not originally present in the request but is on the list to be deleted, the middleware will ignore its omission.
 
-The "add header" functionality will capitalise any header name provided, for example if you configure the middleware to append `x-request-id` it will be added to the request as `X-Request-Id`.
+The "add header" functionality will capitalize any header name provided, for example if you configure the middleware to append `x-request-id` it will be added to the request as `X-Request-Id`.
 
 In the request middleware chain, the API-level transform is applied before the endpoint-level transform so if both middleware are enabled, the endpoint-level transform will operate on the headers that have been added by the API-level transform (and will not receive those that have been deleted by it).
 

--- a/tyk-docs/content/troubleshooting/tyk-gateway/context-canceled.md
+++ b/tyk-docs/content/troubleshooting/tyk-gateway/context-canceled.md
@@ -1,5 +1,5 @@
 ---
-title: "proxy error: context cancelled"
+title: "proxy error: context canceled"
 menu:
   main:
     parent: "Tyk Gateway Troubleshooting"

--- a/tyk-docs/content/tyk-cloud/account-billing/retirement.md
+++ b/tyk-docs/content/tyk-cloud/account-billing/retirement.md
@@ -17,7 +17,7 @@ This page explains what it means when your Tyk Cloud account goes into retiremen
 
 Your plan will go into [retirement]({{< ref "tyk-cloud/troubleshooting-&-support/glossary.md#retirement" >}}) in the following scenarios:
 
-* Your subscription is manually cancelled by a Billing Admin.
+* Your subscription is manually canceled by a Billing Admin.
 * Your periodic subscription payment fails.
 * You are on a Free Trial (5 weeks) and have not signed up to a plan before the expiration of the Free Trial.
 
@@ -29,7 +29,7 @@ When a plan goes into retirement, it means your Organisation, Teams and any Envi
 
 Your Billing Admin needs to do one of the following:
 
-* Renew a subscription that was manually cancelled.
+* Renew a subscription that was manually canceled.
 * Update your payment details and any outstanding payments are cleared.
 * Update a Free Trial to a paid plan, and payment is successful.
 

--- a/tyk-docs/content/tyk-cloud/troubleshooting-&-support/glossary.md
+++ b/tyk-docs/content/tyk-cloud/troubleshooting-&-support/glossary.md
@@ -79,7 +79,7 @@ The Tyk Analytics Dashboard to manage APIs and services.
 
 ### Retirement
 
-Where an Organisation has expired due to either a subscription failure or cancellation and is now within a "retirement" period of 30 days, during which an [Billing Admin]({{< ref "tyk-cloud/teams-&-users/user-roles#user-roles-within-tyk-cloud" >}}) can reinstate full functionality by updating or creating a new subscription.
+Where an Organisation has expired due to either a subscription failure or cancelation and is now within a "retirement" period of 30 days, during which an [Billing Admin]({{< ref "tyk-cloud/teams-&-users/user-roles#user-roles-within-tyk-cloud" >}}) can reinstate full functionality by updating or creating a new subscription.
 
 ## Action Terms
 

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -2336,7 +2336,7 @@ menu:
           path: /troubleshooting/tyk-gateway/502-error-tyk-gateway
           category: Page
           show: True
-        - title: "proxy error: context cancelled"
+        - title: "proxy error: context canceled"
           path: /troubleshooting/tyk-gateway/context-canceled
           category: Page
           show: True


### PR DESCRIPTION
### **User description**
[DX-1437] cancell --> cancel, capitalise --> capitalize (#4979)

switched cancell* and capitalise

[DX-1437]: https://tyktech.atlassian.net/browse/DX-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Corrected spelling from "capitalise" to "capitalize" in multiple documentation files.
- Corrected spelling from "cancellation" to "cancelation" in multiple documentation files.
- Changed title from "context cancelled" to "context canceled" in documentation and menu files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>response-headers.md</strong><dd><code>Corrected spelling from "capitalise" to "capitalize"</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/advanced-configuration/transform-traffic/response-headers.md

<li>Changed "capitalise" to "capitalize" in the description of the "add <br>header" functionality.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4995/files#diff-5560efef131cbdf046c4113dbaa8483003e4190b06890b7cbaee8a687bd5eb90">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>getting-started-python.md</strong><dd><code>Corrected spelling from "cancellation" to "cancelation"</code>&nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/getting-started-python.md

<li>Changed "cancellation" to "cancelation" in the description of the <br>*context* parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4995/files#diff-e756b30e63353f4fe870bedc13d6ba334536bb09d5ee9e4aa16c0b5593398dce">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>otel-plugins.md</strong><dd><code>Corrected spelling from "cancellations" to "cancelations"</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/advanced-configurations/plugins/otel-plugins.md

<li>Changed "cancellations" to "cancelations" in the description of the <br><code>Context</code> parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4995/files#diff-0ee066cae1984cba255e71a2f335c7c9f61a168c6c221f99f3bd038d28425d64">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>url-rewrite-middleware.md</strong><dd><code>Corrected spelling from "capitalisation" to "capitalization"</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/url-rewrite-middleware.md

<li>Changed "capitalisation" to "capitalization" in the description of the <br>request header location.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4995/files#diff-b633acef750f0ca979c0b0e152a09ad289527b1936567268dbfe4a6a1d95faf3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>request-headers.md</strong><dd><code>Corrected spelling from "capitalise" to "capitalize"</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/transform-traffic/request-headers.md

<li>Changed "capitalise" to "capitalize" in the description of the "add <br>header" functionality.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4995/files#diff-6a6cf52339e6068491a3e96f1ae2edcf14d454ede33a8ac54fa0575c220bd7a6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>context-canceled.md</strong><dd><code>Corrected spelling from "context cancelled" to "context canceled"</code></dd></summary>
<hr>

tyk-docs/content/troubleshooting/tyk-gateway/context-canceled.md

- Changed title from "context cancelled" to "context canceled".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4995/files#diff-f0619c1be0875e69d60efa6e71465bb26230179f6145659e19736afb9acc9f1f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>retirement.md</strong><dd><code>Corrected spelling from "cancelled" to "canceled"</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-cloud/account-billing/retirement.md

- Changed "cancelled" to "canceled" in multiple instances.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4995/files#diff-dea0ba30622379efb5cc9158cbf4585f25f1714590efccf5e2e584809406a917">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>glossary.md</strong><dd><code>Corrected spelling from "cancellation" to "cancelation"</code>&nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-cloud/troubleshooting-&-support/glossary.md

<li>Changed "cancellation" to "cancelation" in the description of the <br>"retirement" term.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4995/files#diff-0483e97df3aacbc4f2287d2988a58f3788f060545c7862dcd39ed9b4a89ee6fe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Corrected spelling from "context cancelled" to "context canceled" in </code><br><code>menu</code></dd></summary>
<hr>

tyk-docs/data/menu.yaml

- Changed title from "context cancelled" to "context canceled".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/4995/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

