### PR TITLE
Merging to release-5.6: remove tabs and use spaces (#5607)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
   "printWidth": 120,
   "proseWrap": "always",
   "tabWidth": 2,
-  "useTabs": true,
+  "useTabs": false,
   "overrides": [
     {
       "files": [
@@ -28,3 +28,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
### **User description**
remove tabs and use spaces (#5607)

remove tabs


___

### **PR Type**
configuration changes


___

### **Description**
- Updated the Prettier configuration file to use spaces instead of tabs by setting `useTabs` to `false`.
- This change ensures consistent formatting across the codebase.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.prettierrc</strong><dd><code>Update Prettier configuration to use spaces instead of tabs</code></dd></summary>
<hr>

.prettierrc

<li>Changed <code>useTabs</code> from <code>true</code> to <code>false</code>.<br> <li> Updated configuration to use spaces instead of tabs.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5608/files#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information