### PR TITLE
Merging to release-5.4: Update reference to commit hash (#5426)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/advanced-configurations/plugins/golang/go-development-flow.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/advanced-configurations/plugins/golang/go-development-flow.md
@@ -33,7 +33,7 @@ The commands in the following sections will create a `go.mod` file inside your f
 
 In Gateway version 5.1, the Gateway and plugins transitioned to using [Go modules builds](https://go.dev/ref/mod#introduction).
 
-The example below shows the set of commands for initialising a plugin for compatibility with Tyk Gateway 5.1.2.
+The example below shows the set of commands for initialising a plugin for compatibility with Tyk Gateway 5.2.1.
 
 ```bash
 mkdir tyk-plugin
@@ -43,7 +43,7 @@ go get github.com/TykTechnologies/tyk@ffa83a27d3bf793aa27e5f6e4c7106106286699d
 go mod tidy
 ```
 
-In the example above notice that the commit hash was used for [Tyk Gateway 5.1.2](https://github.com/TykTechnologies/tyk/releases?q=5.1.2&expanded=true)
+In the example above notice that the commit hash was used for [Tyk Gateway 5.2.1](https://github.com/TykTechnologies/tyk/releases/tag/v5.2.1)
 
 #### Initialise plugin for Tyk Gateway versions between v4.2 and v5.0
 


### PR DESCRIPTION
### **User description**
Update reference to commit hash (#5426)

Fixed a typo pointing to wrong version hash (5.1.2) should be (5.2.1)


___

### **PR Type**
documentation


___

### **Description**
- Updated the documentation to correct the version reference from 5.1.2 to 5.2.1 for Tyk Gateway.
- Fixed the commit hash link to point to the correct Tyk Gateway 5.2.1 release.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go-development-flow.md</strong><dd><code>Correct version reference and commit hash in documentation</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/advanced-configurations/plugins/golang/go-development-flow.md

<li>Updated version reference from 5.1.2 to 5.2.1.<br> <li> Corrected the commit hash link for Tyk Gateway version.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5430/files#diff-a016b8ec7c2d819cf621ca429358871dee8495a009193e1dc45d82609aa8e728">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

