### PR TITLE
Merging to release-5.5: add nesting level to 9 (#5500)

### DIFF
--- a/.github/workflows/navigation-levels.yml
+++ b/.github/workflows/navigation-levels.yml
@@ -1,7 +1,7 @@
 name: Check maximum nesting level is not exceeded
 on: [pull_request]
 env:
-  MAX_LEVELS: 7
+  MAX_LEVELS: 9
 
 jobs:
   Check-max-levels:


### PR DESCRIPTION
### **User description**
add nesting level to 9 (#5500)


___

### **PR Type**
configuration changes


___

### **Description**
- Increased the maximum allowed nesting level from 7 to 9 in the GitHub workflow configuration file.
- This change ensures that the workflow can accommodate deeper nesting levels in the codebase.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation-levels.yml</strong><dd><code>Increase maximum nesting level in GitHub workflow configuration</code></dd></summary>
<hr>

.github/workflows/navigation-levels.yml

<li>Updated the <code>MAX_LEVELS</code> environment variable from 7 to 9.<br> <li> This change affects the workflow that checks the maximum nesting <br>level.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5501/files#diff-d753bb3eb43ee7188515baa0a6e287faa4a6b07001d924aded1decda764b033c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information