### PR TITLE
Merging to release-5.4: [DX-1388] Update docs for kv body transforms env vars (#4819)

### DIFF
--- a/tyk-docs/content/tyk-configuration-reference/kv-store.md
+++ b/tyk-docs/content/tyk-configuration-reference/kv-store.md
@@ -137,9 +137,10 @@ When the Gateway starts, Tyk will read the *Value* from the environment variable
 {{< note success >}}
 **Note** 
 
-Prior to Tyk Gateway v5.3.0, environment variables to be used for Target URL or Listen Path must be named `TYK_SECRET_{KEY_NAME}` and would then be referred to using `env://{KEY_NAME}`, i.e. the `TYK_SECRET_` part should not be included in the API definition.
-<br>
-From v5.3.0 onward, the environment variables can be given any name and the full name should be provided in the API definition reference (though the pre-5.3.0 naming method is still supported for these two fields).
+Prior to Tyk Gateway v5.3.0, **environment variables** used for the Target URL or Listen Path had to be named `TYK_SECRET_{KEY_NAME}`. They were referred to in the API definition using `env://{KEY_NAME}` excluding the `TYK_SECRET_` prefix.
+<br><br>
+From v5.3.0 onward, environment variables can have any `KEY_NAME`, and the full name should be provided in the API definition reference. The pre-v5.3.0 naming convention is still supported for backward compatibility, but only for these two fields.
+
 {{< /note >}}
 
 #### Transformation middleware
@@ -155,7 +156,7 @@ To reference the *Value* assigned to a *Key* in one of the KV stores from these 
 - Consul: `$secret_consul.key`
 - Vault: `$secret_vault.key`
 - Tyk config secrets: `$secret_conf.key`
-- Environment variables: `$secret_env.key`
+- Environment variables: `$secret_env.key` or `env://key` (see [here]({{< ref "tyk-configuration-reference/kv-store#using-environment-variables-with-transformation-middleware" >}}))
 
 This notation is used to avoid ambiguity in the middleware parsing (for example where a KV secret is used in a URL rewrite path).
 
@@ -181,6 +182,42 @@ For example, if you create a Key-Value pair in Consul with the *Key* `user_id` t
 When a call is made to `GET /anything`, Tyk will retrieve the *Value* assigned to the `user_id` *Key* in Consul and rewrite the Target URL for the request to `/api/v1/users/{user_id}`.
 
 These references are read (and replaced with the values read from the KV location) during the processing of the API request or response.
+
+##### Using environment variables with transformation middleware
+
+There are some subtleties with the use of environment variables as KV storage for the transformation middleware.
+
+- **Request and Response Body Transforms** support only the `$secret_env.{KEY_NAME}` format.
+- **Request and Response Header Transforms** support both `env://{KEY_NAME}` and `$secret_env.{KEY_NAME}` formats.
+- **URL Rewrite** supports the `env://{KEY_NAME}` format for both the `pattern` and `rewriteTo` fields. The `rewriteTo` field also supports `$secret_env.{KEY_NAME}` format.
+
+{{< note success >}}
+**Notes**  
+
+Due to the way that Tyk Gateway processes the API definition, when you use transformation middleware with the `$secret_env` format, it expects the environment variable to be named `TYK_SECRET_{KEY_NAME}` and to be referenced from the API definition using `$secret_env.{KEY_NAME}`.
+<br><br>
+For example, if you create a Gateway environment variable `TYK_SECRET_NEW_UPSTREAM=http://new.upstream.com`, then in a request body transform middleware, you would reference it as follows:
+
+```json
+{
+  "custom_url": "$secret_env.NEW_UPSTREAM"
+}
+```
+
+To configure the URL rewrite `rewriteTo` field using this variable you could use either:
+
+````json
+{
+  "rewriteTo": "env://TYK_SECRET_NEW_UPSTREAM"
+}
+````
+or
+````json
+{
+  "rewriteTo": "$secret_env.NEW_UPSTREAM"
+}
+````
+{{< /note >}}
 
 #### Other `string` fields
 


### PR DESCRIPTION
### **User description**
[DX-1388] Update docs for kv body transforms env vars (#4819)

* Added example kv env var for body transforms

---------

Co-authored-by: dcs3spp <dcs3spp@users.noreply.github.com>
Co-authored-by: Andy Ost <andy.o@tyk.io>
Co-authored-by: Yaara <yaara@tyk.io>

[DX-1388]: https://tyktech.atlassian.net/browse/DX-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Clarified the naming conventions for environment variables used in Tyk Gateway before and after version 5.3.0.
- Added a new section detailing the use of environment variables with transformation middleware, including supported formats and examples.
- Provided examples for configuring URL rewrite fields using environment variables.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kv-store.md</strong><dd><code>Update and clarify environment variable usage in KV store </code><br><code>documentation</code></dd></summary>
<hr>

tyk-docs/content/tyk-configuration-reference/kv-store.md

<li>Clarified environment variable naming conventions for different Tyk <br>Gateway versions.<br> <li> Added detailed examples for using environment variables with <br>transformation middleware.<br> <li> Introduced a new section on using environment variables with <br>transformation middleware.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5023/files#diff-8a6fc823903007c8abf92aa051b1748f306331c957d3dc2a94a28ef0e75a1838">+41/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

