### PR TITLE
Merging to release-5.3: [TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)

### DIFF
--- a/tyk-docs/assets/scss/_bespoke.scss
+++ b/tyk-docs/assets/scss/_bespoke.scss
@@ -498,7 +498,7 @@ blockquote {
 }
 
 blockquote:before {
-  content: '\e803';
+/*  content: '\e803'; */
   height: 32px;
   font-size: 26px;
   position: relative;

--- a/tyk-docs/content/getting-started/key-concepts/url-matching.md
+++ b/tyk-docs/content/getting-started/key-concepts/url-matching.md
@@ -1,0 +1,323 @@
+---
+title: URL Path Matching
+tags:
+    - URL path matching
+    - Regular expressions
+    - Secure access
+    - Middleware
+    - Routing
+    - Endpoint
+    - Listen path
+description: Overview of URL path matching with the Tyk Gateway
+date: "2024-08-30"
+---
+
+When a request is made to an API hosted on Tyk Gateway, the gateway matches the incoming URL path against routes (patterns) defined in the API definition. Matching the request path against the *listen path* of an API exposed on the gateway is the first step for Tyk determining how to handle the request. Tyk provides a very flexible and configurable approach to URL path matching to support a wide range of use cases.
+ 
+Understanding this process is crucial because it directly impacts how URLs are routed and matched, influencing both API behavior and security controls.
+
+
+## What is URL path matching?
+
+URL path matching defines the rules for how request URLs are compared to
+predefined patterns, determining whether they should trigger certain
+routes, middleware, or security policies. This is especially important
+for developers configuring APIs and middleware to control which endpoints
+are exposed, restricted, or protected.
+
+When configuring APIs, precise URL path matching helps developers:
+
+1. **Control Access to Endpoints**: By using strict or flexible URL path matching patterns, you can fine-tune which routes are exposed to users or external systems.
+2. **Simplify Routing Logic**: Instead of defining individual routes for each endpoint, URL path matching lets you group similar routes using patterns, reducing complexity.
+3. **Enhance Security**: Properly defined URL path matching patterns are essential for enforcing security policies, like blocking or allowing access to specific resources.
+
+URL path matching is fundamental to the behavior of various Tyk middleware, including:
+
+- [Granular access control]({{< ref "security/security-policies/secure-apis-method-path" >}})
+- [Allow List]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware" >}})
+- [Block List]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware" >}})
+- [Request and Response transformation]({{< ref "advanced-configuration/transform-traffic" >}})
+
+{{< note success >}}
+**Note**  
+
+The [URL Rewriting]({{< ref "transform-traffic/url-rewriting#how-url-rewriting-works" >}}) middleware's
+rule check implements regular expression matching only: it does not apply URL path matching logic and is not
+affected by the configurations described in this section
+{{< /note >}}
+
+
+## When might you want to control URL path matching?
+
+Understanding the Gateway's URL path matching behavior is essential in scenarios such as:
+
+- **API Versioning**: You may want to allow different versions of an API, such as `/v1/users` and `/v2/users`, while still matching certain common paths or endpoints.
+- **Middleware Control**: Middleware often relies on URL path matching to determine when specific behaviors, such as rate limiting or authentication, should be applied.
+- **Security Policies**: URL path matching ensures that security policies, such as allow or block lists, are enforced for the correct paths without mistakenly leaving critical routes unprotected.
+
+By fine-tuning these configurations, developers can create robust,
+secure, and maintainable routing rules tailored to their specific use
+cases.
+
+
+## Structure of the API request
+
+When a client makes a request to an API hosted on Tyk Gateway, they provide an HTTP method and *request path*. This *request path* will comprise the host (or domain) name for the Gateway, the API *listen path* and then (optionally) the *endpoint path*.
+
+The *listen path* is a mandatory field defined in the API definition loaded onto the Gateway. Tyk will compare the incoming *request path* (after stripping off the host name) against all registered *listen paths* to identify the API definition (and hence Gateway configuration) that should be used to handle the request. If no match is found, then Tyk will reject the request with `HTTP 404 Not Found`.
+
+If a match is found, Tyk will then handle the request according to the configuration in the matching API definition. The *endpoint path* will be compared against any endpoints defined in the API definition to determine which endpoint-level configuration (such as transformation middleware) should be applied to the request.
+
+### Listen path
+
+Tyk treats the *listen path* configured in the API definition as a regex, allowing advanced users to perform complex listen path matching by setting a regex in the API definition.
+
+The [strict routes]({{< ref "tyk-oss-gateway/configuration#http_server_optionsenable_strict_routes" >}}) option in the Tyk Gateway configuration is provided to avoid nearest-neighbour requests on overlapping routes. If this is set to `true` then Tyk will perform an exact match of the request against the configured *listen path* including the trailing `/` used to mark the end of the *listen path*. For example:
+- with strict routes enabled, an API with *listen path* set to `/app` will match requests to `/app`, `/app/` and `/app/*` but will not match `/app1/*` or `/apple/`
+- without strict routes, all of the above requests would match to the API with *listen path* set to `/app`
+
+<br>
+{{< note success >}}
+**Note**  
+
+Tyk is acting as a secure proxy between the client and upstream service, so when proxying the request upstream, it will replace the Gateway's *host name* with the *target URL* configured in the API definition.
+<br>
+Thus a request to `<gateway-address>/<listen-path>/<version-identifier>/<endpoint-path>` will be proxied to `<target-url>/<listen-path>/<version-identifier>/<endpoint-path>`.
+<br>
+The [strip listen path]({{< ref "tyk-apis/tyk-gateway-api/api-definition-objects/proxy-settings#proxystrip_listen_path" >}}) option is provided to remove the *listen path* from the upstream request; this allows differentiation between the publicly exposed API and private upstream API, for example to provide a cleaner, user-friendly facade to a legacy upstream service.
+{{< /note >}}
+
+### Versioning identifier
+
+If [URL path versioning]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#request-url-path" >}}) is in use for an API, Tyk will perform a match of the first fragment after the *listen path* to identify which version of the API should be invoked.
+
+### Endpoint path
+
+The remainder of the *request path* after any version identifier is considered to be the *endpoint path* (which may be simply `/`). When performing a match against endpoints configured in the API definition, Tyk treats the configured patterns as regular expressions, allowing advanced users to perform complex endpoint path matching by use of regexes in their API definitions.
+
+
+## Pattern matching 
+
+Tyk supports a wide range of patterns when defining *listen path* and *endpoint paths* in API definitions, through the interpretation of the configured pattern as a regular expression during the matching operation. It's easiest to consider three categories of patterns of increasing complexity:
+
+### 1. **Basic matching**
+
+Basic path matching involves the direct comparison of a path against a fixed pattern, for example setting the *listen path* pattern to `/users`.
+
+### 2. **Dynamic path parameter matching**
+
+The use of path parameters in the pattern allow for dynamic segments in requests, commonly used for dynamic routing. This is particularly useful for APIs where resource identifiers or user-specific endpoints need to be handled.
+
+For example, the pattern `/users/{id}` would match any URL of the form `/users/123`, where `123` is treated as a dynamic segment.
+
+Tyk converts dynamic path segments in the configured pattern into capturing groups in the regular expression (`([^/]+)`)as follows (note that these examples include the `^` and `$` that are added when [exact matching](#exact-match) is in use):
+
+|   | **Path pattern**                   | **Regular Expression used in match** |
+|---|------------------------------------|--------------------------------------|
+| 1 | `/users/{id}`                      | `^/users/([^/]+)$`                   |
+| 2 | `/static/{path}/assets/{file}`     | `^/static/([^/]+)/assets/[^/]+)$`    |
+| 3 | `/orders/{orderId}/items/{itemId}` | `^/orders/([^/]+)/items/([^/]+)$`    |
+| 4 | `/orders/{orderId}/items/{itemId}` | `^/orders/([^/]+)/items/([^/]+)$`    |
+
+1. Matches `/users/123`, where `id` is dynamic.
+2. Matches `/static/images/assets/logo.png`, where `path` and `file` are dynamic.
+3. Matches `/orders/456/items/789`, where `orderId` and `itemId` are dynamic.
+4. Matches `/orders/456/items/789`, where `orderId` and `itemId` are dynamic.
+
+You can replace any dynamic path segment with a `*` (wildcard) (or `{*}` in older versions) to take advantage of unnamed parameters, for example: taking example (3) from above, you can define the pattern as `/orders/*/items/*` and Tyk will interpret this as the same regular expression (`^/orders/([^/]+)/items/([^/]+)$`).
+
+### 3. **Advanced pattern matching**
+
+Advanced pattern matching involves the use of more complex regular expressions in the configured patterns, enabling developers to define granular rules that handle varied use cases such as versioning, optional parameters, and multiple route patterns.
+
+You can include regular expressions as dynamic path segments in the *listen path* pattern. Tyk will automatically convert these into capturing groups as follows (note that these examples include the `^` and `$` that are added when [exact matching](#exact-match) is in use):
+
+|   | **Listen path pattern**                      | **Regular Expression used in match**      |
+|---|----------------------------------------------|-------------------------------------------|
+| 1 | `/users/{id}/profile/{type:[a-zA-Z]+}`       | `^/users/([^/]+)/profile/([a-zA-Z]+)$`    |
+| 2 | `/items/{itemID:[0-9]+}/details/{detail}`    | `^/items/([0-9]+)/details/([^/]+)$`       |
+| 3 | `/products/{productId}/reviews/{rating:\d+}` | `^/products/([^/]+)/reviews/(\d+)$`       |
+
+1. Matches paths where `id` is dynamic, and `type` only includes alphabetic characters.
+2. Matches paths like `/items/45/details/overview`, where `itemID` is a number and `detail` is dynamic.
+3. Matches paths like `/products/987/reviews/5`, where `productId` is dynamic and `rating` must be a digit.
+
+With *endpoint path* patterns, however, the logic is more limited. The conversion will be as follows, matching any path segment but not using the regular expression defined in the named parameter (again note that these examples include the `^` and `$` that are added when [exact matching](#exact-match) is in use):
+
+|   | **User Input**                               | **Converted Regular Expression**     |
+|---|----------------------------------------------|--------------------------------------|
+| 1 | `/users/{id}/profile/{type:[a-zA-Z]+}`       | `^/users/([^/]+)/profile/([^/]+)$`    |
+| 2 | `/items/{itemID:[0-9]+}/details/{detail}`    | `^/items/([^/]+)/details/([^/]+)$`    |
+| 3 | `/products/{productId}/reviews/{rating:\d+}` | `^/products/([^/]+)/reviews/([^/]+)$` |
+
+##### Example - ULID validation for a route
+
+For a non-trivial example of regex pattern matching, one can configure a
+complex expression to match [ULID](https://github.com/ulid/spec) values:
+
+- `^/users/(?i)[0-7][0-9A-HJKMNP-TV-Z]{25}$`
+- [Go playground test example](https://go.dev/play/p/nlLUQmVxKsp)
+- Using `(?i)` makes the particular matching case-insensitive
+
+The explicit behavior of the pattern match is to match the pattern by
+prefix all the way to the end of the defined pattern.
+
+The input has full go regex (RE2) support. See
+[pkg.go.dev/regexp](https://pkg.go.dev/regexp) for details.
+
+
+## Path matching modes
+
+Tyk Gateway can be configured to perform path matching in one of four modes:
+
+- [wildcard](#wildcard-match) which matches the pattern to any part of the path
+- [prefix](#prefix-match) which matches the pattern against the start of the path
+- [suffix](#suffix-match) which matches the pattern against the end of the path
+- [exact](#exact-match) which combines prefix and suffix matches
+
+This configuration can be set in the Gateway config file (`tyk.conf`) or using the equivalent environment variables, as described below.
+
+The default behavior of Tyk Gateway is *wildcard* matching as both prefix and suffix controls default to `false`; the introduction of these controls does not change the behavior of any existing API definitions unless either is set to `true` to enforce a different path matching mode.
+
+**Tyk recommends the use of exact path matching with [strict routes](#listen-path) for most use cases**
+
+### Wildcard match
+
+If neither [prefix](#prefix-match) nor [suffix](#suffix-match) configuration options is set to `true`, Tyk will perform wildcard matching. In this mode, Tyk will attempt to match the pattern with any part of the URL path.
+
+For example, the pattern `/user` will match all of the following URLs:
+
+- `/my-api/user`
+- `/my-api/users`
+- `/my-api/v2/user/12345`
+- `/my-api/groups/12/username/abc`
+
+### Prefix match
+
+When [EnablePathPrefixMatching]({{< ref "tyk-oss-gateway/configuration#http_server_options" >}}) is enabled, the Gateway switches to prefix matching where it treats the configured pattern as a prefix which will only match against the beginning of the path. For example, a pattern such as `/json` will only match request URLs that begin with `/json`, rather than matching any URL containing `/json`.
+
+The gateway checks the request URL against several variations depending on whether path versioning is enabled:
+
+- Full path (listen path + version + endpoint): `/listen-path/v4/json`
+- Non-versioned full path (listen path + endpoint): `/listen-path/json`
+- Path without version (endpoint only): `/json`
+
+The logic behind prefix matching is that it prepends the start of string symbol (`^`) if the URL begins with a `/`, to ensure that the URL begins with the specified pattern. For example, `/json` would be evaluated as `^/json`.
+
+For patterns that already start with `^`, the gateway will already perform prefix matching so `EnablePathPrefixMatching` will have no impact.
+
+This option allows for more specific and controlled routing of API requests, potentially reducing unintended matches. Note that you may need to adjust existing route definitions when enabling this option.
+
+Example:
+
+- with wildcard matching, `/json` might match `/api/v1/data/json`.
+- with prefix matching, `/json` would not match `/api/v1/data/json`, but would match `/json/data`.
+
+### Suffix match
+
+When [EnablePathSuffixMatching]({{< ref "tyk-oss-gateway/configuration#http_server_options" >}}) is enabled, the Gateway switches to suffix matching where it treats the configured pattern as a suffix which will only match against the end of the path. For example, a pattern such as `/json` will only match request URLs that end with `/json`, rather than matching any URL containing `/json`.
+
+The gateway checks the request URL against several variations depending on whether path versioning is enabled:
+- Full path (listen path + version + endpoint): `/listen-path/v4/json`
+- Non-versioned full path (listen path + endpoint): `/listen-path/json`
+- Path without version (endpoint only): `/json`
+
+The logic behind prefix matching is that it appends the end of string symbol (`$`), to ensure that the URL ends with the specified pattern. For example, `/json` would be evaluated as `/json$`.
+
+For patterns that already end with `$`, the gateway will already perform suffix matching so EnablePathSuffixMatching will have no impact.
+
+This option allows for more specific and controlled routing of API requests, potentially reducing unintended matches. Note that you may need to adjust existing route definitions when enabling this option.
+
+Example:
+
+- with wildcard matching, `/json` might match `/api/v1/json/data`.
+- with suffic matching, `/json` would not match `/api/v1/json/data`, but would match `/data/json`.
+
+### Exact match
+
+Exact URL path matching combines [prefix](#prefix-match) and [suffix](#suffix-match) matching, to ensure that the URL exactly matches the required pattern.
+
+For example, enabling both flags would result in `/json` being treated as `^/json$`, ensuring the URL exactly matches `/json` with no additional characters before or after it. This allows matching against any of the matching paths explicitly:
+
+- `/listen-path/v4/json` - targeting API by listen path and version
+- `/v4/json` - only targeting the version for any API
+- `/json` - only targeting the endpoint
+
+When we consider that keys and policies may apply access rights over multiple APIs, exact matching allows for fine-grained access policies targeting individual APIs, versions or endpoints.
+
+### Overriding the configured matching mode
+
+The Gateway-wide configuration of prefix and/or suffix matching can be overridden for an API or endpoint by manual addition of the control characters (`^` and `$`) or by omission of the `/` prefix from the pattern as follows:
+
+- if you include `^` at the start of the listen path/endpoint definition the Gateway will apply prefix matching when checking against this pattern
+- if you include `$` at the end of the listen path/endpoint definition the Gateway will apply prefix matching when checking against this pattern
+- if you omit the leading `/` from the listen path/endpoint definition then *prefix* matching will *not* be applied even if set in the Gateway config
+
+Note that if suffix matching is configured in the Gateway config this cannot be overridden using control characters in the pattern, though wildcard matches can be achieved by defining a full regular expression that starts with `^/` and ends with a `$`
+
+##### Summary of the effect of control characters with Gateway settings
+
+The following table indicates the matching that will be performed by the Gateway for different combinations of prefix and suffix modes with different patterns, demonstrating how the use of the `^` and `$` symbols in your *listen path* and *endpoint path* patterns will interact with the configured matching mode.
+
+| Prefix mode | Suffix mode | Pattern | Effective matching mode |
+|--------|--------|------|--------|
+| ❌️ | ❌️ | `/my-api/my-endpoint/{my-param}` | wildcard |
+| ✅  | ❌️ | `/my-api/my-endpoint/{my-param}` | prefix |
+| ❌️ | ✅  | `/my-api/my-endpoint/{my-param}` | suffix |
+| ✅  | ✅  | `/my-api/my-endpoint/{my-param}` | exact |
+| ❌️ | ❌️ | `^/my-api/my-endpoint/{my-param}` | prefix |
+| ✅  | ❌️ | `^/my-api/my-endpoint/{my-param}` | prefix |
+| ❌️ | ✅  | `^/my-api/my-endpoint/{my-param}` | exact |
+| ✅  | ✅  | `^/my-api/my-endpoint/{my-param}` | exact |
+| ❌️ | ❌️ | `/my-api/my-endpoint/{my-param}$` | suffix |
+| ✅  | ❌️ | `/my-api/my-endpoint/{my-param}$` | exact |
+| ❌️ | ✅  | `/my-api/my-endpoint/{my-param}$` | suffix |
+| ✅  | ❌️ | `/my-api/my-endpoint/{my-param}$` | exact |
+| ❌️ | ❌️ | `^/my-api/my-endpoint/{my-param}$` | exact |
+| ✅  | ❌️ | `^/my-api/my-endpoint/{my-param}$` | exact |
+| ❌️ | ✅  | `^/my-api/my-endpoint/{my-param}$` | exact |
+| ✅  | ✅  | `^/my-api/my-endpoint/{my-param}$` | exact |
+| ❌️ | ❌️ | `my-api/my-endpoint/{my-param}` | wildcard |
+| ✅  | ❌️ | `my-api/my-endpoint/{my-param}` | wildcard |
+| ❌️ | ✅  | `my-api/my-endpoint/{my-param}` | suffix |
+| ✅  | ✅  | `my-api/my-endpoint/{my-param}` | suffix |
+| ❌️ | ❌️ | `/my-api/my-endpoint/*` | wildcard |
+| ✅  | ❌️ | `/my-api/my-endpoint/*` | prefix |
+| ❌️ | ✅  | `/my-api/my-endpoint/*` | wildcard |
+| ✅  | ✅  | `/my-api/my-endpoint/*` | prefix |
+| ❌️ | ❌️ | `my-api/my-endpoint/*` | wildcard |
+| ✅  | ❌️ | `my-api/my-endpoint/*` | wildcard |
+| ❌️ | ✅  | `my-api/my-endpoint/*` | wildcard |
+| ✅  | ✅  | `my-api/my-endpoint/*` | wildcard |
+
+## URL path matching without the Gateway configuration options
+
+Gateway level configuration of URL path matching behavior was released in:
+
+- Tyk Gateway 5.0.14
+- Tyk Gateway 5.3.5
+- Tyk Gateway 5.5.1
+
+In those versions, we added support for named parameters to the granular access middleware, extending the regular expressions to a wider set of supported patterns.
+
+Prior to these versions, path matching was done against the full request
+path, `/listen-path/v4/json` in [wildcard](#wildcard-match) mode. To achieve prefix or
+suffix matching in older versions, consider that the input is a regular
+expression. Depending on your setup, you could use `[^/]+` for any of
+the path segments or finer grained regular expressions.
+
+- `^/[^/]+/v4/json$` - exact match for any listen path, `/v4/json` below
+- `^/{listenPath}/{version}/json$`, exact match with named parameters
+- `^/{*}/json`, prefix match (omits the `$`).
+
+You can achieve a [prefix match](#prefix-match) for older versions by adding the listen
+path to the URL, and using a regex such as `^/listen-path/users`. You might consider
+using the ending `$` expression to achieve [exact matching](#exact-match).
+
+{{< warning success >}}
+**Warning**  
+
+Misconfiguration is possible so special care should be taken to ensure
+that your regular expressions are valid; an invalid regular expression
+would have caused undesired behaviour in older versions.
+{{< /warning >}}

--- a/tyk-docs/content/getting-started/key-concepts/url-matching.md
+++ b/tyk-docs/content/getting-started/key-concepts/url-matching.md
@@ -89,7 +89,7 @@ The [strip listen path]({{< ref "tyk-apis/tyk-gateway-api/api-definition-objects
 
 ### Versioning identifier
 
-If [URL path versioning]({{< ref "product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning#request-url-path" >}}) is in use for an API, Tyk will perform a match of the first fragment after the *listen path* to identify which version of the API should be invoked.
+When API versioning is set via URL path (using [location]({{< ref "getting-started/key-concepts/oas-versioning/#key-concepts" >}}) field), Tyk will perform a match of the first fragment after the *listen path* to identify which version of the API should be invoked.
 
 ### Endpoint path
 

--- a/tyk-docs/content/getting-started/key-concepts/url-matching.md
+++ b/tyk-docs/content/getting-started/key-concepts/url-matching.md
@@ -89,7 +89,7 @@ The [strip listen path]({{< ref "tyk-apis/tyk-gateway-api/api-definition-objects
 
 ### Versioning identifier
 
-When API versioning is set via URL path (using [location]({{< ref "getting-started/key-concepts/oas-versioning/#key-concepts" >}}) field), Tyk will perform a match of the first fragment after the *listen path* to identify which version of the API should be invoked.
+When API versioning is set via URL path (using [location]({{< ref "getting-started/key-concepts/oas-versioning#key-concepts" >}}) field), Tyk will perform a match of the first fragment after the *listen path* to identify which version of the API should be invoked.
 
 ### Endpoint path
 

--- a/tyk-docs/content/planning-for-production.md
+++ b/tyk-docs/content/planning-for-production.md
@@ -92,6 +92,11 @@ Each gateway node must be configured in the same way, with the exception being i
 
 In addition to changing the default secrets (see [Change all the shared secrets]({{< ref "planning-for-production#change-all-the-shared-secrets" >}})) if you change the Control API port (see [Change your Control Port]({{< ref "planning-for-production#change-your-control-port" >}})), you also need to change the connection string settings in your `tyk_analytics.conf` file.
 
+### Ensure you are matching only the URL paths that you want to match
+
+We recommend that you configure Tyk Gateway to use [exact URL path matching]({{< ref "getting-started/key-concepts/url-matching#exact-match" >}}) and to enforce [strict route matching]({{< ref "tyk-oss-gateway/configuration#http_server_optionsenable_strict_routes" >}}) to avoid accidentally invoking your unsecured `/health` endpoint when a request is made to `/customer/{customer_id}/account/health`...
+
+Unless you want to make use of Tyk's flexible *listen path* and *endpoint path* matching modes and understand the need to configure patterns carefully, you should enable `TYK_GW_HTTPSERVEROPTIONS_ENABLESTRICTROUTES`, `TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHPREFIXMATCHING` and `TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHSUFFIXMATCHING`.
 
 ### Health checks are expensive
 
@@ -103,7 +108,12 @@ Tyk provides multiple [log levels]({{< ref "log-data" >}}): error, warn, info, d
 
 It is recommended to set to debug only for the duration of troubleshooting as it adds heavier resource overheads. In high performance use cases for Tyk Gateway, consider setting a log level lower than info to improve overall throughput.
 
+<<<<<<< HEAD
 ### Use the optimisation settings
+=======
+### Use the optimization settings
+
+>>>>>>> b770f96a1... [TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)
 The below settings will ensure connections are effectively re-used, removes a transaction from the middleware run that enforces org-level rules, enables the new rate limiter (by disabling sentinel rate limiter) and sets Tyk up to use an in-memory cache for session-state data to save a round-trip to Redis for some other transactions.
 
 Most of the changes below should be already in your `tyk.conf` by default:
@@ -132,6 +142,7 @@ You can calculate the right value using a straightforward formula:
 If the latency between Tyk and your Upstream is around 50ms, then a single connection can handle 1s / 50ms = 20 requests. So if you plan to handle 2000 requests per second using Tyk, the size of your connection pool should be at least 2000 / 20 = 100. For example, on low-latency environments (like 5ms), a connection pool of 100 connections will be enough for 20k RPS.
 
 ### Protect Redis from overgrowing
+
 Please read carefully through this [doc]({{< ref "basic-config-and-security/security/authentication-authorization/physical-key-expiry" >}}) to make an *aware decision* about the expiration of your keys in Redis, after which they will be removed from Redis. If you don't set the lifetime, a zero default means that keys will stay in Redis until you manually delete them, which is no issue if you have a process outside Tyk Gateway to handle it. If you don't - and especially in scenarios that your flow creates many keys or access tokens for every user or even per call - your Redis can quickly get cluttered with obsolete tokens and eventually affect the performance of the Tyk Gateway.
 
 ### Analytics Optimisations
@@ -139,6 +150,7 @@ Please read carefully through this [doc]({{< ref "basic-config-and-security/secu
 If using a [Redis cluster](https://redis.io/docs/management/scaling/) under high load it is recommended that analytics are distributed among the Redis shards. This can be configured by setting the [analytics_config.enable_multiple_analytics_keys]({{< ref "tyk-oss-gateway/configuration#analytics_configenable_multiple_analytics_keys" >}}) parameter to true. Furthermore, analytics can also be disabled for an API using the [do_not_track]({{< ref "tyk-apis/tyk-gateway-api/api-definition-objects/other-root-objects" >}}) configuration parameter. Alternatively, tracking for analytics can be disabled for selected endpoints using the [do not track endpoint plugin]({{< ref "advanced-configuration/transform-traffic/endpoint-designer#do-not-track-endpoint" >}}).
 
 #### Protobuf Serialisation
+
 In Tyk Gateway, using [protobuf]({{< ref "tyk-oss-gateway/configuration/#analytics_configserializer_type" >}}) serialisation, instead of [msgpack](https://msgpack.org) can increase performance for sending and processing analytics. 
 <br/>
 **Note:** *protobuf* is not currently supported in *MDCB* deployment.
@@ -165,9 +177,11 @@ Please note that a single file, with associated inode & dcache consumes approxim
 The changes will apply after a system reboot, but if you do not wish to reboot quite yet, you can apply the change for the current session using `echo 160000 > /proc/sys/fs/file-max`.
 
 ### File Handles / File Descriptors
+
 Now we need to configure the file handles available to your Tyk services.
 
 #### systemd
+
 Override your `systemd` unit files for each of the Tyk services using `systemctl edit {service_name}`.
 
 * Gateway `systemctl edit tyk-gateway.service`

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-middleware.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-middleware.md
@@ -17,12 +17,13 @@ If you have a service that exposes endpoints or supports methods that you do not
 
 ## How the allow list works
 
-Tyk Gateway does not actually maintain a list of allowed endpoints but rather works on the model whereby if the _allow list_ middleware is added to an endpoint then this will automatically block all other endpoints.
+Tyk Gateway does not actually maintain a list of allowed endpoints but rather works on the model whereby if the *allow list* middleware is added to an endpoint then this will automatically block all other endpoints.
 
-Tyk Gateway will subsequently return `HTTP 403 Forbidden` to any requested endpoint that doesn't have the _allow list_ middleware enabled, even if the endpoint is defined and configured in the API definition.
+Tyk Gateway will subsequently return `HTTP 403 Forbidden` to any requested endpoint that doesn't have the *allow list* middleware enabled, even if the endpoint is defined and configured in the API definition.
 
+<br>
 {{< note success >}}
-**Note**  
+**Note**
 
 If you enable the allow list feature by adding the middleware to any endpoint, ensure that you also add the middleware to any other endpoint for which you wish to accept requests.
 {{< /note >}}
@@ -35,13 +36,14 @@ You can also set case sensitivity for the entire [gateway]({{< ref "tyk-oss-gate
 
 ### Endpoint parsing
 
-When you define an endpoint in your API Definition (for example `GET /anything`), Tyk will also match for `GET /anything/somepath` and any other sub-path based on the `GET /anything` route.
+When using the allow list middleware, we recommend that you familiarize yourself with Tyk's [URL matching]({{< ref "getting-started/key-concepts/url-matching" >}}) options.
 
-You will typically configure the _allow list_ middleware to restrict access to only specific paths, so you may not want Tyk to match `GET /anything/somepath`.
+<br>
+{{< note success >}}
+**Note**  
 
-If you add a `$` at the end of the `listen_path` (in our example `GET /anything$`) then Tyk's regular expression matching will be exact, and will not match endpoints with characters following the specified endpoint.
-
-Thus, if you enable the middleware for `GET /anything$` then `GET /anything/somepath` will be blocked unless explicitly added to the API definition with the _allow list_ middleware enabled for that endpoint.
+Tyk recommends that you use [exact]({{< ref "getting-started/key-concepts/url-matching#exact-match" >}}) matching for maximum security, though prefix and wildcard strategies might also apply for your particular deployment or use case.
+{{< /note >}}
 
 <hr>
 
@@ -54,4 +56,3 @@ If you're using Tyk Classic APIs, then you can find details and examples of how 
   - The Allow List is an optional stage in Tyk's API Request processing chain, sitting between the [TBC]() and [TBC]() middleware.
   - The Allow List can be configured at the per-endpoint level within the API Definition and is supported by the API Designer within the Tyk Dashboard. 
  -->
-

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-classic.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-classic.md
@@ -16,24 +16,31 @@ If you're using the newer Tyk OAS APIs, then check out the [Tyk OAS]({{< ref "pr
 To enable and configure the allow list you must add a new `white_list` object to the `extended_paths` section of your API definition.
 
 {{< note success >}}
-**Note**  
+**Note**
 
 Historically, Tyk followed the out-dated whitelist/blacklist naming convention. We are working to remove this terminology from the product and documentation, however this configuration object currently retains the old name.
 {{< /note >}}
 
 The `white_list` object has the following configuration:
+
 - `path`: the endpoint path
 - `method`: this should be blank
 - `ignore_case`: if set to `true` then the path matching will be case insensitive
 - `method_actions`: a shared object used to configure the [mock response]({{< ref "advanced-configuration/transform-traffic/endpoint-designer#mock-response" >}}) middleware
 
 The `method_actions` object should be configured as follows, with an entry created for each allowed method on the path:
+
 - `action`: this should be set to `no_action`
 - `code`: this should be set to `200`
 - `headers` : this should be blank
 
 For example:
+<<<<<<< HEAD
 ```.json  {linenos=true, linenostart=1}
+=======
+
+```json  {linenos=true, linenostart=1}
+>>>>>>> b770f96a1... [TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)
 {
     "extended_paths": {
         "white_list": [

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-oas.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-oas.md
@@ -11,6 +11,7 @@ When working with Tyk OAS APIs the middleware is configured in the [Tyk OAS API 
 
 If you're using the legacy Tyk Classic APIs, then check out the [Tyk Classic]({{< ref "product-stack/tyk-gateway/middleware/allow-list-tyk-classic" >}}) page.
 
+
 ## Configuring the allow list in the Tyk OAS API Definition
 
 The design of the Tyk OAS API Definition takes advantage of the `operationId` defined in the OpenAPI Document that declares both the path and method for which the middleware should be added. Endpoint `paths` entries (and the associated `operationId`) can contain wildcards in the form of any string bracketed by curly braces, for example `/status/{code}`. These wildcards are so they are human readable and do not translate to variable names. Under the hood, a wildcard translates to the “match everything” regex of: `(.*)`.
@@ -18,10 +19,12 @@ The design of the Tyk OAS API Definition takes advantage of the `operationId` de
 The allow list middleware (`allow`) can be added to the `operations` section of the Tyk OAS Extension (`x-tyk-api-gateway`) in your Tyk OAS API Definition for the appropriate `operationId` (as configured in the `paths` section of your OpenAPI Document).
 
 The `allow` object has the following configuration:
+
 - `enabled`: enable the middleware for the endpoint
 - `ignoreCase`: if set to `true` then the path matching will be case insensitive
 
 For example:
+
 ```json {hl_lines=["47-50", "53-56"],linenos=true, linenostart=1}
 {
     "components": {},

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-middleware.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-middleware.md
@@ -5,7 +5,7 @@ description: "Detail of the Block List middleware"
 tags: ["block list", "middleware", "per-endpoint"]
 ---
 
-The Block List middleware is a feature designed to block access to specific API endpoints. Tyk Gateway rejects all requests made to endpoints with the block list enabled, returning `HTTP 403 Forbidden`. 
+The Block List middleware is a feature designed to block access to specific API endpoints. Tyk Gateway rejects all requests made to endpoints with the block list enabled, returning `HTTP 403 Forbidden`.
 
 Note that this is not the same as Tyk's [IP block list]({{< ref "tyk-apis/tyk-gateway-api/api-definition-objects/ip-blacklisting" >}}) feature, which is used to restrict access to APIs based upon the IP of the requestor.
 
@@ -17,23 +17,24 @@ If you are versioning your API and deprecating an endpoint then, instead of havi
 
 ## How the block list works
 
-Tyk Gateway does not actually maintain a list of blocked endpoints but rather works on the model whereby if the _block list_ middleware is added to an endpoint then any request to that endpoint will be rejected, returning `HTTP 403 Forbidden`.
+Tyk Gateway does not actually maintain a list of blocked endpoints but rather works on the model whereby if the *block list* middleware is added to an endpoint then any request to that endpoint will be rejected, returning `HTTP 403 Forbidden`.
 
 ### Case sensitivity
 
-By default the block list is case-sensitive. For example, if you have defined the endpoint `GET /userID` in your API definition then only calls to `GET /userID` will be blocked: calls to `GET /UserID` or `GET /userid` will be allowed. You can configure the middleware to be case insensitive at the endpoint level.
+By default the block list is case-sensitive, so for example if you have defined the endpoint `GET /userID` in your API definition then only calls to `GET /userID` will be blocked: calls to `GET /UserID` or `GET /userid` will be allowed. You can configure the middleware to be case-insensitive at the endpoint level.
 
 You can also set case sensitivity for the entire [gateway]({{< ref "tyk-oss-gateway/configuration#ignore_endpoint_case" >}}) in the Gateway configuration file `tyk.conf`. If case insensitivity is configured at the gateway level, this will override the endpoint-level setting.
 
 ### Endpoint parsing
 
-When you define an endpoint in your API Definition (for example `GET /anything`), Tyk will also match for `GET /anything/somepath` and any other sub-path based on the `GET /anything` route.
+When using the block list middleware, we recommend that you familiarize yourself with Tyk's [URL matching]({{< ref "getting-started/key-concepts/url-matching" >}}) options.
 
-You may not actually want Tyk to reject accesses to sub-paths (such as `GET /anything/somepath`) just to the specific endpoint.
+<br>
+{{< note success >}}
+**Note**  
 
-If you add a `$` at the end of the `listen_path` (in our example `GET /anything$`) then Tyk's regular expression matching will be exact, and will not match endpoints with characters following the specified endpoint.
-
-Thus, if you enable the middleware for `GET /anything$` then whilst `GET /anything` will be blocked, requests to  `GET /anything/somepath` will be allowed.
+Tyk recommends that you use [exact]({{< ref "getting-started/key-concepts/url-matching#exact-match" >}}) matching for maximum security, though prefix and wildcard strategies might also apply for your particular deployment or use case.
+{{< /note >}}
 
 <hr>
 
@@ -46,4 +47,3 @@ If you're using Tyk Classic APIs, then you can find details and examples of how 
   - The Block List is an optional stage in Tyk's API Request processing chain, sitting between the [TBC]() and [TBC]() middleware.
   - The Block List can be configured at the per-endpoint level within the API Definition and is supported by the API Designer within the Tyk Dashboard. 
  -->
-

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/ignore-middleware.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/ignore-middleware.md
@@ -25,6 +25,17 @@ By default the ignore authentication middleware is case-sensitive. If, for examp
 
 You can also set case sensitivity for the entire Tyk Gateway in its [configuration file]({{< ref "tyk-oss-gateway/configuration#ignore_endpoint_case" >}}) `tyk.conf`. If case insensitivity is configured at the gateway level, this will override the endpoint-level setting.
 
+### Endpoint parsing
+
+When using the ignore authentication middleware, we recommend that you familiarize yourself with Tyk's [URL matching]({{< ref "getting-started/key-concepts/url-matching" >}}) options.
+
+<br>
+{{< note success >}}
+**Note**  
+
+Tyk recommends that you use [exact]({{< ref "getting-started/key-concepts/url-matching#exact-match" >}}) matching for maximum security, though prefix and wildcard strategies might also apply for your particular deployment or use case.
+{{< /note >}}
+
 <hr>
 
 If you're using Tyk OAS APIs, then you can find details and examples of how to configure the ignore authentication middleware [here]({{< ref "product-stack/tyk-gateway/middleware/ignore-tyk-oas" >}}).

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-middleware.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-middleware.md
@@ -7,7 +7,11 @@ aliases:
   - /getting-started/using-oas-definitions/mock-response/
 ---
 
+<<<<<<< HEAD
 A mock response is a simulated API response that can be returned by the API gateway without actually sending the request to the backend API service. Mock responses are an integral feature for API development, enabling developers to emulate API behaviour without the need for upstream execution. 
+=======
+A mock response is a simulated API response that can be returned by the API gateway without actually sending the request to the backend API service. Mock responses are an integral feature for API development, enabling developers to emulate API behavior without the need for upstream execution.
+>>>>>>> b770f96a1... [TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)
 
 Tyk's mock response middleware offers this functionality by allowing the configuration of custom responses for designated endpoints. This capability is crucial for facilitating front-end development, conducting thorough testing, and managing unexpected scenarios or failures.
 
@@ -44,19 +48,20 @@ When working with Tyk OAS APIs, Tyk Gateway can parse the [examples and schema](
 ## Middleware execution order during request processing
 
 ### With **Tyk OAS APIs**
+
 - the mock response middleware is executed at the **end** of the request processing chain, immediately prior to the request being proxied to the upstream
 - all other request processing middleware (e.g. authentication, request transforms) will be executed prior to the mock response.
 
 ### With **Tyk Classic APIs**
+
 - the mock response middleware is executed at the **start** of the request processing chain
 - an endpoint with a mock response will not run any other middleware and will immediately return the mocked response for any request. As such, it is always an unauthenticated (keyless) call.
 
 <hr>
 
-## Tutorials
-- [Tyk OAS mock response tutorial]({{< ref "product-stack/tyk-gateway/middleware/mock-response-tyk-oas" >}}) or 
-- [Tyk classic mock response tutorial]({{< ref "product-stack/tyk-gateway/middleware/mock-response-tyk-classic" >}}).
+If you’re using Tyk OAS APIs, then you can find details and examples of how to configure the mock response middleware [here]({{< ref "product-stack/tyk-gateway/middleware/mock-response-tyk-oas" >}}).
 
+If you’re using Tyk Classic APIs, then you can find details and examples of how to configure the response body transformation middleware [here]({{< ref "product-stack/tyk-gateway/middleware/mock-response-tyk-classic" >}}).
 
 <!-- proposed "summary box" to be shown graphically on each middleware page
  ## Mock Response middleware summary

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-tyk-classic.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-tyk-classic.md
@@ -7,12 +7,13 @@ tags: ["mock response", "middleware", "per-endpoint", "Tyk Classic", "Tyk Classi
 
 The [Mock Response]({{< ref "product-stack/tyk-gateway/middleware/mock-response-middleware" >}}) middleware allows you to configure Tyk to return a response for an API endpoint without requiring an upstream service. This can be useful when creating a new API or making a development API available to an external team.
 
-When working with Tyk Classic APIs, this middleware is executed at the start of the request processing chain. Thus an endpoint with the mock response middleware will not be authenticated, will not process other middleware configured for the API (neither API nor endpoint level) and will have no analytics created.  It will simply return the configured response for any request made to that endpoint.
+When working with Tyk Classic APIs, this middleware is executed at the start of the request processing chain. Thus an endpoint with the mock response middleware will not be authenticated, will not process other middleware configured for the API (neither API nor endpoint level) and will have no analytics created. It will simply return the configured response for any request made to that endpoint.
 
-The middleware is configured in the Tyk Classic API Definition. You can do this via the Tyk Dashboard API or in the API Designer.
+The middleware is configured in the Tyk Classic API Definition. You can do this via the Tyk Dashboard API, the API Designer or in [Tyk Operator](#tyk-operator).
 
 If you're using the newer Tyk OAS APIs, then check out the [Tyk OAS]({{< ref "product-stack/tyk-gateway/middleware/mock-response-tyk-oas" >}}) page.
 
+<<<<<<< HEAD
 ### Endpoint parsing
 
 When you define an endpoint in your API Definition (for example `GET /anything`), Tyk will also match for `GET /anything/somepath` and any other sub-path based on the `GET /anything` route.
@@ -24,22 +25,30 @@ If you add a `$` at the end of the `listen_path` (in our example `GET /anything$
 Thus, if you enable the middleware for `GET /anything$` then `GET /anything/somepath` will be proxied to the upstream and will not trigger the mock response.
 
 ## Configuring the middleware in the Tyk Classic API Definition
+=======
+## Configuring the middleware in the Tyk Classic API Definition {#tyk-classic}
+>>>>>>> b770f96a1... [TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)
+
+If you're using Tyk Operator then check out the [configuring the middleware in Tyk Operator](#tyk-operator) section below.
 
 To enable mock response, you must first add the endpoint to a list - one of [allow list]({{< ref "product-stack/tyk-gateway/middleware/allow-list-middleware" >}}), [block list]({{< ref "product-stack/tyk-gateway/middleware/block-list-middleware" >}}) or [ignore authentication]({{< ref "product-stack/tyk-gateway/middleware/ignore-middleware" >}}). This will add a new object to the `extended_paths` section of your API definition - `white_list`, `black_list` or `ignored`. The mock response can then be configured within the `method_actions` element within the new object.
 
 The `white_list`, `black_list` and `ignored` objects all have the same structure and configuration as follows:
+
 - `path`: the endpoint path
 - `method`: this should be blank
 - `ignore_case`: if set to `true` then the path matching will be case insensitive
 - `method_actions`: the configuration of the mock response
 
 The `method_actions` object should be configured as follows, with an entry created for each method on the path for which you wish to configure the mock response:
+
 - `action`: this should be set to `reply`
 - `code`: the HTTP status code to be provided with the response
 - `headers`: the headers to inject with the response
 - `body`: the payload to be returned as the body of the response
 
 For example:
+
 ```json  {linenos=true, linenostart=1}
 {
     "extended_paths": {
@@ -102,9 +111,61 @@ Once you have selected the Mock response middleware for the endpoint, you can co
 #### Step 4: Save the API
 
 Use the *save* or *create* buttons to save the changes and activate the middleware.
- 
+
 {{< note success >}}
-**Note**  
+**Note**
 
 For the mock response to be enabled, the endpoint must also be in a list. We recommend adding the path to an [allow list]({{< ref "advanced-configuration/transform-traffic/endpoint-designer#allowlist" >}}). If this isn't done, then the mock will not be saved when you save your API in the designer.
 {{< /note >}}
+<<<<<<< HEAD
+=======
+
+## Configuring the middleware in Tyk Operator {#tyk-operator}
+
+The process of configuring a mock response is similar to that defined in the [configuring the middleware in Tyk Classic API definition](#tyk-classic) section.
+
+To configure a mock response, you must first add a mock response configuration object to the `extended_paths` section, e.g. one of allow list (`white_list`), block list (`black_list`) or ignore authentication (`ignore`). The mock response configuration object has the following properties:
+
+- path: the path of the endpoint, e.g `/foo`.
+- ignore_case: when set to true the path matching is case insensitive.
+- method_actions: a configuration object that allows the mock response to be configured for a given method, including the response body, response headers and status code. This object should also contain an `action` field with a value set to `reply`.
+
+In the example below we can see that a mock response is configured to ignore authentication (`ignore`) for the `GET /foo` endpoint. When a request is made to the endpoint then authentication will be ignored and a mock response is returned with status code `200` and a response body payload of `{"foo": "bar"}`. The middleware has been configured to be case sensitive, so calls to `GET /Foo` will not ignore authentication.
+
+```yaml {linenos=true, linenostart=1, hl_lines=["26-34"]}
+apiVersion: tyk.tyk.io/v1alpha1
+kind: ApiDefinition
+metadata:
+  name: httpbin
+spec:
+  name: httpbin
+  protocol: http
+  active: true
+  use_keyless: true
+  proxy: 
+    target_url: http://httpbin.org
+    listen_path: /httpbin
+    strip_listen_path: true
+  version_data:
+    default_version: Default
+    not_versioned: true
+    versions:
+      Default:
+        name: Default
+        use_extended_paths: true
+        paths:
+          black_list: []
+          ignored: []
+          white_list: []
+        extended_paths:
+            ignored:
+              - ignore_case: false
+                method_actions:
+                  GET:
+                    action: "reply"
+                    code: 200
+                    data: "{\"foo\": \"bar\"}"
+                    headers: {}
+                path: /foo
+```
+>>>>>>> b770f96a1... [TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)

--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -1263,6 +1263,10 @@ menu:
           path: /concepts/middleware-execution-order
           category: Page
           show: True
+        - title: "What is URL path matching?"
+          path: /getting-started/key-concepts/url-matching
+          category: Page
+          show: True
         - title: "What is Rate Limiting?"
           path: /getting-started/key-concepts/rate-limiting
           category: Page


### PR DESCRIPTION
### **User description**
[TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)


___

### **PR Type**
Documentation


___

### **Description**
- Added a comprehensive guide on URL path matching, detailing its importance, scenarios, and configuration options.
- Updated documentation for various middleware (allow list, block list, ignore authentication, mock response) to include URL matching recommendations.
- Recommended enabling strict and exact URL path matching for production environments to enhance security.
- Updated menu configuration to include the new URL path matching documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>_bespoke.scss</strong><dd><code>Comment out blockquote icon content in SCSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/scss/_bespoke.scss

- Commented out the content property in blockquote:before.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-4d88d302558832943d8a99db09e36c42f8f75ba4a04df83b0b2ada3e1613e4a5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>url-matching.md</strong><dd><code>Add comprehensive guide on URL path matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/getting-started/key-concepts/url-matching.md

<li>Added a comprehensive document on URL path matching.<br> <li> Explained URL path matching importance and scenarios.<br> <li> Detailed the structure of API requests and path matching modes.<br> <li> Provided examples and recommendations for path matching.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-672ca9717aaee1c455840ae52a39c6116530032b0622d5a86edf0fa22861b3a2">+323/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>planning-for-production.md</strong><dd><code>Recommend exact URL path matching in production</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/planning-for-production.md

<li>Added recommendations for URL path matching configuration.<br> <li> Suggested enabling strict and exact path matching.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-49f3285738fe99bae303f814133b36340144d4c04d9f86d291e67832eab33008">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>allow-list-middleware.md</strong><dd><code>Update allow list middleware documentation with URL matching</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-middleware.md

<li>Updated the explanation of allow list middleware.<br> <li> Added notes on URL matching and security recommendations.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-4e6e30155e7c46eb1c2dabcd0b93ba38a60b6617b63476d91eb2bff14621d8a2">+10/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>allow-list-tyk-classic.md</strong><dd><code>Update allow list configuration for Tyk Classic APIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-classic.md

<li>Updated the configuration details for allow list in Tyk Classic.<br> <li> Added notes on terminology changes.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-cecc51e27b2ad48c72c18e637d5f8f3a791b2a9e031dcff2a60506683efbefa5">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>allow-list-tyk-oas.md</strong><dd><code>Document allow list configuration for Tyk OAS APIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/allow-list-tyk-oas.md

<li>Added configuration details for allow list in Tyk OAS API Definition.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-e093b781849fc6bf2906079ffe58a90da02ca2bacd2d9cb73a9bac8c1bde5e5c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block-list-middleware.md</strong><dd><code>Update block list middleware documentation with URL matching</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/block-list-middleware.md

<li>Updated block list middleware documentation.<br> <li> Added notes on URL matching and security recommendations.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-d9653862e5113b8de2f43799aefea787989456ba75f7a66816fac6428e542f5d">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ignore-middleware.md</strong><dd><code>Enhance ignore middleware documentation with URL matching</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/ignore-middleware.md

<li>Added endpoint parsing section for ignore authentication middleware.<br> <li> Included recommendations for URL matching.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-e0701e7359713068897a394cd526f9757b65da8449fe164438d3ff4ba92cc5b7">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mock-response-middleware.md</strong><dd><code>Update mock response middleware documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-middleware.md

<li>Updated mock response middleware documentation.<br> <li> Clarified middleware execution order.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-aa65da83fafc2a9477425a0dc463e44bf45d76ffe809961dfded95b385315e92">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mock-response-tyk-classic.md</strong><dd><code>Update mock response configuration for Tyk Classic and Operator</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-tyk-classic.md

<li>Updated configuration details for mock response in Tyk Classic.<br> <li> Added section for configuring middleware in Tyk Operator.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-812f7be4a473804cef8911ff820243b5792212ca76c1383337445c6848df9c54">+65/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Add URL path matching to documentation menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/data/menu.yaml

- Added URL path matching to the menu.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5446/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information