### PR TITLE
Merging to release-5.5: [DX-1607] Update version-5.3.md - the generic message is incorrect (#5211)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.3.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.3.md
@@ -15,7 +15,7 @@ tags: ["Tyk Dashboard", "Release notes", "v5.3", "5.3.0", "5.3.1", "5.3.2", "5.3
 
 ## Support Lifetime
 
-Our minor releases are supported until our next minor comes out.
+As outlined in the [LTS policy]({{< ref "developer-support/special-releases-and-features/long-term-support-releases" >}}), version 5.3 is a long-term support release with full support available until May 2025. Maintenance support will continue until May 2026. Our next long-term support release will be announced at the end of April 2025.
 
 ---
 ## 5.3.3 Release Notes
@@ -24,7 +24,7 @@ Our minor releases are supported until our next minor comes out.
 
 ### Breaking Changes
 **Attention**: Please read this section carefully.
-There are no breaking changes in this release, however if moving from a version of Tyk older than 5.3.0 please read the explanation provided with [5.3.0 release]({{< ref "#TykOAS-v5.3.0">}}).
+There are no breaking changes in this release, however, if moving from a version of Tyk older than 5.3.0 please read the explanation provided with [5.3.0 release]({{< ref "#TykOAS-v5.3.0">}}).
 
 ### Deprecations
 There are no deprecations in this release.


### PR DESCRIPTION
### **User description**
[DX-1607] Update version-5.3.md - the generic message is incorrect (#5211)

* update release schedule message

---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1607]: https://tyktech.atlassian.net/browse/DX-1607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Updated the support lifetime message in `version-5.3.md` to reflect the Long-Term Support (LTS) policy, specifying full support until May 2025 and maintenance support until May 2026.
- Clarified the message regarding breaking changes in the 5.3.3 release notes, ensuring users are aware of the need to read the explanation if moving from a version older than 5.3.0.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version-5.3.md</strong><dd><code>Update support lifetime and breaking changes messages</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-dashboard/release-notes/version-5.3.md

<li>Updated the support lifetime message to reflect the LTS policy.<br> <li> Clarified the message regarding breaking changes in the 5.3.3 release <br>notes.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5215/files#diff-14b1be0b2206c9ee21cb1002b55361919932e84558f614c4342f05b8eb5431f8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

