### PR TITLE
Merging to release-5.4: DX-1672 Add path-based permission example for Operator (#5375)

### DIFF
--- a/tyk-docs/content/tyk-stack/tyk-operator/secure-an-api.md
+++ b/tyk-docs/content/tyk-stack/tyk-operator/secure-an-api.md
@@ -121,6 +121,10 @@ spec:
       namespace: default
       versions:
         - Default               # Mandatory, Default is created automatically
+      allowed_urls:             # Path-based permissions
+        - url: /get
+          methods:
+            - GET
   quota_max: 10
   quota_renewal_rate: 60
   rate: 5
@@ -145,6 +149,10 @@ Required fields in the policy:
 Access lists for API and versions:
 
 - `access_right_array`: The list of APIs security policy has access to.
+
+Path-based permissions for API:
+
+- `allowed_urls`: Restrict access per path and per method to specific portions of the API
 
 Usage Quota fields:
 


### PR DESCRIPTION
### **User description**
DX-1672 Add path-based permission example for Operator (#5375)

* Update secure-an-api.md
---------

Co-authored-by: Komal Sukhani <komaldsukhani@gmail.com>


___

### **PR Type**
documentation


___

### **Description**
- Added a new section in the documentation to demonstrate path-based permissions for the Tyk Operator.
- Introduced the `allowed_urls` configuration to restrict API access based on specific paths and HTTP methods.
- Enhanced the security documentation with examples of how to implement these permissions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secure-an-api.md</strong><dd><code>Add path-based permission example to API security documentation</code></dd></summary>
<hr>

tyk-docs/content/tyk-stack/tyk-operator/secure-an-api.md

<li>Added an example of path-based permissions for APIs.<br> <li> Introduced <code>allowed_urls</code> to restrict access per path and method.<br> <li> Updated documentation to include new permission settings.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5395/files#diff-62583238874aadf2fcc63ad539d89257c7bd38c3b7d35bf52a30015156f26dd4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

