### PR TITLE
Merging to release-5.5: Update menu.yaml (#5453)

### DIFF
--- a/tyk-docs/data/menu.yaml
+++ b/tyk-docs/data/menu.yaml
@@ -3858,7 +3858,7 @@ menu:
             path: /release-notes/pump-1.8
             category: Page
             show: True
-    - title: "Tyk Operator (Open Source)"
+    - title: "Tyk Operator"
       category: Directory
       show: True
       menu:
@@ -4514,7 +4514,7 @@ menu:
         path: /product-stack/tyk-streaming/troubleshooting
         category: Page
         show: True
-    - title: "Tyk Sync (Open Source)"
+    - title: "Tyk Sync"
       category: Directory
       show: True
       menu:


### PR DESCRIPTION
### **User description**
Update menu.yaml (#5453)

Remove reference to OS


___

### **PR Type**
documentation


___

### **Description**
- Updated `menu.yaml` to remove "Open Source" references from the titles of "Tyk Operator" and "Tyk Sync".
- This change simplifies the titles in the documentation menu.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>menu.yaml</strong><dd><code>Remove "Open Source" references from menu titles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/data/menu.yaml

<li>Removed "Open Source" from the title of "Tyk Operator".<br> <li> Removed "Open Source" from the title of "Tyk Sync".<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5457/files#diff-a6789c66bfa0660f7fdbe4796002ab4777677bae59a0276689c840100ff0b0b2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information