### PR TITLE
Merging to release-5.5: [DX-1697] Gateway Release Notes 5.5.2 (#5496)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.5.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.5.md
@@ -2,7 +2,7 @@
 title: Tyk Gateway 5.5 Release Notes
 date: 2024-03-27T15:51:11Z
 description: "Release notes documenting updates, enhancements, and changes for Tyk Gateway versions within the 5.5.X series."
-tags: ["Tyk Gateway", "Release notes", "changelog", "v5.5", "5.5", "5.5.0", "5.5.1"]
+tags: ["Tyk Gateway", "Release notes", "changelog", "v5.5", "5.5", "5.5.0", "5.5.1", "5.5.2"]
 ---
 
 **Open Source** ([Mozilla Public License](https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md))
@@ -12,6 +12,60 @@ tags: ["Tyk Gateway", "Release notes", "changelog", "v5.5", "5.5", "5.5.0", "5.5
 ## Support Lifetime
 
 Our minor releases are supported until our next minor comes out.
+
+---
+
+## 5.5.2 Release Notes
+
+### Release Date 03 October 2024
+
+### Release Highlights
+This release replaces Tyk Gateway 5.5.1 which was accidentally released as a non-distroless image.
+
+
+### Breaking Changes
+
+There are no breaking changes in this release.
+
+### Dependencies {#dependencies-5.5.2}
+
+#### Compatibility Matrix For Tyk Components
+
+| Gateway Version | Recommended Releases | Backwards Compatibility |
+|----    |---- |---- |
+| 5.5.2 | MDCB v2.7     | MDCB v2.4.2 |
+|         | Operator v0.18 | Operator v0.17 |
+|         | Sync v1.5   | Sync v1.4.3 |
+|         | Helm Chart v2.0.0 | Helm all versions |
+| | EDP v1.10 | EDP all versions |
+| | Pump v1.11 | Pump all versions |
+| | TIB (if using standalone) v1.5.1 | TIB all versions |
+
+#### 3rd Party Dependencies & Tools
+
+| Third Party Dependency                                       | Tested Versions        | Compatible Versions    | Comments | 
+| ------------------------------------------------------------ | ---------------------- | ---------------------- | -------- | 
+| [Go](https://go.dev/dl/)                                     | 1.21  |  1.21  | [Go plugins]({{< ref "/plugins/supported-languages/golang" >}}) must be built using Go 1.21 | 
+| [Redis](https://redis.io/download/)  | 6.2.x, 7.x  | 6.2.x, 7.x  | Used by Tyk Gateway | 
+| [OpenAPI Specification](https://spec.openapis.org/oas/v3.0.3)| v3.0.x                 | v3.0.x                 | Supported by [Tyk OAS]({{< ref "/tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc" >}}) |
+
+Given the potential time difference between your upgrade and the release of this version, we recommend users verify the ongoing support of third-party dependencies they install, as their status may have changed since the release.
+
+### Deprecations
+<!-- Required. Use the following statement if there are no deprecations, or explain if there are -->
+There are no deprecations in this release.
+
+### Upgrade instructions {#upgrade-5.5.2}
+If you are upgrading to 5.5.2, please follow the detailed [upgrade instructions](#upgrading-tyk).
+
+### Downloads
+- [Docker image to pull](https://hub.docker.com/r/tykio/tyk-gateway/tags?page=&page_size=&ordering=&name=v5.5.2)
+  - ```bash
+    docker pull tykio/tyk-gateway:v5.5.2
+    ``` 
+- Helm charts
+  - [tyk-charts v2.0.0]({{< ref "product-stack/tyk-charts/release-notes/version-2.0.md" >}})
+- [Source code tarball for OSS projects](https://github.com/TykTechnologies/tyk/releases)
 
 ---
 


### PR DESCRIPTION
### **User description**
[DX-1697] Gateway Release Notes 5.5.2 (#5496)

[DX-1697]: https://tyktech.atlassian.net/browse/DX-1697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Added comprehensive release notes for Tyk Gateway version 5.5.2, including release highlights, breaking changes, dependencies, and deprecations.
- Updated the tags in the release notes to include version 5.5.2.
- Included a compatibility matrix for Tyk components and third-party dependencies.
- Provided upgrade instructions and download links for the new version.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version-5.5.md</strong><dd><code>Add release notes and details for Tyk Gateway 5.5.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.5.md

<li>Added release notes for Tyk Gateway version 5.5.2.<br> <li> Updated tags to include version 5.5.2.<br> <li> Detailed compatibility matrix for Tyk components and third-party <br>dependencies.<br> <li> Provided upgrade instructions and download links for version 5.5.2.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5509/files#diff-38c96e78461917033740cb3c935527340524536d7182c1883e89215261dbb496">+55/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information