### PR TITLE
Merging to release-5.4: double alias /getting-started/installation/with-tyk-on-premises/ (#5031)

### DIFF
--- a/tyk-docs/content/shared/self-managed-licensing-include.md
+++ b/tyk-docs/content/shared/self-managed-licensing-include.md
@@ -6,7 +6,9 @@ Tyk Self-Managed is the easiest way to install Tyk Full Lifecycle API Management
 See [licensing and deployment models]({{< ref "tyk-on-premises/licensing" >}}) to learn about the different deployment options for Self-Managed.
 
 Register here to get a 14-day temporary licenses for the Tyk Dashboard & Developer Portal:
+
 {{< button_left href="https://tyk.io/sign-up/" color="green" content="Free trial" >}}
 
-For longer duration trials, or to request trials of the other proprietary software please contact the Tyk Team and tell
-us about your plans: {{< button_left href="https://tyk.io/contact/" color="green" content="Contact us" >}}
+For longer duration trials, or to request trials of the other proprietary software please contact the Tyk Team and tell us about your plans:
+
+{{< button_left href="https://tyk.io/contact/" color="green" content="Contact us" >}}

--- a/tyk-docs/content/tyk-on-premises.md
+++ b/tyk-docs/content/tyk-on-premises.md
@@ -8,7 +8,6 @@ menu:
     main:
         parent: "API Management"
 aliases:
-  - /getting-started/installation/with-tyk-on-premises/
   - /tyk-on-premises/getting-started/
   - /getting-started/installation/with-tyk-on-premises/bootstrapper-cli/
   - /get-started/with-tyk-on-premise/

--- a/tyk-docs/content/tyk-self-managed/install.md
+++ b/tyk-docs/content/tyk-self-managed/install.md
@@ -10,16 +10,18 @@ menu:
         parent: Tyk Self-Managed
 aliases:
   - /tyk-self-managed/istio/
-  - "tyk-self-managed/install"
+  - /tyk-self-managed/install/
   - /getting-started/installation/with-tyk-on-premises/
   - /get-started/with-tyk-on-premise/installation/
 ---
 
-First, click here to get a free trial license - 
+First, click here to get a trial license
+
 </br>
+
 {{< button_left href="https://tyk.io/sign-up/#self" color="green" content="Self-managed Free License" >}}
 
-Now choose your the installation
+**Now choose your preferred installation option**
 
 {{< grid >}}
 


### PR DESCRIPTION
### **User description**
double alias /getting-started/installation/with-tyk-on-premises/ (#5031)


___

### **PR Type**
Documentation


___

### **Description**
- Improved formatting for buttons in the self-managed licensing section.
- Removed duplicate alias in the tyk-on-premises documentation.
- Corrected alias format and improved wording in the self-managed install guide.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>self-managed-licensing-include.md</strong><dd><code>Improved formatting for licensing section buttons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/self-managed-licensing-include.md

<li>Added a newline before the "Free trial" button.<br> <li> Adjusted the placement of the "Contact us" button for better <br>formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5037/files#diff-b46c343a3cf502455a2e6f2507461b16ef81846d3ef643d79786035d023f46e1">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tyk-on-premises.md</strong><dd><code>Removed duplicate alias in tyk-on-premises</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-on-premises.md

<li>Removed duplicate alias for <br><code>/getting-started/installation/with-tyk-on-premises/</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5037/files#diff-b0f038f8e9334fff1d674de39dfcc2eb93738df5edc0cfea5d4ac4c3205b7808">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>install.md</strong><dd><code>Corrected alias and improved wording in install guide</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-self-managed/install.md

<li>Corrected alias format for <code>/tyk-self-managed/install/</code>.<br> <li> Improved wording for trial license and installation options.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5037/files#diff-79e3085f7b898531e3e8990926b3d7dd929ec10994721efe971b634dc26e0e14">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

