### PR TITLE
Merging to release-5.6: DX-1715 Tyk Operator configuration should be added to tyk stack page (#5583)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md
+++ b/tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md
@@ -453,6 +453,10 @@ global:
        keyName: "postgreConnectionURLkey"
 ```
 
+***Tyk Operator License***
+
+It can be configured via `global.license.operator` as a plain text or Kubernetes secret which includes `OperatorLicense` key in it. Then, this secret must be referenced via `global.secrets.useSecretName`.
+
 ### Gateway Configurations
 
 This section explains how to configure the `tyk-gateway` section for updating the Gateway version, enabling TLS, enabling autoscaling etc.
@@ -877,7 +881,14 @@ tyk-dev-portal:
 
 ### Tyk Operator Configurations
 
-In order to enable installing Tyk Operator along-side Tyk Stack installation, please set `global.components.operator` to `true`.
+Tyk Operator is a licensed component that requires a valid key for operation. 
+Please refer to the [Tyk Operator Installation Guide]({{<ref "tyk-stack/tyk-operator/installing-tyk-operator">}})
+for detailed information on the installation and upgrade processes. 
+
+Prior to installing Tyk Operator, ensure that a valid license key is provided by setting `global.license.operator` field in values.yaml file. You can set license key via a Kubernetes secret using `global.secrets.useSecretName` field. The secret should contain a key called `OperatorLicense`.
+
+In order to enable installing Tyk Operator along-side Tyk Stack installation, please set `global.components.operator`
+to `true`.
 
 All other configurations related to Tyk Operator are available under `tyk-operator` section of `values.yaml` file.
 


### PR DESCRIPTION
### **User description**
DX-1715 Tyk Operator configuration should be added to tyk stack page (#5583)

Update tyk-stack-chart.md


___

### **PR Type**
Documentation


___

### **Description**
- Added detailed instructions for configuring the Tyk Operator License in the `tyk-stack-chart.md` file.
- Included information on setting the license key using `global.license.operator` and Kubernetes secrets.
- Updated the reference to the Tyk Operator Installation Guide for more comprehensive installation and upgrade processes.
- Emphasized the requirement of a valid license key for the Tyk Operator and how to provide it.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tyk-stack-chart.md</strong><dd><code>Add Tyk Operator License Configuration Instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md

<li>Added instructions for configuring Tyk Operator License.<br> <li> Explained the requirement of a valid license key for Tyk Operator.<br> <li> Clarified the use of Kubernetes secret for license configuration.<br> <li> Updated reference to Tyk Operator Installation Guide.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5602/files#diff-f6e45bbf530fa763d587dec798584c8eb6294229ef353d3212ab01bf6b0a1d7c">+13/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information