### PR TITLE
[TT-13281/TT-13282] Document OAS common parameter usage in dashboard OAS endpoint designer

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/validate-request-tyk-oas.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/validate-request-tyk-oas.md
@@ -5,7 +5,7 @@ description: "Using the Request Validation middleware with Tyk OAS APIs"
 tags: ["request validation", "validate request", "middleware", "per-endpoint", "Tyk OAS", "Tyk OAS API"]
 ---
 
-The [request validation]({{< ref "product-stack/tyk-gateway/middleware/validate-request-middleware" >}}) middleware provides a way to validate the presence, correctness and conformity of HTTP requests to make sure they meet the expected format required by the upstream API endpoints.
+The [request validation]({{< ref "product-stack/tyk-gateway/middleware/validate-request-middleware" >}}) middleware provides a way to validate the presence, correctness and conformity of HTTP requests to make sure they meet the expected format required by the upstream API endpoints. If the incoming request fails validation, the Tyk Gateway will reject the request with an `HTTP 422 Unprocessable Entity` response. Tyk can be [configured](#configuring-the-request-validation-middleware) to return a different HTTP status code if required. 
 
 The middleware is configured in the [Tyk OAS API Definition]({{< ref "tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc#operation" >}}). You can do this via the Tyk Dashboard API or in the API Designer.
 
@@ -25,7 +25,7 @@ As explained in the OpenAPI [documentation](https://learn.openapis.org/specifica
 
 ### Request parameters
 
-The `parameters` field in the OpenAPI description is an array of [parameter objects](https://swagger.io/docs/specification/describing-parameters/) that each describe one parameter shared by all operations on that path. Here, an operation is defined as a combination of HTTP method and path, or, as Tyk calls it, an endpoint. Each `parameter` has two mandatory fields:
+The `parameters` field in the OpenAPI description is an array of [parameter objects](https://swagger.io/docs/specification/describing-parameters/) that each describe one variable element in the request. Each `parameter` has two mandatory fields:
 - `in`: the location of the parameter (`path`, `query`, `header`)
 - `name`: a unique identifier within that location (i.e. no duplicate header names for a given operation/endpoint)
 
@@ -33,7 +33,13 @@ There are also optional `description` and `required` fields.
 
 For each parameter, a schema can be declared that defines the `type` of data that can be stored (e.g. `boolean`, `string`) and any `example` or `default` values. 
 
-Parameters that apply to all operations within a path can be defined at the [path level](https://swagger.io/docs/specification/v3_0/describing-parameters/#common-parameters) rather than at the operation level. These path-level parameters, also known as common parameters, appear as read-only fields in Tyk Dashboard's OAS endpoint designer. To modify these common parameters, users need to use the OAS raw editor, as changes made from the OAS endpoint editor could impact other endpoints.
+#### Operation (endpoint-level) parameters
+
+An operation is a combination of HTTP method and path or, as Tyk calls it, an endpoint - for example `GET /users`. Operation, or endpoint-level parameters can be defined in the OpenAPI description and will apply only to that operation within the API. These can be added or modified within Tyk Dashboard's [API designer](#configuring-the-middleware-in-the-api-designer).
+
+#### Common (path-level) parameters
+
+[Common parameters](https://swagger.io/docs/specification/v3_0/describing-parameters/#common-parameters), that apply to all operations within a path, can be defined at the path level within the OpenAPI description. Tyk refers to these as path-level parameters and displays them as read-only fields in the Dashboard's API designer. If you need to add or modify common parameters you must use the *Raw Definition* editor, or edit your OpenAPI document outside Tyk and [update]({{< ref "/getting-started/using-oas-definitions/update-an-oas-api" >}}) the API.
 
 ### Request body
 
@@ -41,11 +47,15 @@ The `requestBody` field in the OpenAPI description is a [Request Body Object](ht
 
 ## Configuring the request validation middleware
 
-The request validation middleware does not require configuration when working with Tyk OAS APIs. If it is [enabled](#enabling-the-request-validation-middleware) for an endpoint, then the middleware will automatically validate requests made to that endpoint against the schema defined in the API definition. The default response, if validation fails, is for Tyk Gateway to reject the request with an `HTTP 422 Unprocessable Entity` response. If you want to return a different HTTP status code, this can be set when enabling the middleware.
+When working with Tyk OAS APIs, the request validation middleware automatically determines the validation rules based on the API schema. The only configurable option for the middleware is to set the desired HTTP status code that will be returned if a request fails validation. The default response will be `HTTP 422 Unprocessable Entity` unless otherwise configured.
 
 ## Enabling the request validation middleware
 
-When you create a Tyk OAS API by importing your OpenAPI description, you can instruct Tyk to enable request validation [automatically](#automatically-enabling-the-request-validation-middleware) for all endpoints with defined schemas. If you are creating your API without import, or if you only want to enable request validation for some endpoints, you can [manually enable](#manually-enabling-the-request-validation-middleware) the middleware in the Tyk OAS API definition.
+If the middleware is enabled for an endpoint, then Tyk will automatically validate requests made to that endpoint against the schema defined in the API definition.
+
+When you create a Tyk OAS API by importing your OpenAPI description, you can instruct Tyk to enable request validation [automatically](#automatically-enabling-the-request-validation-middleware) for all endpoints with defined schemas.
+
+If you are creating your API without import, or if you only want to enable request validation for some endpoints, you can [manually enable](#manually-enabling-the-request-validation-middleware) the middleware in the Tyk OAS API definition.
 
 ### Automatically enabling the request validation middleware
 
@@ -55,8 +65,7 @@ The request validation middleware can be enabled for all endpoints that have def
 
 {{< img src="/img/dashboard/api-designer/tyk-oas-validate-request-import.png" alt="Select the option during OpenAPI import to validate requests" >}}
 
-If you want to adjust the configuration, for example to remove validation from specific endpoints or to change the HTTP status code returned on error, you can update the API definition as described [here](#manual-activation-of-request-validation-middleware).
-Note that path-level parameters, or [common parameters](https://swagger.io/docs/specification/v3_0/describing-parameters/#common-parameters), will also be validated when request validation middleware is enabled on an endpoint.
+As noted, the automatic application of request validation during import will apply the middleware to all endpoints declared in your OpenAPI description. If you want to adjust this configuration, for example to remove validation from specific endpoints or to change the HTTP status code returned on error, you can update the Tyk OAS API definition as described [here](#manually-enabling-the-request-validation-middleware).
 
 ### Manually enabling the request validation middleware
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/validate-request-tyk-oas.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/validate-request-tyk-oas.md
@@ -31,7 +31,9 @@ The `parameters` field in the OpenAPI description is an array of [parameter obje
 
 There are also optional `description` and `required` fields.
 
-For each parameter, a schema can be declared that defines the `type` of data that can be stored (e.g. `boolean`, `string`) and any `example` or `default` values.
+For each parameter, a schema can be declared that defines the `type` of data that can be stored (e.g. `boolean`, `string`) and any `example` or `default` values. 
+
+Parameters that apply to all operations within a path can be defined at the [path level](https://swagger.io/docs/specification/v3_0/describing-parameters/#common-parameters) rather than at the operation level. These path-level parameters, also known as common parameters, appear as read-only fields in Tyk Dashboard's OAS endpoint designer. To modify these common parameters, users need to use the OAS raw editor, as changes made from the OAS endpoint editor could impact other endpoints.
 
 ### Request body
 
@@ -54,6 +56,7 @@ The request validation middleware can be enabled for all endpoints that have def
 {{< img src="/img/dashboard/api-designer/tyk-oas-validate-request-import.png" alt="Select the option during OpenAPI import to validate requests" >}}
 
 If you want to adjust the configuration, for example to remove validation from specific endpoints or to change the HTTP status code returned on error, you can update the API definition as described [here](#manual-activation-of-request-validation-middleware).
+Note that path-level parameters, or [common parameters](https://swagger.io/docs/specification/v3_0/describing-parameters/#common-parameters), will also be validated when request validation middleware is enabled on an endpoint.
 
 ### Manually enabling the request validation middleware
 


### PR DESCRIPTION
### **User description**
### For internal users - Please add a Jira DX PR ticket to the subject!
<br>

Parent: https://tyktech.atlassian.net/browse/TT-13281
Subtask: https://tyktech.atlassian.net/browse/TT-13282
---

### Preview Link
<!-- Add a direct preview link to make it easier for the reviewer to review. Best to add a few direct links to the pages in the PR -->
<br>

### Description
<!-- 1. Describe your changes in detail. Why is this change required? What problem does it solve?
     2. Please explain the change to the reviewer. Pay special attention to changes that are hard to spot, 
       for example:
       2.1. Name change in the file name or directory name - please flag it out since it’s hard 
            to compare text after such a change 
       2.2. Terminology change - flag it out to make sure the reviewer is aware before approving
     3. @mentions of the person to review the proposed changes. They need to be able to know the topic well in order to approve it.
-->
<br>

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have added a **preview link** to the PR description.
- [ ] I have reviewed the suggestions made by our AI (PR Agent) and updated them accordingly (spelling errors, rephrasing, etc.)
- [ ] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [ ] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [ ] Make sure you have started *your change* off *our latest `master`*.
- [ ] I **labeled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->


___

### **PR Type**
Documentation


___

### **Description**
- Documented the usage of common parameters in OpenAPI Specification (OAS) within Tyk Dashboard's endpoint designer.
- Explained that common parameters can be defined at the path level and appear as read-only fields in the OAS endpoint designer.
- Clarified that modifications to common parameters should be done using the OAS raw editor to avoid impacting other endpoints.
- Noted that common parameters are subject to validation when request validation middleware is enabled.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate-request-tyk-oas.md</strong><dd><code>Document common parameters usage in OAS endpoint designer</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/middleware/validate-request-tyk-oas.md

<li>Added explanation for defining common parameters at the path level.<br> <li> Clarified that common parameters appear as read-only in Tyk <br>Dashboard's OAS endpoint designer.<br> <li> Noted that common parameters are validated when request validation <br>middleware is enabled.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5682/files#diff-a1293fab5ca25d551b1e27b05df28df73dc208715b7579bca919821a80cfe948">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information