### PR TITLE
Merging to release-5.5: fix user roles table for tyk cloud (#5414)

### DIFF
--- a/tyk-docs/content/tyk-cloud/teams-&-users/user-roles.md
+++ b/tyk-docs/content/tyk-cloud/teams-&-users/user-roles.md
@@ -49,7 +49,7 @@ The following table shows the scope for each user role.
 | Delete / change environments                      |               | X         | X          |              |
 | View environments                                 |               | X         | X          | X            |
 | Create and delete cloud data planes               |               | X         | X          |              |
-| Create and delete control planes                  |               | X         | X          | X            |
+| Create and delete control planes                  |               | X         | X          |              |
 | View deployments                                  |               | X         | X          | X            |
 | Deploy, undeploy, redeploy, restart a deployment. |               | X         | X          | X            |
 | Create and manage basic SSO                       |               | X         | X          |              |


### PR DESCRIPTION
### **User description**
fix user roles table for tyk cloud (#5414)


___

### **PR Type**
documentation


___

### **Description**
- Updated the user roles table in the Tyk Cloud documentation.
- Removed the permission for creating and deleting control planes from a specific user role.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user-roles.md</strong><dd><code>Update user roles table for Tyk Cloud documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-cloud/teams-&-users/user-roles.md

<li>Updated the user roles table for Tyk Cloud.<br> <li> Removed permission for creating and deleting control planes from a <br>specific role.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5421/files#diff-52c9fcffe4c098b51fae51278fea19c51019a009961928de1c9b3f2be1b45447">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

