### PR TITLE
Merging to release-5.5: [DX-1407] Tyk Streams: Add overview page to Inputs, Outputs & Processors (#5360)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/common-configuration/processing-pipelines.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/common-configuration/processing-pipelines.md
@@ -26,4 +26,4 @@ output:
   resource: bar
 ```
 
-If the field `threads` is set to `-1` (the default) it will automatically match the number of logical CPUs available. By default almost all Tyk Streams sources will utilise as many processing threads as have been configured, which makes horizontal scaling easy.
+If the field `threads` is set to `-1` (the default) it will automatically match the number of logical CPUs available. By default almost all Tyk Streams sources will utilize as many processing threads as have been configured, which makes horizontal scaling easy.

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/inputs/overview.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/inputs/overview.md
@@ -1,0 +1,64 @@
+---
+title: Inputs
+description: Explains an overview of inputs
+tags: [ "Tyk Streams", "Stream Inputs", "Inputs" ]
+---
+
+An input is a source of data piped through an array of optional [processors]({{< ref "/product-stack/tyk-streaming/configuration/processors/overview" >}}):
+
+```yaml
+input:
+  label: my_redis_input
+
+  redis_streams:
+    url: tcp://localhost:6379
+    streams:
+      - tyk_stream
+    body_key: body
+    consumer_group: tyk_group
+
+  # Optional list of processing steps
+  processors:
+   - mapping: |
+       root.document = this.without("links")
+       root.link_count = this.links.length()
+```
+
+Some inputs have a logical end ends once the last row is consumed, when this happens the input gracefully terminates and Tyk Streams will shut itself down once all messages have been processed fully.
+
+## Brokering
+
+Only one input is configured at the root of a Tyk Streams config. However, the root input can be a [broker]({{< ref "/product-stack/tyk-streaming/configuration/inputs/broker" >}}) which combines multiple inputs and merges the streams:
+
+```yaml
+input:
+  broker:
+    inputs:
+      - kafka:
+          addresses: [ TODO ]
+          topics: [ foo, bar ]
+          consumer_group: foogroup
+
+      - redis_streams:
+          url: tcp://localhost:6379
+          streams:
+            - tyk_stream
+          body_key: body
+          consumer_group: tyk_group
+```
+
+## Labels
+
+Inputs have an optional field `label` that can uniquely identify them in observability data such as metrics and logs.
+
+<!-- TODO
+
+When know if Tyk Streams will support metrics then link to metrics
+
+Inputs have an optional field `label` that can uniquely identify them in observability data such as metrics and logs. This can be useful when running configs with multiple inputs, otherwise their metrics labels will be generated based on their composition. For more information check out the [metrics documentation][metrics.about].
+
+-->
+
+## Generating Messages
+
+It's possible to generate data with Tyk Streams using the [generate]({{< ref "/product-stack/tyk-streaming/configuration/inputs/generate" >}}) input, which is also a convenient way to trigger scheduled pipelines.

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/overview.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/overview.md
@@ -1,0 +1,109 @@
+---
+title: Outputs
+description: Explains an overview of outputs
+tags: [ "Tyk Streams", "Stream Outputs", "Outputs" ]
+---
+
+An output is a sink where we wish to send our consumed data after applying an optional array of [processors]({{< ref "/product-stack/tyk-streaming/configuration/processors/overview" >}}). Only one output is configured at the root of a Tyk Streams config. However, the output can be a [broker]({{< ref "/product-stack/tyk-streaming/configuration/outputs/broker" >}}) which combines multiple outputs under a chosen brokering pattern, or a [switch]({{< ref "/product-stack/tyk-streaming/configuration/outputs/switch" >}}) which is used to multiplex against different outputs.
+
+An output config section looks like this:
+
+```yaml
+output:
+  label: my_s3_output
+
+  aws_s3:
+    bucket: TODO
+    path: '${! meta("kafka_topic") }/${! json("message.id") }.json'
+
+  # Optional list of processing steps
+  processors:
+    - mapping: '{"message":this,"meta":{"link_count":this.links.length()}}'
+```
+
+## Back Pressure
+
+Tyk Streams outputs apply back pressure to components upstream. This means if your output target starts blocking traffic Tyk Streams will gracefully stop consuming until the issue is resolved.
+
+## Retries
+
+When a Tyk Streams output fails to send a message the error is propagated back up to the input, where depending on the protocol it will either be pushed back to the source as a Noack (e.g. AMQP) or will be reattempted indefinitely with the commit withheld until success (e.g. Kafka).
+
+It's possible to instead have Tyk Streams indefinitely retry an output until success with a [retry]({{< ref "/product-stack/tyk-streaming/configuration/outputs/retry" >}}) output. Some other outputs, such as the [broker]({{< ref "/product-stack/tyk-streaming/configuration/outputs/broker" >}}), might also retry indefinitely depending on their configuration.
+
+## Dead Letter Queues
+
+It's possible to create fallback outputs for when an output target fails using a [fallback]({{< ref "/product-stack/tyk-streaming/configuration/outputs/fallback" >}}) output:
+
+```yaml
+output:
+  fallback:
+    - aws_sqs:
+        url: https://sqs.us-west-2.amazonaws.com/TODO/TODO
+        max_in_flight: 20
+
+    - http_client:
+        url: http://backup:1234/dlq
+        verb: POST
+```
+
+## Multiplexing Outputs
+
+There are a few different ways of multiplexing in Tyk Streams, here's a quick run through:
+
+### Interpolation Multiplexing
+
+Some output fields support [field interpolation]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/interpolation" >}}), which is a super easy way to multiplex messages based on their contents in situations where you are multiplexing to the same service.
+
+For example, multiplexing against Kafka topics is a common pattern:
+
+```yaml
+output:
+  kafka:
+    addresses: [ TODO:6379 ]
+    topic: ${! meta("target_topic") }
+```
+
+Refer to the field documentation for a given output to see if it support interpolation.
+
+### Switch Multiplexing
+
+A more advanced form of multiplexing is to route messages to different output configurations based on a query. This is easy with the [switch]({{< ref "/product-stack/tyk-streaming/configuration/outputs/switch" >}}) output:
+
+```yaml
+output:
+  switch:
+    cases:
+      - check: this.type == "foo"
+        output:
+          amqp_1:
+            urls: [ amqps://guest:guest@localhost:5672/ ]
+            target_address: queue:/the_foos
+
+      - check: this.type == "bar"
+        output:
+          gcp_pubsub:
+            project: dealing_with_mike
+            topic: mikes_bars
+
+      - output:
+          redis_streams:
+            url: tcp://localhost:6379
+            stream: everything_else
+          processors:
+            - mapping: |
+                root = this
+                root.type = this.type.not_null() | "unknown"
+```
+
+## Labels
+
+Outputs have an optional field `label` that can uniquely identify them in observability data such as metrics and logs.
+
+<!--
+
+TODO replace with this paragraph when determine if product supports metrics 
+
+Outputs have an optional field `label` that can uniquely identify them in observability data such as metrics and logs. This can be useful when running configs with multiple outputs, otherwise their metrics labels will be generated based on their composition. For more information check out the [metrics documentation][metrics.about].
+
+-->

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/reject.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/reject.md
@@ -1,0 +1,37 @@
+---
+title: Reject
+description: Explains an overview of the reject output
+tags: [ "Tyk Streams", "Stream Processors", "Outputs", "Reject" ]
+---
+
+Rejects all messages, treating them as though the output destination failed to publish them.
+
+```yml
+# Config fields, showing default values
+output:
+  label: ""
+  reject: ""
+```
+
+The routing of messages after this output depends on the type of input it came from. For inputs that support propagating nacks upstream such as AMQP or NATS the message will be nacked. However, for inputs that are sequential such as files or Kafka the messages will simply be reprocessed from scratch.
+
+## Examples
+
+### Rejecting Failed Messages
+
+This input is particularly useful for routing messages that have failed during processing, where instead of routing them to some sort of dead letter queue we wish to push the error upstream. We can do this with a switch broker:
+
+```yaml
+output:
+  switch:
+    retry_until_success: false
+    cases:
+      - check: '!errored()'
+        output:
+          amqp_1:
+            urls: [ amqps://guest:guest@localhost:5672/ ]
+            target_address: queue:/the_foos
+
+      - output:
+          reject: "processing failed due to: ${! error() }"
+```

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/switch.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/switch.md
@@ -1,0 +1,165 @@
+---
+title: Switch
+description: Explains an overview of configuring switch output
+tags: [ "Tyk Streams", "Stream Outputs", "Outputs", "switch" ]
+---
+
+The switch output type allows you to route messages to different outputs based on their contents.
+
+## Common
+
+```yml
+# Common config fields, showing default values
+output:
+  label: ""
+  switch:
+    retry_until_success: false
+    cases: [] # No default (required)
+```
+
+## Advanced
+
+```yml
+# All config fields, showing default values
+output:
+  label: ""
+  switch:
+    retry_until_success: false
+    strict_mode: false
+    cases: [] # No default (required)
+```
+
+Messages that do not pass the check of a single output case are effectively dropped. In order to prevent this outcome set the field [strict_mode](#strict_mode) to `true`, in which case messages that do not pass at least one case are considered failed and will be nacked and/or reprocessed depending on your input.
+
+## Examples
+
+### Basic Multiplexing
+
+
+The most common use for a switch output is to multiplex messages across a range of output destinations. The following config checks the contents of the field `type` of messages and sends `foo` type messages to an `amqp_1` output, `bar` type messages to a `gcp_pubsub` output, and everything else to a `redis_streams` output.
+
+Outputs can have their own processors associated with them, and in this example the `redis_streams` output has a processor that enforces the presence of a type field before sending it.
+
+```yaml
+output:
+  switch:
+    cases:
+      - check: this.type == "foo"
+        output:
+          amqp_1:
+            urls: [ amqps://guest:guest@localhost:5672/ ]
+            target_address: queue:/the_foos
+
+      - check: this.type == "bar"
+        output:
+          gcp_pubsub:
+            project: dealing_with_mike
+            topic: mikes_bars
+
+      - output:
+          redis_streams:
+            url: tcp://localhost:6379
+            stream: everything_else
+          processors:
+            - mapping: |
+                root = this
+                root.type = this.type | "unknown"
+```
+
+### Control Flow
+
+The `continue` field allows messages that have passed a case to be tested against the next one also. This can be useful when combining non-mutually-exclusive case checks.
+
+In the following example a message that passes both the check of the first case as well as the second will be routed to both.
+
+```yaml
+output:
+  switch:
+    cases:
+      - check: 'this.user.interests.contains("walks").catch(false)'
+        output:
+          amqp_1:
+            urls: [ amqps://guest:guest@localhost:5672/ ]
+            target_address: queue:/people_what_think_good
+        continue: true
+
+      - check: 'this.user.dislikes.contains("videogames").catch(false)'
+        output:
+          gcp_pubsub:
+            project: people
+            topic: that_i_dont_want_to_hang_with
+```
+
+## Fields
+
+### retry_until_success
+
+If a selected output fails to send a message this field determines whether it is reattempted indefinitely. If set to false the error is instead propagated back to the input level.
+
+If a message can be routed to >1 outputs it is usually best to set this to true in order to avoid duplicate messages being routed to an output.
+
+
+Type: `bool`  
+Default: `false`  
+
+### strict_mode
+
+This field determines whether an error should be reported if no condition is met. If set to true, an error is propagated back to the input level. The default behavior is false, which will drop the message.
+
+
+Type: `bool`  
+Default: `false`  
+
+### cases
+
+A list of switch cases, outlining outputs that can be routed to.
+
+
+Type: `array`  
+
+```yml
+# Examples
+
+cases:
+  - check: this.urls.contains("http://tyk.dev")
+    continue: true
+    output:
+      cache:
+        key: ${!json("id")}
+        target: foo
+  - output:
+      s3:
+        bucket: bar
+        path: ${!json("id")}
+```
+
+### cases[].check
+
+A [Bloblang query]({{< ref "/product-stack/tyk-streaming/guides/bloblang/overview" >}}) that should return a boolean value indicating whether a message should be routed to the case output. If left empty the case always passes.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+check: this.type == "foo"
+
+check: this.contents.urls.contains("https://tyk.dev/")
+```
+
+### cases[].output
+
+An [output]({{< ref "/product-stack/tyk-streaming/configuration/outputs/overview" >}}) for messages that pass the check to be routed to.
+
+
+Type: `output`  
+
+### cases[].continue
+
+Indicates whether, if this case passes for a message, the next case should also be tested.
+
+
+Type: `bool`  
+Default: `false`  

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/for-each.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/for-each.md
@@ -12,6 +12,6 @@ label: ""
 for_each: []
 ```
 
-This is useful for forcing batch wide processors such as [dedupe]({{< ref "" >}}) or interpolations such as the `value` field of the `metadata` processor to execute on individual message parts of a batch instead.
+This is useful for forcing batch wide processors such as [dedupe]({{< ref "/product-stack/tyk-streaming/configuration/processors/dedupe" >}}) or interpolations such as the `value` field of the `metadata` processor to execute on individual message parts of a batch instead.
 
 Please note that most processors already process per message of a batch, and this processor is not needed in those cases.

--- a/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/overview.md
+++ b/tyk-docs/content/product-stack/tyk-streaming/configuration/processors/overview.md
@@ -1,0 +1,99 @@
+---
+title: Processors
+description: Explains an overview of processors
+tags: [ "Tyk Streams", "Stream Processors", "Processors" ]
+---
+
+Tyk Streams processors are functions applied to messages passing through a pipeline. The function signature allows a processor to mutate or drop messages depending on the content of the message. There are many types on offer but the most powerful are the [mapping]({{< ref "/product-stack/tyk-streaming/configuration/processors/mapping" >}}) and [mutation]({{< ref "/product-stack/tyk-streaming/configuration/processors/mutation" >}}) processors.
+
+Processors are set via config, and depending on where in the config they are placed they will be run either immediately after a specific input (set in the input section), on all messages (set in the pipeline section) or before a specific output (set in the output section). Most processors apply to all messages and can be placed in the pipeline section:
+
+```yaml
+pipeline:
+  threads: 1
+  processors:
+    - label: my_mapping
+      mapping: |
+        root.message = this
+        root.meta.link_count = this.links.length()
+```
+
+The `threads` field in the pipeline section determines how many parallel processing threads are created. You can read more about parallel processing in the [pipeline guide]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/processing-pipelines" >}}).
+
+## Labels
+
+<!-- 
+
+TODO: Replace paragraph below in subsequent iteration when know if metrics supported from product
+
+Processors have an optional field `label` that can uniquely identify them in observability data such as metrics and logs. This can be useful when running configs with multiple nested processors, otherwise their metrics labels will be generated based on their composition. For more information check out the [metrics documentation].
+
+-->
+
+Processors have an optional field `label` that can uniquely identify them in observability data such as metrics and logs.
+
+## Error Handling
+
+Some processors have conditions whereby they might fail. Rather than throw these messages into the abyss Tyk Streams still attempts to send these messages onwards, and has mechanisms for filtering, recovering or dead-letter queuing messages that have failed which can be read about in the [error handling]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/error-handling" >}}) section.
+
+### Error Logs
+
+Errors that occur during processing can be roughly separated into two groups; those that are unexpected intermittent errors such as connectivity problems and those that are logical errors such as bad input data or unmatched schemas.
+
+All processing errors result in the messages being flagged as failed and debug level logs being emitted that describe the error. Only errors that are known to be intermittent are also logged at the error level.
+
+<!-- 
+
+TODO: Subsequent iteration when know if metrics supported from product
+
+All processing errors result in the messages being flagged as failed, [error metrics][metrics.about] increasing for the given errored processor, and debug level logs being emitted that describe the error. Only errors that are known to be intermittent are also logged at the error level.
+
+-->
+
+The reason for this behavior is to prevent noisy logging in cases where logical errors are expected and will likely be [handled in config]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/error-handling" >}}). However, this can also sometimes make it easy to miss logical errors in your configs when they lack error handling. 
+
+<!-- We cannot include this yet until CLI and config functionality is provided
+
+If you suspect you are experiencing processing errors and do not wish to add error handling yet then a quick and easy way to expose those errors is to enable debug level logs with the cli flag `--log.level=debug` or by setting the level in config:
+
+```yaml
+logger:
+  level: DEBUG
+```
+-->
+
+## Using Processors as Outputs
+
+It might be the case that a processor that results in a side effect, such as the [redis]({{< ref "/product-stack/tyk-streaming/configuration/processors/redis" >}}) processor, is the only side effect of a pipeline, and therefore could be considered the output.
+
+In such cases it's possible to place these processors within a [reject]({{< ref "/product-stack/tyk-streaming/configuration/outputs/reject" >}}) output so that they behave the same as regular outputs, where success results in dropping the message with an acknowledgement and failure results in a nack (or retry):
+
+```yaml
+output:
+  reject: 'failed to send data: ${! error() }'
+  processors:
+    - try:
+        - redis:
+            url: tcp://localhost:6379
+            command: sadd
+            args_mapping: 'root = [ this.key, this.value ]'
+        - mapping: root = deleted()
+```
+
+The way this works is that if your processor with the side effect (`redis` in this case) succeeds then the final `mapping` processor deletes the message which results in an acknowledgement. If the processor fails then the `try` block exits early without executing the `mapping` processor and instead the message is routed to the `reject` output, which nacks the message with an error message containing the error obtained from the `redis` processor.
+
+## Batching and Multiple Part Messages
+
+All Tyk Streams processors support multiple part messages, which are synonymous with batches.
+
+<!-- TODO: Add referring link to windowed_processing when determine from product if this feature is supported 
+
+All Tyk Streams processors support multiple part messages, which are synonymous with batches. This enables some cool [windowed processing][windowed_processing] capabilities.
+
+-->
+
+Many processors are able to perform their behaviors on specific parts of a message batch, or on all parts, and have a field `parts` for specifying an array of part indexes they should apply to. If the list of target parts is empty these processors will be applied to all message parts.
+
+Part indexes can be negative, and if so the part will be selected from the end counting backwards starting from -1. E.g. if part = -1 then the selected part will be the last part of the message, if part = -2 then the part before the last element will be selected, and so on.
+
+Some processors such as [dedupe]({{< ref "/product-stack/tyk-streaming/configuration/processors/dedupe" >}}) act across an entire batch, when instead we might like to perform them on individual messages of a [batch]({{< ref "/product-stack/tyk-streaming/configuration/common-configuration/batching" >}}). In this case the [for_each]({{< ref "/product-stack/tyk-streaming/configuration/processors/for-each" >}}) processor can be used.

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -4042,6 +4042,10 @@ menu:
           category: Directory
           show: True
           menu:
+          - title: "Overview"
+            path: /product-stack/tyk-streaming/configuration/inputs/overview
+            category: Page
+            show: True
           - title: "Amqp_0_9"
             path: /product-stack/tyk-streaming/configuration/inputs/amqp-0-9
             category: Page
@@ -4094,6 +4098,10 @@ menu:
           category: Directory
           show: True
           menu:
+          - title: "Overview"
+            path: /product-stack/tyk-streaming/configuration/outputs/overview
+            category: Page
+            show: True
           - title: "Amqp_0_9"
             path: /product-stack/tyk-streaming/configuration/outputs/amqp-0-9
             category: Page
@@ -4146,6 +4154,10 @@ menu:
             path: /product-stack/tyk-streaming/configuration/outputs/redis-pubsub
             category: Page
             show: True
+          - title: "Reject"
+            path: /product-stack/tyk-streaming/configuration/outputs/reject
+            category: Page
+            show: True
           - title: "Retry"
             path: /product-stack/tyk-streaming/configuration/outputs/retry
             category: Page
@@ -4158,6 +4170,10 @@ menu:
             path: /product-stack/tyk-streaming/configuration/outputs/stdout
             category: Page
             show: True
+          - title: "Switch"
+            path: /product-stack/tyk-streaming/configuration/outputs/switch
+            category: Page
+            show: True
           - title: "Sync Response"
             path: /product-stack/tyk-streaming/configuration/outputs/sync-response
             category: Page
@@ -4166,6 +4182,10 @@ menu:
           category: "Directory"
           show: True
           menu:
+          - title: "Overview"
+            path: /product-stack/tyk-streaming/configuration/processors/overview
+            category: Page
+            show: True
           - title: "Avro"
             path: /product-stack/tyk-streaming/configuration/processors/avro
             category: Page


### PR DESCRIPTION
### **User description**
[DX-1407] Tyk Streams: Add overview page to Inputs, Outputs & Processors (#5360)

add overview pages for inputs, outputs & processors

---------

Co-authored-by: Simon Pears <simon@tyk.io>

[DX-1407]: https://tyktech.atlassian.net/browse/DX-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Added new overview documentation pages for Tyk Streams inputs, outputs, and processors, providing detailed explanations and examples.
- Updated the menu structure to include links to the new documentation pages.
- Corrected spelling and reference links in existing documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>processing-pipelines.md</strong><dd><code>Correct spelling in processing pipelines documentation.</code>&nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/common-configuration/processing-pipelines.md

- Corrected spelling from "utilise" to "utilize".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5372/files#diff-23d021e24523f3121d716435546ded4aea34c918c0f57c4909bf34a1b1952331">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>overview.md</strong><dd><code>Add overview documentation for Tyk Streams inputs.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/inputs/overview.md

<li>Added an overview page for inputs in Tyk Streams.<br> <li> Explained the concept of inputs and brokering.<br> <li> Described the use of labels and message generation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5372/files#diff-137bb33185e963bd4a676922003151ddf16600dea74012d563b41970f9055571">+64/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>overview.md</strong><dd><code>Add overview documentation for Tyk Streams outputs.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/overview.md

<li>Added an overview page for outputs in Tyk Streams.<br> <li> Explained back pressure, retries, and dead letter queues.<br> <li> Described multiplexing outputs and the use of labels.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5372/files#diff-110b780ea9638891d3486e05821ce38aec096ec3ac088363573b6a00bc1f3cbd">+109/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reject.md</strong><dd><code>Document reject output configuration in Tyk Streams.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/reject.md

<li>Introduced a page for the reject output in Tyk Streams.<br> <li> Explained the use of reject output for failed message routing.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5372/files#diff-83b6017502b312025b46d454e7e7bf73bb10f0446211ae567059f0734eec0b2f">+37/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>switch.md</strong><dd><code>Add documentation for switch output configuration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/outputs/switch.md

<li>Added documentation for configuring switch outputs.<br> <li> Provided examples of basic and advanced multiplexing.<br> <li> Explained fields like retry_until_success and strict_mode.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5372/files#diff-a357a64f3a040b2324a8ac9d4afdc894314676ff6afdbe100d5cb652dcde044d">+165/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>for-each.md</strong><dd><code>Fix reference link in for-each processor documentation.</code>&nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/for-each.md

- Corrected the reference link for the dedupe processor.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5372/files#diff-7627ecf1a91b06c2198c4addd073e73b0cdccdeb5ca44b61b8f9f1adf7bba825">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>overview.md</strong><dd><code>Add overview documentation for Tyk Streams processors.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-streaming/configuration/processors/overview.md

<li>Added an overview page for processors in Tyk Streams.<br> <li> Explained processor configuration and error handling.<br> <li> Discussed using processors as outputs and handling batches.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5372/files#diff-c181e013fe2b2f5bfd96eb330e1b1cc04a8cdca2cc0dd188cd4bcc8f7e0a7539">+99/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Update menu structure to include new documentation pages.</code></dd></summary>
<hr>

tyk-docs/data/menu.yaml

<li>Updated menu to include new overview pages for inputs, outputs, and <br>processors.<br> <li> Added entries for reject and switch outputs.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5372/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

