### PR TITLE
Merging to release-5.3: double alias /getting-started/installation/with-tyk-on-premises/ (#5031)

### DIFF
--- a/tyk-docs/content/tyk-on-premises.md
+++ b/tyk-docs/content/tyk-on-premises.md
@@ -8,7 +8,6 @@ menu:
     main:
         parent: "API Management"
 aliases:
-  - /getting-started/installation/with-tyk-on-premises/
   - /tyk-on-premises/getting-started/
   - /getting-started/installation/with-tyk-on-premises/bootstrapper-cli/
   - /get-started/with-tyk-on-premise/

--- a/tyk-docs/content/tyk-self-managed/install.md
+++ b/tyk-docs/content/tyk-self-managed/install.md
@@ -10,16 +10,18 @@ menu:
         parent: Tyk Self-Managed
 aliases:
   - /tyk-self-managed/istio/
-  - "tyk-self-managed/install"
+  - /tyk-self-managed/install/
   - /getting-started/installation/with-tyk-on-premises/
   - /get-started/with-tyk-on-premise/installation/
 ---
 
-First, click here to get a free trial license - 
+First, click here to get a trial license
+
 </br>
+
 {{< button_left href="https://tyk.io/sign-up/#self" color="green" content="Self-managed Free License" >}}
 
-Now choose your the installation
+**Now choose your preferred installation option**
 
 {{< grid >}}
 


### PR DESCRIPTION
### **User description**
double alias /getting-started/installation/with-tyk-on-premises/ (#5031)


___

### **PR Type**
Documentation


___

### **Description**
- Removed duplicate alias `/getting-started/installation/with-tyk-on-premises/` from `tyk-on-premises.md`.
- Corrected alias format for `/tyk-self-managed/install/` in `install.md`.
- Updated text for trial license and installation options in `install.md`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tyk-on-premises.md</strong><dd><code>Remove duplicate alias from tyk-on-premises.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-on-premises.md

<li>Removed duplicate alias <br><code>/getting-started/installation/with-tyk-on-premises/</code><br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5038/files#diff-b0f038f8e9334fff1d674de39dfcc2eb93738df5edc0cfea5d4ac4c3205b7808">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>install.md</strong><dd><code>Correct alias and update text in install.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-self-managed/install.md

<li>Corrected alias format for <code>/tyk-self-managed/install/</code><br> <li> Updated text for trial license and installation options<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5038/files#diff-79e3085f7b898531e3e8990926b3d7dd929ec10994721efe971b634dc26e0e14">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

