### PR TITLE
Merging to release-5.4: [DX-1601] Add alias to events page (#5185)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/basic-config-and-security/report-monitor-and-trigger-events/event-webhook-tyk-oas.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/basic-config-and-security/report-monitor-and-trigger-events/event-webhook-tyk-oas.md
@@ -3,6 +3,8 @@ date: 2024-07-09
 title: Webhook event handlers with Tyk OAS APIs
 tags: ["event handling", "API events", "webhook", "Tyk OAS"]
 description: "Webhook event handlers with Tyk OAS APIs"
+aliases:
+    - /tyk-api-gateway-v-3-0/api-management/events/ 
 ---
 
 [Webhooks]({{< ref "basic-config-and-security/report-monitor-trigger-events/webhooks" >}}) are event handlers that can be registered against API Events. The webhook will be triggered when the corresponding event is fired and will send a customizable fixed payload to any open endpoint.


### PR DESCRIPTION
### **User description**
[DX-1601] Add alias to events page (#5185)

add alias to events page

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1601]: https://tyktech.atlassian.net/browse/DX-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Added an alias to the event webhook documentation page to improve accessibility and ensure users can find the page using the old URL.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event-webhook-tyk-oas.md</strong><dd><code>Add alias to event webhook documentation page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/basic-config-and-security/report-monitor-and-trigger-events/event-webhook-tyk-oas.md

<li>Added <code>aliases</code> section to the front matter.<br> <li> Included alias for the events page.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5186/files#diff-4cdee05250382ee771c4deb3ec01b1a55a214cc13acc8b2b65367cea69757b97">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

