### PR TITLE
Merging to release-5.5: [DX-1610] Removed MDCB from components table (#5213)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md
+++ b/tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md
@@ -23,7 +23,6 @@ By default, this chart installs the following components as sub-charts on a [Kub
 |---------------------------------|--------------------|-----------------------------|
 | Tyk Gateway                     | true               | n/a                         |
 | Tyk Dashboard                   | true               | n/a                         |
-| Tyk MDCB                        | true               | n/a                         |
 | Tyk Pump                        | false              | global.components.pump      |
 | Tyk Enterprise Developer Portal | false              | global.components.devPortal | 
 | Tyk Operator                    | false              | global.components.operator  |


### PR DESCRIPTION
### **User description**
[DX-1610] Removed MDCB from components table (#5213)

Removed MDCB from components table

[DX-1610]: https://tyktech.atlassian.net/browse/DX-1610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Removed the `Tyk MDCB` component from the components table in the Tyk stack chart documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tyk-stack-chart.md</strong><dd><code>Remove `Tyk MDCB` from components table in documentation</code>&nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md

- Removed the `Tyk MDCB` component from the components table.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5221/files#diff-f6e45bbf530fa763d587dec798584c8eb6294229ef353d3212ab01bf6b0a1d7c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

