### PR TITLE
Merging to release-5.3: fix user roles table for tyk cloud (#5414)

### DIFF
--- a/tyk-docs/content/tyk-cloud/teams-&-users/user-roles.md
+++ b/tyk-docs/content/tyk-cloud/teams-&-users/user-roles.md
@@ -49,7 +49,7 @@ The following table shows the scope for each user role.
 | Delete / change environments                      |               | X         | X          |              |
 | View environments                                 |               | X         | X          | X            |
 | Create and delete cloud data planes               |               | X         | X          |              |
-| Create and delete control planes                  |               | X         | X          | X            |
+| Create and delete control planes                  |               | X         | X          |              |
 | View deployments                                  |               | X         | X          | X            |
 | Deploy, undeploy, redeploy, restart a deployment. |               | X         | X          | X            |
 | Create and manage basic SSO                       |               | X         | X          |              |


### PR DESCRIPTION
### **User description**
fix user roles table for tyk cloud (#5414)


___

### **PR Type**
documentation


___

### **Description**
- Updated the Tyk Cloud user roles documentation to accurately reflect the permissions for creating and deleting control planes.
- Removed the ability for a specific user role to create and delete control planes in the documentation table.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user-roles.md</strong><dd><code>Update user roles table for Tyk Cloud documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-cloud/teams-&-users/user-roles.md

<li>Updated the user roles table for Tyk Cloud.<br> <li> Removed the ability for a specific role to create and delete control <br>planes.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5422/files#diff-52c9fcffe4c098b51fae51278fea19c51019a009961928de1c9b3f2be1b45447">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

