### PR TITLE
Merging to release-5.5: Fix operator "pro" configuration mode name (#5323)

### DIFF
--- a/tyk-docs/content/tyk-stack/tyk-operator/installing-tyk-operator.md
+++ b/tyk-docs/content/tyk-stack/tyk-operator/installing-tyk-operator.md
@@ -77,7 +77,7 @@ The secret should contain the following keys:
 
 {{< tab_end >}}
 
-{{< tab_start "Self Managed" >}}
+{{< tab_start "Licensed mode (Self-managed or Tyk Cloud)" >}}
 
 | Key | Mandatory | Example Value | Description  |
 |:-----|:-----|:----------------|:-------------|


### PR DESCRIPTION
### **User description**
Fix operator "pro" configuration mode name (#5323)

Update installing-tyk-operator.md


___

### **PR Type**
Documentation


___

### **Description**
- Updated the documentation to correct the operator configuration mode name from "Self Managed" to "Licensed mode (Self-managed or Tyk Cloud)".


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>installing-tyk-operator.md</strong><dd><code>Update tab title for operator configuration mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-stack/tyk-operator/installing-tyk-operator.md

<li>Updated the tab title from "Self Managed" to "Licensed mode <br>(Self-managed or Tyk Cloud)".<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5324/files#diff-0b4360968306ecca2c98ec75cb33de17643269cf4ce999c6fd93b789df611d3a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

