### PR TITLE
Merging to release-5.5: test change in operator versioning still merges (#5369)

### DIFF
--- a/tyk-docs/content/getting-started/key-concepts/versioning.md
+++ b/tyk-docs/content/getting-started/key-concepts/versioning.md
@@ -234,7 +234,7 @@ We can see in the example below that one version is configured for the API withi
 - the default version (`default_version`) is `v1`
 - the `definition` configuration block contains a `location` field set to `header` and has an accompanying `key` field set to `x-api-version`. Subsequently, the version identifier for the API will be retrieved from the `x-api-version` header. The comments provide examples for how to configure the version identifier to be retrieved from URL or a named URL parameter
 - an allow list, black list and ignore authentication middleware have been configured for version `v1`
-- an alternative upstream URL (`override_target`) is configured for `v1` to send requests to `http://test.org`.
+- an alternative upstream URL (`override_target`) is configured for `v1` to send requests to `http://test.org`
 
 ```yaml {linenos=table,hl_lines=["14-17", "25-27", "29-82"], linenostart=1}
 apiVersion: tyk.tyk.io/v1alpha1


### PR DESCRIPTION
### **User description**
test change in operator versioning still merges (#5369)


___

### **PR Type**
documentation


___

### **Description**
- Made a minor formatting change in the versioning documentation by removing an unnecessary period for consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>versioning.md</strong><dd><code>Minor formatting update in versioning documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/getting-started/key-concepts/versioning.md

<li>Removed a period at the end of a sentence for consistency.<br> <li> Minor formatting change in the documentation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5370/files#diff-5f5d913588858b56d4c0e81bafaf8fb30e4ef7ae663f830509dfae2d40a7c05c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

