### PR TITLE
Merging to release-5.3: [DX-647] API HostCheckObject.Timeout is hardcoded and undocumented (#5518)

### DIFF
--- a/tyk-docs/content/planning-for-production/ensure-high-availability/uptime-tests.md
+++ b/tyk-docs/content/planning-for-production/ensure-high-availability/uptime-tests.md
@@ -95,17 +95,13 @@ Or a long form, which allows for a full request to be checked or mocked:
     "this": "that",
     "more": "beans"
   },
-  "body": "VEhJUyBJUyBBIEJPRFkgT0JKRUNUIFRFWFQNCg0KTW9yZSBzdHVmZiBoZXJl"
+  "body": "VEhJUyBJUyBBIEJPRFkgT0JKRUNUIFRFWFQNCg0KTW9yZSBzdHVmZiBoZXJl",
+  "timeout": 1000
 }
 ```
 
-The `body` is Base64 encoded.
-
-{{< note success >}}
-**Note**  
-
-Using the quick form will not enforce a timeout, while the long form will fail with a 500ms timeout.
-{{< /note >}}
+*   `body`: The `body` is Base64 encoded.
+*   `timeout`: The `timeout` in milli seconds.
 
 
 ## Configure with the Dashboard


### PR DESCRIPTION
### **User description**
[DX-647] API HostCheckObject.Timeout is hardcoded and undocumented (#5518)

Fixes

[DX-647]: https://tyktech.atlassian.net/browse/DX-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
documentation


___

### **Description**
- Added documentation for the `timeout` parameter in the uptime tests configuration, specifying its value in milliseconds.
- Clarified the description of the `body` parameter, indicating that it is Base64 encoded.
- Removed outdated note regarding timeout enforcement in the quick form.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uptime-tests.md</strong><dd><code>Document `timeout` parameter and clarify usage in uptime tests</code></dd></summary>
<hr>

tyk-docs/content/planning-for-production/ensure-high-availability/uptime-tests.md

<li>Added documentation for the <code>timeout</code> parameter in the long form <br>example.<br> <li> Clarified the description for <code>body</code> and <code>timeout</code> fields.<br> <li> Removed outdated note about timeout enforcement.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5539/files#diff-2279e6d184d520debfc11229fe9c7afcac86ede75d5e8d0c9d10268f5ce206de">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information