### PR TITLE
Merging to release-5.3: [DX-1573] Update GW and Dashboard 5.3.3 LTS On Release Landing Page (#5152)

### DIFF
--- a/tyk-docs/data/releases/dashboard.json
+++ b/tyk-docs/data/releases/dashboard.json
@@ -1,9 +1,23 @@
 {
   "home": "tyk-dashboard",
   "licensed": true,
+<<<<<<< HEAD
   "latest": "5.3.2",
   "lts": "5.3.1",
   "releaseNotesPath": "product-stack/tyk-dashboard/release-notes/overview",
+=======
+  "latest": "5.4.0",
+  "lts": "5.3.3",
+  "releaseNotesPath": "product-stack/tyk-dashboard/release-notes/overview",
+  "5.4.0": {
+    "date": "02/07/2024",
+    "docker": "https://hub.docker.com/r/tykio/tyk-dashboard/tags?page=1&name=v5.4.0"
+  },
+  "5.3.3": {
+    "date": "02/08/2024",
+    "docker": "https://hub.docker.com/r/tykio/tyk-dashboard/tags?page=1&name=5.3.3"
+  },
+>>>>>>> 57a3b3231... [DX-1573] Update GW and Dashboard 5.3.3 LTS On Release Landing Page (#5152)
   "5.3.2": {
     "date": "05/06/2024",
     "docker": "https://hub.docker.com/r/tykio/tyk-dashboard/tags?page=1&name=5.3.2"

--- a/tyk-docs/data/releases/gateway.json
+++ b/tyk-docs/data/releases/gateway.json
@@ -1,9 +1,25 @@
 {
   "home": "tyk-oss-gateway",
   "licensed": false,
+<<<<<<< HEAD
   "latest": "5.3.2",
   "lts": "5.3.1",
   "releaseNotesPath": "product-stack/tyk-gateway/release-notes/overview",
+=======
+  "latest": "5.4.0",
+  "lts": "5.3.3",
+  "releaseNotesPath": "product-stack/tyk-gateway/release-notes/overview",
+  "5.4.0": {
+    "date": "02/07/2024",
+    "tag": "https://github.com/TykTechnologies/tyk/releases/tag/v5.4.0",
+    "docker": "https://hub.docker.com/r/tykio/tyk-gateway/tags?page=1&name=v5.4.0"
+  },
+  "5.3.3": {
+    "date": "02/08/2024",
+    "tag": "https://github.com/TykTechnologies/tyk/releases/tag/v5.3.3",
+    "docker": "https://hub.docker.com/r/tykio/tyk-gateway/tags?page=1&name=5.3.3"
+  },
+>>>>>>> 57a3b3231... [DX-1573] Update GW and Dashboard 5.3.3 LTS On Release Landing Page (#5152)
   "5.3.2": {
     "date": "05/06/2024",
     "tag": "https://github.com/TykTechnologies/tyk/releases/tag/v5.3.2",


### PR DESCRIPTION
[DX-1573] Update GW and Dashboard 5.3.3 LTS On Release Landing Page (#5152)

update GW and Dashboard 5.3.3 LTS links

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1573]: https://tyktech.atlassian.net/browse/DX-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ