### PR TITLE
[DX-1629] Improved clarity for Tyk Classic versioning

### DIFF
--- a/tyk-docs/content/getting-started/key-concepts/versioning.md
+++ b/tyk-docs/content/getting-started/key-concepts/versioning.md
@@ -40,16 +40,18 @@ To add an API version, you must add a new entry in the `versions` list:
 There is also some API-level configuration for versioning, which is located in the `definition` section of the Tyk Classic API definition:
 
 The `definition` section has the following fields:
-- `default`: the default version of the API (this is the same as `default_version` in `version_data`); if left empty this will be automatically replaced with "self" and will point to the original API definition
-- `enabled`: toggle to enable or disable versioning
-- `name`: the chosen name for the version
-- `strip_path`: deprecated field; use `strip_path_versioning_data` instead. Defaults to false
 - `location`: used to configure where the versioning identifier should be provided: `header`, `url`, `url-param`
-- `strip_versioning_data`: set to `true` for Tyk to [remove the versioning identifier]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#stripping-version-identifier" >}}) prior to creating the upstream (target) URL)
-- `fallback_to_default`: set to `true` for Tyk to [invoke the default version]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#fallback-to-default" >}}) if an invalid version is requested
-- `url_versioning_pattern`: configure this with a regex that matches the format that you use for the versioning identifier (`versions.name`) if you are using `strip_versioning_data` and `fallback_to_default` with `location=url` [with Tyk 5.5.0 or later]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#stripping-url-path-version-and-default-fallback" >}})
-- `versions`: not used; since this is a legacy option it will be visible as empty `{}` in the API definition
 - `key`: the versioning identifier key used if `location` is set to `header` or `url-param`
+- `strip_versioning_data`: set this to `true` to [remove the versioning identifier]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#stripping-version-identifier" >}}) prior to creating the upstream (target) URL)
+- `fallback_to_default`: set this to `true` to [invoke the default version]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#fallback-to-default" >}}) if an invalid version is requested
+- `url_versioning_pattern`: if you are using `strip_versioning_data` and `fallback_to_default` with `location=url` [with Tyk 5.5.0 or later]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#stripping-url-path-version-and-default-fallback" >}}) you can configure this with a regex that matches the format that you use for the versioning identifier (`versions.name`)
+
+The following fields in `definition` are deprecated or otherwise not used for Tyk Classic API versioning and should be left with their default values:
+- `enabled`: defaults to `false`
+- `default`: defaults to an empty string `""`
+- `name`: defaults to an empty string `""`
+- `strip_path`: deprecated field; defaults to `false`
+- `versions`: defaults to an empty array `{}`
 
 When you first create an API, it will not be "versioned" (i.e. `not_versioned` will be set to `true`) and there will be a single `Default` version created in the `version_data` section of the API definition.
 
@@ -146,16 +148,11 @@ Here's an example of the minimal configuration that would need to be added to th
     }
   },
   "definition": {
-    "default": "",
-    "enabled": false,
-    "name": "",
-    "strip_path": false,
     "location": "header",
+    "key": "x-api-version",
     "strip_versioning_data": false,
     "fallback_to_default": true,
-    "url_versioning_pattern": "",
-    "versions": {},
-    "key": "x-api-version"
+    "url_versioning_pattern": ""
   }
 }
 ```

--- a/tyk-docs/content/getting-started/key-concepts/versioning.md
+++ b/tyk-docs/content/getting-started/key-concepts/versioning.md
@@ -46,7 +46,7 @@ The `definition` section has the following fields:
 - `fallback_to_default`: set this to `true` to [invoke the default version]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#fallback-to-default" >}}) if an invalid version is requested
 - `url_versioning_pattern`: if you are using `strip_versioning_data` and `fallback_to_default` with `location=url` [with Tyk 5.5.0 or later]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#stripping-url-path-version-and-default-fallback" >}}) you can configure this with a regex that matches the format that you use for the versioning identifier (`versions.name`)
 
-The following fields in `definition` are deprecated or otherwise not used for Tyk Classic API versioning and should be left with their default values:
+The following fields in `definition` are either deprecated or otherwise not used for Tyk Classic API versioning and should be left with their default values:
 - `enabled`: defaults to `false`
 - `default`: defaults to an empty string `""`
 - `name`: defaults to an empty string `""`


### PR DESCRIPTION
### **User description**
DX-1629

### Preview Link
https://deploy-preview-5293--tyk-docs.netlify.app/docs/nightly/getting-started/key-concepts/versioning/

### Description
Removed ambiguity over fields in the `definition` field that are not used by Tyk Classic API versioning


___

### **PR Type**
Documentation


___

### **Description**
- Improved clarity on the fields used in the `definition` section for Tyk Classic API versioning.
- Specified which fields are deprecated or not used and their default values.
- Updated example configuration to align with the clarified documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>versioning.md</strong><dd><code>Clarification and update of Tyk Classic API versioning documentation</code></dd></summary>
<hr>

tyk-docs/content/getting-started/key-concepts/versioning.md

<li>Clarified the usage of fields in the <code>definition</code> section for Tyk <br>Classic API versioning.<br> <li> Added notes on deprecated or unused fields with default values.<br> <li> Updated example configuration to reflect changes in field usage.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5293/files#diff-5f5d913588858b56d4c0e81bafaf8fb30e4ef7ae663f830509dfae2d40a7c05c">+13/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

