### PR TITLE
Merging to release-5.6: [DX-1798] Driver in the wrong position in manifest.json - go bundle example (#5710)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/advanced-configurations/plugins/golang/loading-go-plugins.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/advanced-configurations/plugins/golang/loading-go-plugins.md
@@ -100,9 +100,10 @@ The contents of `manifest.json`:
         "name": "AddFooBarHeader",
         "path": "AddFooBarHeader.so"
       }
-    ]
+    ],
+    "driver": "goplugin"
   },
-  "driver": "goplugin",
+
   ...
 }
 ```


### PR DESCRIPTION
### **User description**
[DX-1798] Driver in the wrong position in manifest.json - go bundle example (#5710)

Update loading-go-plugins.md

The driver needs to be inside the "custom_middleware"


___

### **PR Type**
Documentation


___

### **Description**
- Corrected the position of the `driver` field in the `manifest.json` example within the documentation to ensure it is inside the `custom_middleware` array.
- This change clarifies the correct structure of the `manifest.json` file for users implementing Go plugins.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loading-go-plugins.md</strong><dd><code>Corrected `driver` field position in `manifest.json` example</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/advanced-configurations/plugins/golang/loading-go-plugins.md

<li>Moved the <code>driver</code> field inside the <code>custom_middleware</code> array in the <br><code>manifest.json</code> example.<br> <li> Corrected the position of the <code>driver</code> field for clarity and accuracy.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5712/files#diff-7ebf7b8ec1dafac7ce19f79f6b16643cfaee642a7aa61f5142246fd132a90cac">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information