### PR TITLE
[TT-13476] Update documentation for 5.3

### DIFF
--- a/tyk-docs/assets/others/dashboard-admin-swagger.yml
+++ b/tyk-docs/assets/others/dashboard-admin-swagger.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Tyk Dashboard Admin API
-  version: 5.3.0
+  version: 5.3.8
   description: |-
     For Tyk On-Premises installations only, the Dashboard Admin API has two endpoints and is used to set up and provision a Tyk Dashboard instance without the command line.
 

--- a/tyk-docs/assets/others/dashboard-swagger.yml
+++ b/tyk-docs/assets/others/dashboard-swagger.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Tyk Dashboard API
-  version: 5.3.3
+  version: 5.3.8
   description: |-
     ## <a name="introduction"></a> Introduction
 

--- a/tyk-docs/assets/others/gateway-swagger.yml
+++ b/tyk-docs/assets/others/gateway-swagger.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Tyk Gateway API
-  version: 5.3.0
+  version: 5.3.8
   description: |-
     The Tyk Gateway API is the primary means for integrating your application with the Tyk API Gateway system. This API is very small, and has no granular permissions system. It is intended to be used purely for internal automation and integration.
 

--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -153,50 +153,46 @@ Regular expressions and parameterized routes will be left alone regardless of th
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHPREFIXMATCHING</b><br />
 Type: `bool`<br />
 
-EnablePathPrefixMatching changes the URL matching from wildcard mode to prefix mode.
-For example, `/json` matches `*/json*` by current default behaviour.
-If prefix matching is enabled, the match will be performed as a prefix match (`/json*`).
+EnablePathPrefixMatching changes how the gateway matches incoming URL paths against routes (patterns) defined in the API definition.
+By default, the gateway uses wildcard matching. When EnablePathPrefixMatching is enabled, it switches to prefix matching. For example, a defined path such as `/json` will only match request URLs that begin with `/json`, rather than matching any URL containing `/json`.
 
-The `/json` url would be matched as `^/json` against the following paths:
+The gateway checks the request URL against several variations depending on whether path versioning is enabled:
+- Full path (listen path + version + endpoint): `/listen-path/v4/json`
+- Non-versioned full path (listen path + endpoint): `/listen-path/json`
+- Path without version (endpoint only): `/json`
 
-- Full listen path and versioning URL (`/listen-path/v4/json`)
-- Stripped listen path URL (`/v4/json`)
-- Stripped version information (`/json`) - match.
+For patterns that start with `/`, the gateway prepends `^` before performing the check, ensuring a true prefix match.
+For patterns that start with `^`, the gateway will already perform prefix matching so EnablePathPrefixMatching will have no impact.
+This option allows for more specific and controlled routing of API requests, potentially reducing unintended matches. Note that you may need to adjust existing route definitions when enabling this option.
 
-If versioning is disabled then the following URLs are considered:
+Example:
 
-- Full listen path and endpoint (`/listen-path/json`)
-- Stripped listen path (`/json`) - match.
+With wildcard matching, `/json` might match `/api/v1/data/json`.
+With prefix matching, `/json` would not match `/api/v1/data/json`, but would match `/json/data`.
 
-For inputs that start with `/`, a prefix match is ensured by
-prepending the start of string `^` caret.
-
-For all other cases, the pattern remains unmodified.
-
-Combine this option with `enable_path_suffix_matching` to achieve
-exact url matching with `/json` being evaluated as `^/json$`.
+Combining EnablePathPrefixMatching with EnablePathSuffixMatching will result in exact URL matching, with `/json` being evaluated as `^/json$`.
 
 ### http_server_options.enable_path_suffix_matching
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHSUFFIXMATCHING</b><br />
 Type: `bool`<br />
 
-EnablePathSuffixMatching changes the URL matching to match as a suffix.
-For example: `/json` is matched as `/json$` against the following paths:
+EnablePathSuffixMatching changes how the gateway matches incoming URL paths against routes (patterns) defined in the API definition.
+By default, the gateway uses wildcard matching. When EnablePathSuffixMatching is enabled, it switches to suffix matching. For example, a defined path such as `/json` will only match request URLs that end with `/json`, rather than matching any URL containing `/json`.
 
-- Full listen path and versioning URL (`/listen-path/v4/json`)
-- Stripped listen path URL (`/v4/json`)
-- Stripped version information (`/json`) - match.
+The gateway checks the request URL against several variations depending on whether path versioning is enabled:
+- Full path (listen path + version + endpoint): `/listen-path/v4/json`
+- Non-versioned full path (listen path + endpoint): `/listen-path/json`
+- Path without version (endpoint only): `/json`
 
-If versioning is disabled then the following URLs are considered:
+For patterns that already end with `$`, the gateway will already perform suffix matching so EnablePathSuffixMatching will have no impact. For all other patterns, the gateway appends `$` before performing the check, ensuring a true suffix match.
+This option allows for more specific and controlled routing of API requests, potentially reducing unintended matches. Note that you may need to adjust existing route definitions when enabling this option.
 
-- Full listen path and endpoint (`/listen-path/json`)
-- Stripped listen path (`/json`) - match.
+Example:
 
-If the input pattern already ends with a `$` (`/json$`)
-then the pattern remains unmodified.
+With wildcard matching, `/json` might match `/api/v1/json/data`.
+With suffix matching, `/json` would not match `/api/v1/json/data`, but would match `/api/v1/json`.
 
-Combine this option with `enable_path_prefix_matching` to achieve
-exact url matching with `/json` being evaluated as `^/json$`.
+Combining EnablePathSuffixMatching with EnablePathPrefixMatching will result in exact URL matching, with `/json` being evaluated as `^/json$`.
 
 ### http_server_options.ssl_insecure_skip_verify
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_SSLINSECURESKIPVERIFY</b><br />

--- a/tyk-docs/content/shared/x-tyk-gateway.md
+++ b/tyk-docs/content/shared/x-tyk-gateway.md
@@ -647,6 +647,9 @@ Tyk classic API definition: `hmac_allowed_clock_skew`.
 ### **OIDC**
 
 OIDC contains configuration for the OIDC authentication mode.
+OIDC support will be deprecated starting from 5.7.0.
+To avoid any disruptions, we recommend that you use JSON Web Token (JWT) instead,
+as explained in https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/openid-connect/.
 
 **Field: `enabled` (`boolean`)**
 Enabled activates the OIDC authentication mode.
@@ -1296,6 +1299,9 @@ Value is the configured timeout in seconds.
 ### **ExternalOAuth**
 
 ExternalOAuth holds configuration for an external OAuth provider.
+ExternalOAuth support will be deprecated starting from 5.7.0.
+To avoid any disruptions, we recommend that you use JSON Web Token (JWT) instead,
+as explained in https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/ext-oauth-middleware/.
 
 **Field: `enabled` (`boolean`)**
 Enabled activates external oauth functionality.


### PR DESCRIPTION
### **User description**
Triggered by: lghiur

Included:

Tyk Gateway: true
Tyk Dashboard: true
Tyk MDCB false
Tyk Pump false

Intended for: 5.3
Changes sourced from: release-5.3.8
Config info generator branch: main

Note: Docs for 5.3.8 (branch suffix: docs)

JIRA: https://tyktech.atlassian.net/browse/TT-13476


___

### **PR Type**
Documentation


___

### **Description**
- Updated API versions in Swagger files to 5.3.8 for Dashboard Admin, Dashboard, and Gateway APIs.
- Clarified documentation on URL path matching configurations, including examples for prefix and suffix matching.
- Added deprecation notices for OIDC and ExternalOAuth, recommending the use of JWT instead.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-admin-swagger.yml</strong><dd><code>Update Dashboard Admin API version to 5.3.8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/others/dashboard-admin-swagger.yml

- Updated API version from 5.3.0 to 5.3.8.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5699/files#diff-83878808ab8520d5dfcff9ddb8981f481b3f6a977b4f4aa344f681131ae9a1ad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dashboard-swagger.yml</strong><dd><code>Update Dashboard API version to 5.3.8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/others/dashboard-swagger.yml

- Updated API version from 5.3.3 to 5.3.8.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5699/files#diff-97d3961fa92a4034f55bb3ca902c734bec0a55b4f9b4fc6466f6750da7ca5021">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gateway-swagger.yml</strong><dd><code>Update Gateway API version to 5.3.8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/others/gateway-swagger.yml

- Updated API version from 5.3.0 to 5.3.8.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5699/files#diff-86641d5f43d842a51680c692c0ca3cd7d7e67776df7bf1409cf97f83a885ad99">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gateway-config.md</strong><dd><code>Clarify URL path matching configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/gateway-config.md

<li>Clarified URL matching behavior for path prefix and suffix matching.<br> <li> Improved examples for path matching configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5699/files#diff-0a53845669feaeb0d62d4b17d24bfee5fc23482ec7562bd52e23db03373f14d0">+25/-29</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-gateway.md</strong><dd><code>Add deprecation notice for OIDC and ExternalOAuth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/x-tyk-gateway.md

<li>Added deprecation notice for OIDC and ExternalOAuth starting from <br>version 5.7.0.<br> <li> Recommended using JWT as an alternative.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5699/files#diff-c4c21855fe9a7bb5c25d2f53fd19b2c5afec3ef3f8ca54c0105d8bfe197ff31c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information