### PR TITLE
Merging to release-5.4: [DX-1437] modell --> model, flavour --> flavor, categorise --> categorize, licence --> license, normalise --> normalize, programme --> program, recognise --> recognize (#5022)

### DIFF
--- a/tyk-docs/content/advanced-configuration/other-protocols.md
+++ b/tyk-docs/content/advanced-configuration/other-protocols.md
@@ -7,4 +7,4 @@ menu:
 weight: 7
 ---
 
-Tyk concerns itself primariy with the HTTP/HTTPS protocol when it comes to handling and modelling traffic. However, given the recent popularity of Websocket-based APIs, Tyk also supports transparent WebSocket proxying, both TLS and non-TLS.
+Tyk concerns itself primariy with the HTTP/HTTPS protocol when it comes to handling and modeling traffic. However, given the recent popularity of Websocket-based APIs, Tyk also supports transparent WebSocket proxying, both TLS and non-TLS.

--- a/tyk-docs/content/apim.md
+++ b/tyk-docs/content/apim.md
@@ -2,7 +2,7 @@
 title: "Tyk API Management Deployment Options"
 date: 2020-06-24
 linkTitle: API Management
-tags: ["Tyk API Management", "Licencing", "Open Source", "Self-Managed", "Tyk Cloud", "API Gateway"]
+tags: ["Tyk API Management", "Licensing", "Open Source", "Self-Managed", "Tyk Cloud", "API Gateway"]
 description: "How to decide on which Tyk deployment option is best for you"
 aliases:
     - /getting-started/deployment-options/

--- a/tyk-docs/content/getting-started/key-concepts/graphql-entities.md
+++ b/tyk-docs/content/getting-started/key-concepts/graphql-entities.md
@@ -68,11 +68,11 @@ extend type MyEntity @key(fields: "id") {
 Types that are identical by name and structure and feature in more than one subgraph are shared types.
 
 #### Can I extend a shared type?
-Subgraphs are normalised before federation. This means you can extend a type if the resolution of the extension after normalisation is exactly identical to the resolution of the type after normalisation in other subgraphs.
+Subgraphs are normalized before federation. This means you can extend a type if the resolution of the extension after normalization is exactly identical to the resolution of the type after normalization in other subgraphs.
 
 Unless the resolution of the extension in a single subgraph is exactly identical to all other subgraphs, extension is not possible.
 
-Here is a valid example where both subgraphs resolve to identical enums after normalisation:
+Here is a valid example where both subgraphs resolve to identical enums after normalization:
 
 **Subgraph 1:**
 

--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/custom-auth-python.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/custom-auth-python.md
@@ -363,7 +363,7 @@ Our function accepts three parameters:
 - **date_string** is the date extracted from the date header in the request sent by Tyk Gateway.
 - **secret_key** is the value of the secret used for signing.
 
-The function computes and returns the HMAC signature for a string formatted as *date: date_string*, where *date_string* corresponds to the value of the *date_string* parameter. The signature is computed using the secret value given in the *secret_key* parameter and the HMAC algorithm given in the *algorithm* parameter. A *ValueError* is raised if the hash algorithm is unrecognised. 
+The function computes and returns the HMAC signature for a string formatted as *date: date_string*, where *date_string* corresponds to the value of the *date_string* parameter. The signature is computed using the secret value given in the *secret_key* parameter and the HMAC algorithm given in the *algorithm* parameter. A *ValueError* is raised if the hash algorithm is unrecognized. 
 
 We use the following Python modules in our implementation:
 
@@ -464,7 +464,7 @@ The *Object* payload received from the Gateway is updated and returned as a resp
 Specifically, our function performs the following tasks:
 
 - Extracts the *Date* and *Authorization* headers from the request and verifies that the *Authorization* header is structured correctly, using our *parse_auth_header* function. We store the extracted *Authorization* header fields in the *parse_dict* dictionary. If the structure is invalid then a 400 bad request response is returned to Tyk Gateway, using our *set_response_error* function.
-- We use our *verify_hmac_signature* function to compute and verify the HMAC signature. A 400 bad request error is returned to the Gateway if HMAC signature verification fails, due to an unrecognised HMAC algorithm.
+- We use our *verify_hmac_signature* function to compute and verify the HMAC signature. A 400 bad request error is returned to the Gateway if HMAC signature verification fails, due to an unrecognized HMAC algorithm.
 - A 401 unauthorized error response is returned to the Gateway under the following conditions:
 
     - The client HMAC signature and the computed HMAC signature do not match.

--- a/tyk-docs/content/product-stack/tyk-dashboard/advanced-configurations/api-categories.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/advanced-configurations/api-categories.md
@@ -5,7 +5,7 @@ description: "Using API categories with Tyk"
 tags: ["category", "categories", "governance", "API governance"]
 ---
 
-API categorisation is a governance feature provided within the Tyk Dashboard that helps you to manage a portfolio of APIs. You can filter the list of APIs visible in the Dashboard UI or to be returned by the Dashboard API by category. You can assign an API to any number of categories and any number of APIs to a category. All category names are entirely user defined.
+API categorization is a governance feature provided within the Tyk Dashboard that helps you to manage a portfolio of APIs. You can filter the list of APIs visible in the Dashboard UI or to be returned by the Dashboard API by category. You can assign an API to any number of categories and any number of APIs to a category. All category names are entirely user defined.
 
 ## When to use API categories
 #### Managing a large portfolio of APIs

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.2.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.2.md
@@ -65,10 +65,10 @@ Changed the look & feel of request logs in Playground tab for GraphQL APIs. New 
 
 ##### Shared types
 Types of the same name can be defined in more than one subgraph (a shared type). This will no longer produce an error if each definition is identical.
-Shared types cannot be extended outside of the current subgraph, and the resolved extension must be identical to the resolved extension of the shared type in all other subgraphs (see subgraph normalisation notes). Attempting to extend a shared type will result in an error.
+Shared types cannot be extended outside of the current subgraph, and the resolved extension must be identical to the resolved extension of the shared type in all other subgraphs (see subgraph normalization notes). Attempting to extend a shared type will result in an error.
 The federated supergraph will include a single definition of a shared type, regardless of how many times it has been identically defined in its subgraphs.
 
-##### Subgraph normalisation before federation
+##### Subgraph normalization before federation
 Extensions of types whose base type is defined in the same subgraph will be resolved before an attempt at federation. A valid example involving a shared type:
 
 Subgraph 1:

--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.2.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.2.md
@@ -254,7 +254,7 @@ Added a new Dashboard configuration option `allow_unsafe_oas`. This permits the 
 <details>
 <summary>Fixed security policy grant permissions issue encountered with MongoDB</summary>
 
-Fixed an issue when using MongoDB and [Tyk Security Policies]({{< ref "getting-started/key-concepts/what-is-a-security-policy" >}}) where Tyk could incorrectly grant access to an API after that API had been deleted from the associated policy. This was due to the policy cleaning operation that is triggered when an API is deleted from a policy in a MongoDB installation. With this fix, the policy cleaning operation will not remove the final (deleted) API from the policy; Tyk recognises that the API record is invalid and denies granting access rights to the key.
+Fixed an issue when using MongoDB and [Tyk Security Policies]({{< ref "getting-started/key-concepts/what-is-a-security-policy" >}}) where Tyk could incorrectly grant access to an API after that API had been deleted from the associated policy. This was due to the policy cleaning operation that is triggered when an API is deleted from a policy in a MongoDB installation. With this fix, the policy cleaning operation will not remove the final (deleted) API from the policy; Tyk recognizes that the API record is invalid and denies granting access rights to the key.
 </details>
 </li>
 <li>

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-classic.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-classic.md
@@ -62,7 +62,7 @@ For example:
 
 In this example the allow list middleware has been configured for HTTP `GET` and `PUT` requests to the `/status/200` endpoint. Requests to any other endpoints will be rejected with `HTTP 403 Forbidden`, unless they also have the allow list middleware enabled.
 Note that the allow list has been configured to be case sensitive, so calls to `GET /Status/200` will also be rejected.
-Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /status/200/foobar` will be allowed as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware#endpoint-parsing" >}}) will recognise this as `GET /status/200`.
+Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /status/200/foobar` will be allowed as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware#endpoint-parsing" >}}) will recognize this as `GET /status/200`.
 
 ## Configuring the Allow List in the API Designer
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-oas.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-oas.md
@@ -88,7 +88,7 @@ For example:
 
 In this example the allow list middleware has been configured for requests to the `GET /anything` and `PUT /anything` endpoints. Requests to any other endpoints will be rejected with `HTTP 403 Forbidden`, unless they also have the allow list middleware enabled.
 Note that the allow list has been configured to be case insensitive, so calls to `GET /Anything` will be allowed
-Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /anything/foobar` will be allowed as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware#endpoint-parsing" >}}) will recognise this as `GET /anything`.
+Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /anything/foobar` will be allowed as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware#endpoint-parsing" >}}) will recognize this as `GET /anything`.
 
 The configuration above is a complete and valid Tyk OAS API Definition that you can import into Tyk to try out the allow list feature.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-classic.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-classic.md
@@ -62,7 +62,7 @@ For example:
 
 In this example the block list middleware has been configured for HTTP `GET` and `PUT` requests to the `/status/200` endpoint. Requests to these endpoints will be rejected with `HTTP 403 Forbidden`.
 Note that the block list has been configured to be case sensitive, so calls to `GET /Status/200` will not be rejected.
-Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /status/200/foobar` will be rejected as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware#endpoint-parsing" >}}) will recognise this as `GET /status/200`.
+Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /status/200/foobar` will be rejected as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware#endpoint-parsing" >}}) will recognize this as `GET /status/200`.
 
 ## Configuring the Block List in the API Designer
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-oas.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-oas.md
@@ -88,7 +88,7 @@ For example:
 
 In this example the block list middleware has been configured for requests to the `GET /anything` and `PUT /anything` endpoints. Requests to these endpoints will be rejected with `HTTP 403 Forbidden`.
 Note that the block list has been configured to be case insensitive, so calls to `GET /Anything` will also be blocked.
-Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /anything/foobar` will be rejected as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware#endpoint-parsing" >}}) will recognise this as `GET /anything`.
+Note also that the endpoint path has not been terminated with `$`. Requests to, for example, `GET /anything/foobar` will be rejected as the [regular expression pattern match]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware#endpoint-parsing" >}}) will recognize this as `GET /anything`.
 
 The configuration above is a complete and valid Tyk OAS API Definition that you can import into Tyk to try out the block list feature.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/url-rewrite-middleware.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/url-rewrite-middleware.md
@@ -29,7 +29,7 @@ Keys can be located in the following elements of the request:
 Note that there is no key name when using the request body location, as the entire body (payload) of the request is used as the key value.
 {{< /note >}}
 
-When using the request header location, the key name is the normalised form of the header name: with capitalization and use of `-` as separator. For example, the header name`customer_identifier` would be identified in a rule via the key name `Customer-Identifier`.
+When using the request header location, the key name is the normalized form of the header name: with capitalization and use of `-` as separator. For example, the header name`customer_identifier` would be identified in a rule via the key name `Customer-Identifier`.
 
 When using the request path location, you can use wildcards in the key name (which is the URL path) - for example `/asset/{type}/author/`. The URL rewrite middleware will treat the wildcard as a `(.*)` regex so that any value matches. The wildcard value itself will be ignored, is not extracted from the key, and is not available for use in constructing the [rewrite path](#creating-the-rewrite-path).
 

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.1.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.1.md
@@ -60,7 +60,7 @@ So, if you upgrade from Tyk v4.1.0 to v4.2.0 you only need to have the plugins c
 - Fixed an issue with the calculation of TTL for keys in an MDCB deployment such that TTL could be different between worker and controller Gateways
 - Fixed a bug when using Open ID where quota was not tracked correctly
 - Fixed multiple issues with schema merging in GraphQL federation. Federation subgraphs with the same name shared types like objects, interfaces, inputs, enums, unions and scalars will no longer cause errors when users are merging schemas into a federated supergraph.
-- Fixed an issue where schema merging in GraphQL federation could fail depending on the order or resolving subgraph schemas and only first instance of a type and its extension would be valid. Subgraphs are now individually normalised before a merge is attempted and all extensions that are possible in the federated schema are applied.
+- Fixed an issue where schema merging in GraphQL federation could fail depending on the order or resolving subgraph schemas and only first instance of a type and its extension would be valid. Subgraphs are now individually normalized before a merge is attempted and all extensions that are possible in the federated schema are applied.
 - Fixed an issue with accessing child properties of an object query variable for GraphQL where query {{.arguments.arg.foo}} would return "{ "foo":"123456" }" instead of "123456"
 
 ## Updated Versions

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.2.md
@@ -67,10 +67,10 @@ Changed the look & feel of request logs in Playground tab for GraphQL APIs. New 
 
 ##### Shared types
 Types of the same name can be defined in more than one subgraph (a shared type). This will no longer produce an error if each definition is identical.
-Shared types cannot be extended outside of the current subgraph, and the resolved extension must be identical to the resolved extension of the shared type in all other subgraphs (see subgraph normalisation notes). Attempting to extend a shared type will result in an error.
+Shared types cannot be extended outside of the current subgraph, and the resolved extension must be identical to the resolved extension of the shared type in all other subgraphs (see subgraph normalization notes). Attempting to extend a shared type will result in an error.
 The federated supergraph will include a single definition of a shared type, regardless of how many times it has been identically defined in its subgraphs.
 
-##### Subgraph normalisation before federation
+##### Subgraph normalization before federation
 Extensions of types whose base type is defined in the same subgraph will be resolved before an attempt at federation. A valid example involving a shared type:
 
 Subgraph 1:
@@ -124,7 +124,7 @@ Added support for Kafka as a data source in Universal Data Graph. Configuration 
 ##### Fixed
 - Fixed an issue where the Gateway would not create the circuit breaker events (BreakerTripped and BreakerReset) for which the Tyk Dashboard offers webhooks.
 - Types of the same name can be defined in more than one subgraph (a shared type). This will no longer produce an error if each definition is exactly identical.
-- Apply Federation Subgraph normalisation do avoid merge errors. Extensions of types whose base type is defined in the same subgraph will be resolved before an attempt at federation.
+- Apply Federation Subgraph normalization do avoid merge errors. Extensions of types whose base type is defined in the same subgraph will be resolved before an attempt at federation.
 
 ## Updated Versions
 Tyk Gateway 4.2

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.2.md
@@ -278,7 +278,7 @@ Fixed an issue where [enforced timeouts]({{< ref "planning-for-production/ensure
 <details>
 <summary>Incorrect access privileges were granted in security policies</summary>
 
-Fixed an issue when using MongoDB and [Tyk Security Policies]({{< ref "getting-started/key-concepts/what-is-a-security-policy" >}}) where Tyk could incorrectly grant access to an API after that API had been deleted from the associated policy. This was due to the policy cleaning operation that is triggered when an API is deleted from a policy in a MongoDB installation. With this fix, the policy cleaning operation will not remove the final (deleted) API from the policy; Tyk recognises that the API record is invalid and denies granting access rights to the key.
+Fixed an issue when using MongoDB and [Tyk Security Policies]({{< ref "getting-started/key-concepts/what-is-a-security-policy" >}}) where Tyk could incorrectly grant access to an API after that API had been deleted from the associated policy. This was due to the policy cleaning operation that is triggered when an API is deleted from a policy in a MongoDB installation. With this fix, the policy cleaning operation will not remove the final (deleted) API from the policy; Tyk recognizes that the API record is invalid and denies granting access rights to the key.
 </details>
 </li>
 <li>

--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
@@ -563,9 +563,9 @@ This release introduces an enhanced trace generation system for Universal Data G
 </li>
 <li>
 <details>
-<summary>Disabled normalise and validate in GraphQL Engine</summary>
+<summary>Disabled normalize and validate in GraphQL Engine</summary>
 
-For GraphQL requests normalisation and validation has been disabled in the GraphQL engine. Both of those actions were performed in the Tyk Gateway and were unnecessary to be done again in the engine. This enhances performance slightly and makes detailed OTel traces concise and easier to read.
+For GraphQL requests normalization and validation has been disabled in the GraphQL engine. Both of those actions were performed in the Tyk Gateway and were unnecessary to be done again in the engine. This enhances performance slightly and makes detailed OTel traces concise and easier to read.
 </details>
 </li>
 <li>

--- a/tyk-docs/content/product-stack/tyk-sync/release-notes/sync-1.5.md
+++ b/tyk-docs/content/product-stack/tyk-sync/release-notes/sync-1.5.md
@@ -77,7 +77,7 @@ Added support for API templates in `dump`, `sync`, `update`, and `publish` comma
 <details>
 <summary>Support for API Categories of OAS APIs </summary>
 
-Added support for API categories in OAS APIs. Users can now include API Category in the API Definition file. Tyk Sync will update the categories of the API accordingly. It improved organisation and categorisation of APIs, making management more intuitive.
+Added support for API categories in OAS APIs. Users can now include API Category in the API Definition file. Tyk Sync will update the categories of the API accordingly. It improved organisation and categorization of APIs, making management more intuitive.
 </details>
 </li>
 </ul>

--- a/tyk-docs/content/tyk-dashboard-analytics/traffic-per-api.md
+++ b/tyk-docs/content/tyk-dashboard-analytics/traffic-per-api.md
@@ -23,7 +23,7 @@ You will also see an error breakdown and the endpoint popularity stats for the A
 
 {{< img src="/img/2.10/error_breakdown_api.png" alt="API error breakdown pie chart" >}}
 
-Tyk will try to normalise endpoint metrics by identifying IDs and UUIDs in a URL string and replacing them with normalised tags, this can help make your analytics more useful. It is possible to configure custom tags in the configuration file of your Tyk Self-Managed or Multi-Cloud installation.
+Tyk will try to normalize endpoint metrics by identifying IDs and UUIDs in a URL string and replacing them with normalized tags, this can help make your analytics more useful. It is possible to configure custom tags in the configuration file of your Tyk Self-Managed or Multi-Cloud installation.
 
 {{< note success >}}
 **Note**

--- a/tyk-docs/content/tyk-developer-portal.md
+++ b/tyk-docs/content/tyk-developer-portal.md
@@ -12,7 +12,7 @@ aliases:
 
 The Tyk Developer Portal enables you to expose a facade of your APIs and then allow third-party developers to register and use your APIs.
 
-The Tyk Developer Portal comes into two flavours:
+The Tyk Developer Portal comes into two flavors:
 *   Tyk Classic Developer Portal.
 *   Tyk Enterprise Developer Portal.
 

--- a/tyk-docs/content/tyk-developer-portal/tyk-portal-classic/portal-concepts.md
+++ b/tyk-docs/content/tyk-developer-portal/tyk-portal-classic/portal-concepts.md
@@ -55,7 +55,7 @@ If a new API requires key approval, the new key request will be generated, and a
 
 In the context of the developer portal, a security policy is the main "element" being exposed to public access. The policy is the same as a standard policy, and the policy forms the baseline template that gets used when the portal generates a token for the developer.
 
-Security policies are used instead of a one-to-one mapping because they encapsulate all the information needed for a public API programme:
+Security policies are used instead of a one-to-one mapping because they encapsulate all the information needed for a public API program:
 
 1.  Rate limits
 2.  Quota

--- a/tyk-docs/content/tyk-on-premises.md
+++ b/tyk-docs/content/tyk-on-premises.md
@@ -88,6 +88,6 @@ Sign up for a free trial to test it out:
 Please visit our [Self-Managed installation]({{< ref "tyk-self-managed/install" >}}) page to get started.
 
 
-## Licencing
+## Licensing
 
 Read more about licensing [here]({{< ref "tyk-on-premises/licensing" >}}).

--- a/tyk-docs/content/tyk-self-managed/install.md
+++ b/tyk-docs/content/tyk-self-managed/install.md
@@ -57,6 +57,6 @@ Install on Microsoft Azure
 
 {{< /grid >}}
 
-### Licencing
+### Licensing
 
 Read more about licensing [here]({{< ref "tyk-on-premises/licensing" >}}).


### PR DESCRIPTION
### **User description**
[DX-1437] modell --> model, flavour --> flavor, categorise --> categorize, licence --> license, normalise --> normalize, programme --> program, recognise --> recognize (#5022)

* centre

* Update licensing.md

@Roeegg2 I fixed the link

* labelled, minimise, maximise, enrol, finalis, monetis, neighbour

* another monetise

* modell flavour categoris licenc normalis programme recogniz

* Update tyk-docs/content/tyk-developer-portal.md

fixed

---------

Co-authored-by: Yaara <yaara@tyk.io>

[DX-1437]: https://tyktech.atlassian.net/browse/DX-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Corrected various British English spellings to American English spellings across multiple documentation files.
- Updated terms include "modelling" to "modeling", "licencing" to "licensing", "normalised" to "normalized", "recognise" to "recognize", "categorisation" to "categorization", and more.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>other-protocols.md</strong><dd><code>Corrected spelling in advanced configuration documentation.</code></dd></summary>
<hr>

tyk-docs/content/advanced-configuration/other-protocols.md

- Corrected the spelling of "modelling" to "modeling".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-51abbd1b8feb9bb84205c942ae2dafe5f4977d82682e6b85cb4bc4e8158350a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>apim.md</strong><dd><code>Corrected spelling in API management deployment options.</code>&nbsp; </dd></summary>
<hr>

tyk-docs/content/apim.md

- Corrected the spelling of "Licencing" to "Licensing" in tags.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-955dad1c340a1116b954795e70d8170dd79f5a0ea27b163342c5592db831b580">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graphql-entities.md</strong><dd><code>Corrected spelling in GraphQL entities documentation.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/getting-started/key-concepts/graphql-entities.md

- Corrected the spelling of "normalised" to "normalized".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-1c4f015f5d4918d2fe9525734a1b3d701843c4da14a2edb17e41ca978c77c60b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>custom-auth-python.md</strong><dd><code>Corrected spelling in custom auth Python plugin documentation.</code></dd></summary>
<hr>

tyk-docs/content/plugins/supported-languages/rich-plugins/grpc/custom-auth-python.md

- Corrected the spelling of "unrecognised" to "unrecognized".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-d1eb6bb614f7a6fc0c7ba43c0c4ff2e081023319f6a9da6144a82b353cd1e0a8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api-categories.md</strong><dd><code>Corrected spelling in API categories documentation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-dashboard/advanced-configurations/api-categories.md

- Corrected the spelling of "categorisation" to "categorization".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-f07e7ef6da9026d309b98cc5a35b7e2c1de4ae7e21977deb24f32e847819544b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version-4.2.md</strong><dd><code>Corrected spelling in Tyk Dashboard version 4.2 release notes.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-4.2.md

- Corrected the spelling of "normalisation" to "normalization".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-b9c7148f398a253f42273f7ab585325009a7d750465192b3d3e83a0a6ecdd7f9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version-5.2.md</strong><dd><code>Corrected spelling in Tyk Dashboard version 5.2 release notes.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.2.md

- Corrected the spelling of "recognises" to "recognizes".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-c38cb3b1fa171a37b1cbef7bd921234fa47827692ee3171aa3a243e54cd7afba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>allow-list-tyk-classic.md</strong><dd><code>Corrected spelling in allow list middleware documentation.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-classic.md

- Corrected the spelling of "recognise" to "recognize".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-cecc51e27b2ad48c72c18e637d5f8f3a791b2a9e031dcff2a60506683efbefa5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>allow-list-tyk-oas.md</strong><dd><code>Corrected spelling in allow list middleware documentation.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-oas.md

- Corrected the spelling of "recognise" to "recognize".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-e093b781849fc6bf2906079ffe58a90da02ca2bacd2d9cb73a9bac8c1bde5e5c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block-list-tyk-classic.md</strong><dd><code>Corrected spelling in block list middleware documentation.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-classic.md

- Corrected the spelling of "recognise" to "recognize".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-fa1759a8a4acde261b0666ef109b1c3c711a4a2216e407c608ca0e6670d4dd9c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block-list-tyk-oas.md</strong><dd><code>Corrected spelling in block list middleware documentation.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-tyk-oas.md

- Corrected the spelling of "recognise" to "recognize".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-ca354f3751407d04336f4f43dc2d839dc0d8e047450db3f7aa0f3bf083d4bcd4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>url-rewrite-middleware.md</strong><dd><code>Corrected spelling in URL rewrite middleware documentation.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/url-rewrite-middleware.md

- Corrected the spelling of "normalised" to "normalized".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-b633acef750f0ca979c0b0e152a09ad289527b1936567268dbfe4a6a1d95faf3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version-4.1.md</strong><dd><code>Corrected spelling in Tyk Gateway version 4.1 release notes.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/release-notes/version-4.1.md

- Corrected the spelling of "normalised" to "normalized".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-f8333d782508aefa1ad48832f7bcf0e1449e0d51edfa8c6fc040126ebd9f6c04">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version-5.3.md</strong><dd><code>Corrected spelling in Tyk Gateway version 5.3 release notes.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md

- Corrected the spelling of "normalise" to "normalize".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-ead598197a92e18014f4f7c35c341621948fb6cdf66d45c1dd05de21bc2b35aa">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sync-1.5.md</strong><dd><code>Corrected spelling in Tyk Sync version 1.5 release notes.</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-sync/release-notes/sync-1.5.md

- Corrected the spelling of "categorisation" to "categorization".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-a06d5107a9959c9b092d45a567d7114c09ae6d94f53f8c698f418e56d674c0d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>traffic-per-api.md</strong><dd><code>Corrected spelling in traffic per API documentation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-dashboard-analytics/traffic-per-api.md

- Corrected the spelling of "normalise" to "normalize".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-6a2a502377b53c26d357fdab3e25d09282bfc8fba734e2ae5a304105ec91df5a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tyk-developer-portal.md</strong><dd><code>Corrected spelling in Tyk Developer Portal documentation.</code></dd></summary>
<hr>

tyk-docs/content/tyk-developer-portal.md

- Corrected the spelling of "flavours" to "flavors".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-d456faf01ca30bb689d49127194dad014e70030a0bf8c643ce589b064dc1ee4c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>portal-concepts.md</strong><dd><code>Corrected spelling in Tyk Portal Classic documentation.</code>&nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-developer-portal/tyk-portal-classic/portal-concepts.md

- Corrected the spelling of "programme" to "program".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-b293b397b70a2fb7c56808d013590fcc7fd1cb562dc98a70f5573296a7e97b58">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tyk-on-premises.md</strong><dd><code>Corrected spelling in Tyk On-Premises documentation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-on-premises.md

- Corrected the spelling of "Licencing" to "Licensing".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-b0f038f8e9334fff1d674de39dfcc2eb93738df5edc0cfea5d4ac4c3205b7808">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>install.md</strong><dd><code>Corrected spelling in Tyk Self-Managed installation documentation.</code></dd></summary>
<hr>

tyk-docs/content/tyk-self-managed/install.md

- Corrected the spelling of "Licencing" to "Licensing".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5025/files#diff-79e3085f7b898531e3e8990926b3d7dd929ec10994721efe971b634dc26e0e14">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

