### PR TITLE
Merging to release-5.3: [DX-1407] Tyk Streams: Try Processor (#5010)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/catch.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/catch.md
@@ -29,4 +29,4 @@ If the processor `foo` fails for a particular message, that message will be fed 
 
 When messages leave the catch block their fail flags are cleared. This processor is useful for when it's possible to recover failed messages, or when special actions (such as logging/metrics) are required before dropping them.
 
-<!-- TODO: add link to error handling /docs/configuration/error_handling -->
+More information about error handing can be found [here]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/error-handling" >}}).

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/try.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/try.md
@@ -1,0 +1,53 @@
+---
+title: Try
+description: Explains an overview of try processor
+tags: [ "Tyk Streams", "Stream Processors", "Processors", "Try" ]
+---
+
+Executes a list of child processors on messages only if no prior processors have failed (or the errors have been cleared).
+
+```yml
+# Config fields, showing default values
+label: ""
+try: []
+```
+
+This processor behaves similarly to the [for_each]({{< ref "/product-stack/tyk-streaming/configuration/processors/for-each" >}}) processor, where a list of child processors are applied to individual messages of a batch. However, if a message has failed any prior processor (before or during the try block) then that message will skip all following processors.
+
+For example, with the following config:
+
+```yaml
+pipeline:
+  processors:
+    - resource: foo
+    - try:
+      - resource: bar
+      - resource: baz
+      - resource: buz
+```
+
+If the processor `bar` fails for a particular message, that message will skip the processors `baz` and `buz`. Similarly, if `bar` succeeds but `baz` does not then `buz` will be skipped. If the processor `foo` fails for a message then none of `bar`, `baz` or `buz` are executed on that message.
+
+This processor is useful for when child processors depend on the successful output of previous processors. This processor can be followed with a [catch]({{< ref "/product-stack/tyk-streaming/configuration/processors/catch" >}}) processor for defining child processors to be applied only to failed messages.
+
+More information about error handing can be found [here]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/error-handling" >}}).
+
+### Nesting within a catch block
+
+In some cases it might be useful to nest a try block within a catch block, since the [catch processor]({{< ref "/product-stack/tyk-streaming/configuration/processors/catch" >}}) only clears errors *after* executing its child processors. This means a nested try processor will not execute unless the errors are explicitly cleared beforehand.
+
+This can be done by inserting an empty catch block before the try block like as follows:
+
+```yaml
+pipeline:
+  processors:
+    - resource: foo
+    - catch:
+      - log:
+          level: ERROR
+          message: "Foo failed due to: ${! error() }"
+      - catch: [] # Clear prior error
+      - try:
+        - resource: bar
+        - resource: baz
+```

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -4052,6 +4052,10 @@ menu:
             path: /product-stack/tyk-streaming/configuration/processors/split
             category: Page
             show: True
+          - title: "Try"
+            path: /product-stack/tyk-streaming/configuration/processors/try
+            category: Page
+            show: True
         - title: "Common Configurations"
           category: Directory
           show: True


### PR DESCRIPTION
### **User description**
[DX-1407] Tyk Streams: Try Processor (#5010)

* add try processor draft

* add try processor catch links and error handling links

---------

Co-authored-by: Simon Pears <simon@tyk.io>
Co-authored-by: Leonid Bugaev <leonsbox@gmail.com>

[DX-1407]: https://tyktech.atlassian.net/browse/DX-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
documentation


___

### **Description**
- Added a new documentation page for the 'Try' processor, explaining its purpose, configuration, and usage with examples.
- Updated the 'Catch' processor documentation to include a link to the error handling section.
- Updated the documentation menu to include the new 'Try' processor page.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>catch.md</strong><dd><code>Add link to error handling documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/catch.md

- Added a link to the error handling documentation.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5264/files#diff-4174aa9eb5bce0803a14c1213401c7d475f12f57ea4ea3834c8d062c2b87188a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>try.md</strong><dd><code>Introduce documentation for 'Try' processor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/try.md

<li>Introduced a new document for the 'Try' processor.<br> <li> Explained the behavior and configuration of the 'Try' processor.<br> <li> Provided examples and use cases for the 'Try' processor.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5264/files#diff-a2e3436dbbe32433b1feaa743cc4c24cc6af55a8885294ce56e90fe79dc1f111">+53/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Add 'Try' processor to documentation menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/data/menu.yaml

- Added a menu entry for the 'Try' processor documentation.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5264/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

