### PR TITLE
[DX-1694] Added custom rate limit key to change log

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md
@@ -968,6 +968,13 @@ Previously OAS-to-UDG converter had limitations in handling enums from OpenAPI d
 OAS-to-UDG converter can now handle HTTP status code ranges that are defined by the OpenAPI Specification. This means that code ranges defined as 1XX, 2XX, etc will be correctly converted by the tool.
 </details>
 </li>
+<li>
+<details>
+<summary>Added support for custom rate limit keys</summary>
+
+We have added the capability for users to define a [custom rate limit key]({{< ref "tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/configuring-custom-rate-limit-keys" >}}) within session metadata. This increases flexibility with rate limiting, as the rate limit can be assigned to different entities identifiable from the session metadata (such as a client app or organization) and is particularly useful for users of Tyk's Enterprise Developer Portal.
+</details>
+</li>
 </ul>
 
 #### Changed


### PR DESCRIPTION
### **User description**
Was originally missed when 5.3 was released


___

### **PR Type**
documentation


___

### **Description**
- Added documentation for the new feature of custom rate limit keys in the Tyk Gateway version 5.3 release notes.
- This feature allows users to define custom rate limit keys within session metadata, enhancing flexibility in rate limiting.
- The documentation includes a link to the configuration guide for setting up custom rate limit keys.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version-5.3.md</strong><dd><code>Documented support for custom rate limit keys in release notes</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.3.md

<li>Added a new entry to the release notes for version 5.3.<br> <li> Documented support for custom rate limit keys in session metadata.<br> <li> Included a link to the configuration guide for custom rate limit keys.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5491/files#diff-ead598197a92e18014f4f7c35c341621948fb6cdf66d45c1dd05de21bc2b35aa">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information