### PR TITLE
Update tyk-oss-chart.md

### DIFF
--- a/tyk-docs/content/product-stack/tyk-charts/tyk-oss-chart.md
+++ b/tyk-docs/content/product-stack/tyk-charts/tyk-oss-chart.md
@@ -303,6 +303,8 @@ Default service port of gateway is 8080. You can change this at `global.serviceP
 An Ingress resource is created if `tyk-gateway.gateway.ingress.enabled` is set to true.
 
 ```yaml
+tyk-gateway:
+  gateway:
     ingress:
       # if enabled, creates an ingress resource for the gateway
       enabled: true


### PR DESCRIPTION
fix the docs helm

There was missing two lines pointing to a particular key in `values.yaml`