### PR TITLE
Merging to release-5.3: Tyk Streams: [DX-1407, DX-1551] Rate Limits (#5050)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/kafka.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/kafka.md
@@ -625,7 +625,7 @@ period: 500ms
 
 ### batching.check
 
-A [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) query that should return a boolean value indicating whether a message should end a batch.
+A [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) query that should return a boolean value indicating whether a message should end a batch.
 
 
 Type: `string`  

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/nats.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/nats.md
@@ -377,7 +377,7 @@ Type: `string`
 
 ### inject_tracing_map
 
-EXPERIMENTAL: A [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mapping used to inject an object containing tracing propagation information into outbound messages. The specification of the injected fields will match the format used by the service wide tracer.
+EXPERIMENTAL: A [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mapping used to inject an object containing tracing propagation information into outbound messages. The specification of the injected fields will match the format used by the service wide tracer.
 
 
 Type: `string`   

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/redis-pubsub.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/redis-pubsub.md
@@ -318,7 +318,7 @@ period: 500ms
 
 ### batching.check
 
-A [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) query that should return a boolean value indicating whether a message should end a batch.
+A [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) query that should return a boolean value indicating whether a message should end a batch.
 
 Type: `string`  
 Default: `""`  

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/bloblang.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/bloblang.md
@@ -100,11 +100,6 @@ pipeline:
 
 [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mappings can fail, in which case the message remains unchanged, errors are logged, and the message is flagged as having failed, allowing you to use [standard processor error handling patterns]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/error-handling" >}}).
 
-<<<<<<< HEAD
-However, [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behaviour.
-<!-- TODO - add link which you can read about [in this section](/docs/guides/bloblang/about#error-handling). -->
-=======
 <!-- TODO add fallback link -->
 
 <!-- However, [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired [fallback behavior]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/error-handling" >}}). -->
->>>>>>> 1dc7956d0... Tyk Streams: [DX-1407, DX-1551] Rate Limits (#5050)

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/bloblang.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/bloblang.md
@@ -12,7 +12,7 @@ label: ""
 bloblang: ""
 ```
 
-[Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) is a powerful language that enables a wide range of mapping, transformation and filtering tasks.
+[Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) is a powerful language that enables a wide range of mapping, transformation and filtering tasks.
 
 If your mapping is large and you'd prefer for it to live in a separate file then you can execute a mapping directly from a file with the expression `from "<path>"`, where the path must be absolute, or relative from the location that Tyk Streams is executed from.
 
@@ -98,8 +98,13 @@ pipeline:
 
 ## Error Handling
 
-[Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mappings can fail, in which case the message remains unchanged, errors are logged, and the message is flagged as having failed, allowing you to use
-<!-- TODO - add link [standard processor error handling patterns](/docs/configuration/error_handling). -->
+[Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mappings can fail, in which case the message remains unchanged, errors are logged, and the message is flagged as having failed, allowing you to use [standard processor error handling patterns]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/error-handling" >}}).
 
+<<<<<<< HEAD
 However, [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behaviour.
 <!-- TODO - add link which you can read about [in this section](/docs/guides/bloblang/about#error-handling). -->
+=======
+<!-- TODO add fallback link -->
+
+<!-- However, [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired [fallback behavior]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/error-handling" >}}). -->
+>>>>>>> 1dc7956d0... Tyk Streams: [DX-1407, DX-1551] Rate Limits (#5050)

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/branch.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/branch.md
@@ -4,7 +4,7 @@ description: Branch Processor
 tags: ["Branch","Processors","Composition"]
 ---
 
-The `branch` processor allows you to create a new request message via a [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mapping, execute a list of processors on the request messages, and, finally, map the result back into the source message using another mapping.
+The `branch` processor allows you to create a new request message via a [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mapping, execute a list of processors on the request messages, and, finally, map the result back into the source message using another mapping.
 
 ```yml
 # Config fields, showing default values
@@ -33,7 +33,7 @@ If the root of your request map is set to `deleted()` then the branch processors
 
 ### request_map
 <!-- TODO: add a link -->
-A [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mapping that describes how to create a request payload suitable for the child processors of this branch. If left empty then the branch will begin with an exact copy of the origin message (including metadata).
+A [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mapping that describes how to create a request payload suitable for the child processors of this branch. If left empty then the branch will begin with an exact copy of the origin message (including metadata).
 
 
 Type: `string`  
@@ -65,7 +65,7 @@ Type: `array`
 
 ### result_map
 
-A [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mapping that describes how the resulting messages from branched processing should be mapped back into the original payload. If left empty the origin message will remain unchanged (including metadata).
+A [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mapping that describes how the resulting messages from branched processing should be mapped back into the original payload. If left empty the origin message will remain unchanged (including metadata).
 
 
 Type: `string`  

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mapping.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mapping.md
@@ -37,11 +37,7 @@ Mapping documents is advantageous in situations where the result is a document w
 
 [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mappings can fail, in which case the message remains unchanged, errors are logged, and the message is flagged as having failed, allowing you to use standard processor error handling patterns.
 
-<<<<<<< HEAD
-However, [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behaviour.
-=======
 However, [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behavior.
->>>>>>> 1dc7956d0... Tyk Streams: [DX-1407, DX-1551] Rate Limits (#5050)
 
 
 ## Examples

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mapping.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mapping.md
@@ -4,7 +4,7 @@ description: Explains an overview of mapping
 tags: [ "Mapping", "Parsing","Processors" ]
 ---
 
-Executes a [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mapping on messages, creating a new document that replaces (or filters) the original message.
+Executes a [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mapping on messages, creating a new document that replaces (or filters) the original message.
 
 
 ```yml
@@ -13,7 +13,7 @@ label: ""
 mapping: "" # No default (required)
 ```
 
-[Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) is a powerful language that enables a wide range of mapping, transformation and filtering tasks.
+[Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) is a powerful language that enables a wide range of mapping, transformation and filtering tasks.
 
 If your mapping is large, and you'd prefer for it to live in a separate file then you can execute a mapping directly from a file with the expression `from "<path>"`, where the path must be absolute, or relative from the location that Tyk Streams is executed from.
 
@@ -35,9 +35,13 @@ Mapping documents is advantageous in situations where the result is a document w
 
 ## Error Handling
 
-[Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mappings can fail, in which case the message remains unchanged, errors are logged, and the message is flagged as having failed, allowing you to use standard processor error handling patterns.
+[Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mappings can fail, in which case the message remains unchanged, errors are logged, and the message is flagged as having failed, allowing you to use standard processor error handling patterns.
 
+<<<<<<< HEAD
 However, [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behaviour.
+=======
+However, [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behavior.
+>>>>>>> 1dc7956d0... Tyk Streams: [DX-1407, DX-1551] Rate Limits (#5050)
 
 
 ## Examples

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mutation.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mutation.md
@@ -42,11 +42,7 @@ Mutations are advantageous over a standard mapping in situations where the resul
 
 [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mappings can fail, in which case the error is logged and the message is flagged as having failed, allowing you to use standard processor error handling patterns.
 
-<<<<<<< HEAD
-However, [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behaviour.
-=======
 However, [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behavior.
->>>>>>> 1dc7956d0... Tyk Streams: [DX-1407, DX-1551] Rate Limits (#5050)
 
 
 ## Examples

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mutation.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mutation.md
@@ -4,7 +4,7 @@ description: Mutation Processor
 tags: ["Processors","Mapping","Parsing" ]
 ---
 
-Executes a [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mapping and directly transforms the contents of messages, mutating (or deleting) them.
+Executes a [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mapping and directly transforms the contents of messages, mutating (or deleting) them.
 
 
 
@@ -14,7 +14,7 @@ label: ""
 mutation: "" # No default (required)
 ```
 
-[Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) is a powerful language that enables a wide range of mapping, transformation and filtering tasks.
+[Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) is a powerful language that enables a wide range of mapping, transformation and filtering tasks.
 
 If your mapping is large and you'd prefer for it to live in a separate file then you can execute a mapping directly from a file with the expression `from "<path>"`, where the path must be absolute, or relative from the location that Tyk Streams is executed from.
 
@@ -40,9 +40,13 @@ Mutations are advantageous over a standard mapping in situations where the resul
 
 ## Error Handling
 
-[Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mappings can fail, in which case the error is logged and the message is flagged as having failed, allowing you to use standard processor error handling patterns.
+[Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mappings can fail, in which case the error is logged and the message is flagged as having failed, allowing you to use standard processor error handling patterns.
 
+<<<<<<< HEAD
 However, [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behaviour.
+=======
+However, [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) itself also provides powerful ways of ensuring your mappings do not fail by specifying desired fallback behavior.
+>>>>>>> 1dc7956d0... Tyk Streams: [DX-1407, DX-1551] Rate Limits (#5050)
 
 
 ## Examples

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/rate-limit.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/rate-limit.md
@@ -1,0 +1,24 @@
+
+---
+title: Rate Limit
+description: Explains an overview of rate limit processor
+tags: [ "Tyk Streams", "Stream Processors", "Processors", "Rate Limit" ]
+---
+
+Throttles the throughput of a pipeline according to a specified [rate_limit]({{< ref "/product-stack/tyk-streaming/configuration/rate-limits/overview" >}}) resource. Rate limits are shared across components and therefore apply globally to all processing pipelines.
+
+```yml
+# Config fields, showing default values
+label: ""
+rate_limit:
+  resource: "" # No default (required)
+```
+
+## Fields
+
+### resource
+
+The target [rate_limit resource]({{< ref "/product-stack/tyk-streaming/configuration/rate-limits/overview" >}}).
+
+
+Type: `string`  

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/redis.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/redis.md
@@ -351,7 +351,7 @@ command: ${! meta("command") }
 
 ### args_mapping
 
-A [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) mapping which should evaluate to an array of values matching in size to the number of arguments required for the specified Redis command.
+A [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) mapping which should evaluate to an array of values matching in size to the number of arguments required for the specified Redis command.
 
 Type: `string`
 

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/rate-limits/local.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/rate-limits/local.md
@@ -1,0 +1,33 @@
+---
+title: Local Rate Limit
+description: Explains an overview of local rate limit
+tags: [ "Tyk Streams", "Rate Limits", "Local", "Local rate Limits" ]
+---
+
+The local rate limit is a simple X every Y type rate limit that can be shared across any number of components within the pipeline but does not support distributed rate limits across multiple running instances of Tyk Streams.
+
+```yml
+# Config fields, showing default values
+label: ""
+local:
+  count: 1000
+  interval: 1s
+```
+
+## Fields
+
+### count
+
+The maximum number of requests to allow for a given period of time.
+
+
+Type: `int`  
+Default: `1000`  
+
+### interval
+
+The time window to limit requests by.
+
+
+Type: `string`  
+Default: `"1s"`  

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/rate-limits/overview.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/rate-limits/overview.md
@@ -1,0 +1,47 @@
+---
+title: Rate Limits Overview
+description: Explains an overview of rate limits
+tags: [ "Tyk Streams", "Rate Limits" ]
+---
+
+A rate limit is a strategy for limiting the usage of a shared resource across parallel components in a Tyk Streams instance, or potentially across multiple instances. They are configured as a resource:
+
+```yaml
+rate_limit_resources:
+  - label: foobar
+    local:
+      count: 500
+      interval: 1s
+```
+
+And most components that hit external services have a field `rate_limit` for specifying a rate limit resource to use. For example, if we wanted to use our `foobar` rate limit with a HTTP request:
+
+```yaml
+input:
+  http_client:
+    url: TODO
+    verb: GET
+    rate_limit: foobar
+```
+
+By using a rate limit in this way we can guarantee that our input will only poll our HTTP source at the rate of 500 requests per second.
+
+Some components don't have a `rate_limit` field but we might still wish to throttle them by a rate limit, in which case we can use the [rate_limit processor]({{< ref "/product-stack/tyk-streaming/configuration/processors/rate-limit" >}}) that applies back pressure to a processing pipeline when the limit is reached. For example:
+
+```yaml
+input:
+  http_server:
+    path: /post
+output:
+  http_server:
+    ws_path: /subscribe
+pipeline:
+  processors:
+    - rate_limit:
+        resource: example_rate_limit
+rate_limit_resources:
+  - label: example_rate_limit
+    local:
+      count: 3
+      interval: 20s
+```

--- a/tyk-docs/content/product-stack/tyk-streaming/guides/bloblang/advanced.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/guides/bloblang/advanced.md
@@ -4,7 +4,7 @@ description: Explains some advanced Bloblang patterns
 tags: [ "Tyk Streams", "Bloblang", "Bloblang Advanced", "Bloblang Patterns" ]
 ---
 
-This section explains some advanced [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) patterns
+This section explains some advanced [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) patterns
 
 ## Map Parameters
 
@@ -122,7 +122,7 @@ pipeline:
 
 ## Creating CSV
 
-Tyk Streams has a few different ways of outputting a stream of CSV data. However, the best way to do it is by converting the documents into CSV rows with [Bloblang]({< ref "/product-stack/tyk-streaming/reference/guides/overview" >}) as this gives you full control over exactly how the schema is generated, erroneous data is handled, and escaping of column data is performed.
+Tyk Streams has a few different ways of outputting a stream of CSV data. However, the best way to do it is by converting the documents into CSV rows with [Bloblang]({{< ref "product-stack/tyk-streaming/guides/bloblang/overview" >}}) as this gives you full control over exactly how the schema is generated, erroneous data is handled, and escaping of column data is performed.
 
 A common and simple use case is to simply flatten documents and write out the column values in alphabetical order. The first row we generate should also be prefixed with a row containing those column names. Here's a mapping that achieves this by using a `count` function to detect the very first invocation of the mapping in a stream pipeline:
 

--- a/tyk-docs/content/product-stack/tyk-streaming/guides/bloblang/arithmetic.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/guides/bloblang/arithmetic.md
@@ -4,7 +4,7 @@ description: Explains Bloblang Arithmetic
 tags: [ "Tyk Streams", "Bloblang", "Bloblang Arithmetic", "Arithmetic" ]
 ---
 
-[Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) supports a range of comparison operators `!`, `>`, `>=`, `==`, `<`, `<=`, `&&`, `||` and mathematical operators `+`, `-`, `*`, `/`, `%`. How these operators behave is dependent on the type of the values they're used with, and therefore it's worth fully understanding these behaviors if you intend to use them heavily in your mappings.
+[Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) supports a range of comparison operators `!`, `>`, `>=`, `==`, `<`, `<=`, `&&`, `||` and mathematical operators `+`, `-`, `*`, `/`, `%`. How these operators behave is dependent on the type of the values they're used with, and therefore it's worth fully understanding these behaviors if you intend to use them heavily in your mappings.
 
 ## Mathematical
 
@@ -12,9 +12,9 @@ All mathematical operators (`+`, `-`, `*`, `/`, `%`) are valid against number va
 
 ### Number Degradation
 
-In [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) any number resulting from a method, function or arithmetic is either a 64-bit signed integer or a 64-bit floating point value. Numbers from input documents can be any combination of size and be signed or unsigned.
+In [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) any number resulting from a method, function or arithmetic is either a 64-bit signed integer or a 64-bit floating point value. Numbers from input documents can be any combination of size and be signed or unsigned.
 
-When a mathematical operation is performed with two or more integer values [Bloblang]({< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}) will create an integer result, with the exception of division. However, if any number within a mathematical operation is a floating point then the result will be a floating point value.
+When a mathematical operation is performed with two or more integer values [Bloblang]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) will create an integer result, with the exception of division. However, if any number within a mathematical operation is a floating point then the result will be a floating point value.
 
 In order to explicitly coerce numbers into integer types you can use the [.ceil(), .floor(), or .round()]({{< ref "/product-stack/tyk-streaming/guides/bloblang/methods/numbers" >}}) methods.
 

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -4028,6 +4028,10 @@ menu:
             path: /product-stack/tyk-streaming/configuration/processors/protobuf
             category: Page
             show: True
+          - title: "Rate Limit"
+            path: /product-stack/tyk-streaming/configuration/processors/rate-limit 
+            category: Page
+            show: True
           - title: "Redis"
             path: /product-stack/tyk-streaming/configuration/processors/redis
             category: Page
@@ -4140,6 +4144,18 @@ menu:
               path: "/product-stack/tyk-streaming/guides/bloblang/methods/type-coercion"
               category: Page
               show: True
+      - title: "Rate Limits"
+        category: Directory
+        show: true
+        menu:
+        - title: "Overview"
+          path: /product-stack/tyk-streaming/configuration/rate-limits/overview 
+          category: Page
+          show: True
+        - title: "Local"
+          path: /product-stack/tyk-streaming/configuration/rate-limits/local
+          category: Page
+          show: True
       - title: "Deployment Considerations"
         path: /product-stack/tyk-streaming/deployment-considerations
         category: Page


### PR DESCRIPTION
### **User description**
Tyk Streams: [DX-1407, DX-1551] Rate Limits (#5050)

* Add rate limits
---------

Co-authored-by: Simon Pears <simon@tyk.io>


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Corrected Bloblang reference syntax across multiple documentation files.
- Added new documentation for Rate Limit processor.
- Added new documentation for Local Rate Limit.
- Added new documentation for Rate Limits Overview.
- Updated menu with entries for Rate Limit and Local Rate Limit documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>kafka.md</strong><dd><code>Fix Bloblang reference syntax in Kafka configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/kafka.md

- Corrected Bloblang reference syntax.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-176e49aa4ffe1b361860972ea2306e458aa04efcdbf6ae578be781b8ec90577e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nats.md</strong><dd><code>Fix Bloblang reference syntax in NATS configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/nats.md

- Corrected Bloblang reference syntax.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-de86c03a5a8a140016ce8e5c0bb9a34d44c4f36fac4d1b6ebdfe04e790c4f254">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis-pubsub.md</strong><dd><code>Fix Bloblang reference syntax in Redis PubSub configuration</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/redis-pubsub.md

- Corrected Bloblang reference syntax.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-8e83381560810874536889d0659c04e044a0f4ebfe464057b354e5350659c1d1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bloblang.md</strong><dd><code>Fix Bloblang reference syntax and add TODO for fallback link</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/bloblang.md

<li>Corrected Bloblang reference syntax.<br> <li> Added TODO for fallback link.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-875c2d2e52c9c566f00ad432eea3fd78551d7805f35b93d8d4ba1a5e3f04eb7c">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>branch.md</strong><dd><code>Fix Bloblang reference syntax in Branch processor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/branch.md

- Corrected Bloblang reference syntax.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-7d1b866d462211ba97a516b61e17c2227f0c82a69afc175cb66a8faf81f15663">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mapping.md</strong><dd><code>Fix Bloblang reference syntax in Mapping processor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mapping.md

- Corrected Bloblang reference syntax.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-2b07665ce2e62c370719baf24158f1bde1cfe067c17c838473b7499bb1b7b36f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mutation.md</strong><dd><code>Fix Bloblang reference syntax in Mutation processor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/mutation.md

- Corrected Bloblang reference syntax.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-5e0e03d4ce6ea061e4a6caf5ea881f9faa7eeedc9d9dbe87e971724e4dcc6821">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rate-limit.md</strong><dd><code>Add documentation for Rate Limit processor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/rate-limit.md

- Added new documentation for Rate Limit processor.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-3b34da2673c158e12bd9ff91c6a1ca244dd22b3d9b222e5af9aff16127790451">+24/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis.md</strong><dd><code>Fix Bloblang reference syntax in Redis processor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/redis.md

- Corrected Bloblang reference syntax.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-26ac8e46ac40b0523ff4a70a8e419aeceb7355b1aec9e9c222f0a707048e2b8f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>local.md</strong><dd><code>Add documentation for Local Rate Limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/rate-limits/local.md

- Added new documentation for Local Rate Limit.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-f31570be75bed05b47066e646e6447847859c6c529697c7fbe8d97af9615d260">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>overview.md</strong><dd><code>Add documentation for Rate Limits Overview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/rate-limits/overview.md

- Added new documentation for Rate Limits Overview.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-a87a98549e1b3fb15b4e1de83f891858832d51a062dcbee1694f0ca6d11ae79a">+47/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>advanced.md</strong><dd><code>Fix Bloblang reference syntax in advanced Bloblang patterns</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/guides/bloblang/advanced.md

- Corrected Bloblang reference syntax.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-ede9026b7dbdb5294d2085d7c2d642fd8ce6baed88840d90b993df50684aa452">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>arithmetic.md</strong><dd><code>Fix Bloblang reference syntax in Bloblang arithmetic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/guides/bloblang/arithmetic.md

- Corrected Bloblang reference syntax.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-5fa5b747d85c0b8e2a34c74ad377891d511b36213d306cd20ed931ccaa36f7b0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Update menu with Rate Limit documentation entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/data/menu.yaml

<li>Added menu entries for Rate Limit and Local Rate Limit documentation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5146/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

