### PR TITLE
Merging to release-5.3: Update api-ownership.md add prefix api (#5090)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-dashboard/advanced-configurations/user-management/api-ownership.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/advanced-configurations/user-management/api-ownership.md
@@ -90,8 +90,8 @@ When working with Tyk OAS APIs, you can manage owners for an API using these end
 
 | Method | Endpoint path           | Action                                                                                 |
 |--------|-------------------------|----------------------------------------------------------------------------------------|
-| `PUT`  | `/apis/{apiID}/access`  | Assign a list of owners to the specified API                                           |
-| `GET`  | `/apis/{apiID}/access`  | Retrieve the list of owners of the specified API                                       |
+| `PUT`  | `/api/apis/{apiID}/access`  | Assign a list of owners to the specified API                                           |
+| `GET`  | `/api/apis/{apiID}/access`  | Retrieve the list of owners of the specified API                                       |
 
 For each of these endpoints, the payload consists of two string lists: one for user IDs, the other for user group IDs.
 ```json


### PR DESCRIPTION
### **User description**
Update api-ownership.md add prefix api (#5090)

Update api-ownership.md


___

### **PR Type**
documentation


___

### **Description**
- Updated the `api-ownership.md` documentation to include the `/api` prefix in the endpoint paths for managing API owners.
- Modified the `PUT` and `GET` endpoints to reflect the new paths.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-ownership.md</strong><dd><code>Update API ownership endpoint paths with `/api` prefix</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-dashboard/advanced-configurations/user-management/api-ownership.md

<li>Updated endpoint paths to include the <code>/api</code> prefix.<br> <li> Modified <code>PUT</code> and <code>GET</code> endpoints for managing API owners.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5093/files#diff-247f2ac87d42006333576999d1a48110a64e524dfc696cfc5a3b1369e44218ef">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

