### PR TITLE
Merging to release-5.4: remove publish time (#5404)

### DIFF
--- a/tyk-docs/config.toml
+++ b/tyk-docs/config.toml
@@ -37,7 +37,7 @@ showEmptyPages = false
     endLevel = 5
     ordered = true
 [frontmatter]
-lastmod = ["lastmod", ":git",':fileModTime', "date", "publishDate"]
+lastmod = ["lastmod", "publishDate", ":git",':fileModTime', "date"]
 [outputFormats.urlcheck]
    mediaType = "application/json"
    baseName = "urlcheck"

--- a/tyk-docs/content/tyk-on-prem/kubernetes-on-windows.md
+++ b/tyk-docs/content/tyk-on-prem/kubernetes-on-windows.md
@@ -1,5 +1,4 @@
 ---
-publishdate: 2020-03-09
 lastmod: 2020-03-09
 title: Deploy Tyk Self managed On Windows Using Helm
 tags: ["Tyk Stack", "Self Managed", "Installation", "Kubernetes", "Helm Chart", "Helm", "Windows", "Tyk Self managed", "Tyk Pro", "API Management"]


### PR DESCRIPTION
### **User description**
remove publish time (#5404)


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Removed `publishDate` from the `lastmod` array in the `config.toml` file to streamline metadata handling.
- Deleted the `publishdate` metadata from the Kubernetes on Windows documentation to ensure consistency with other documents.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.toml</strong><dd><code>Modify lastmod array to remove publishDate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/config.toml

<li>Removed <code>publishDate</code> from the <code>lastmod</code> array.<br> <li> Adjusted the order of elements in the <code>lastmod</code> array.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5406/files#diff-b5607885ca99f865246defbac60f7998022af1e5da2cba05d27eac99e12a15fa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kubernetes-on-windows.md</strong><dd><code>Remove publishdate metadata from Kubernetes on Windows doc</code></dd></summary>
<hr>

tyk-docs/content/tyk-on-prem/kubernetes-on-windows.md

- Removed `publishdate` metadata from the document.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5406/files#diff-5d3878134875b999318fb4e8291493ae54b65f359347a9723b053ace07b4e556">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

