### PR TITLE
validate anchor links failure

### DIFF
--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -27,3 +27,4 @@ jobs:
         uses: wjdp/htmltest-action@master
         with:
           config: .htmltest.yml
+          log_level: 0

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -5,5 +5,6 @@ IgnoreDirectoryMissingTrailingSlash: true
 CheckInternalHash: false
 IgnoreEmptyHref: true
 CheckExternal: false
+CheckAnchors: true
 IgnoreURLs:
   - "apps"

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -2,7 +2,7 @@ DirectoryPath: "tyk-docs/public"
 IgnoreAltMissing: true
 IgnoreAltEmpty: true
 IgnoreDirectoryMissingTrailingSlash: true
-CheckInternalHash: false
+CheckInternalHash: true
 IgnoreEmptyHref: true
 CheckExternal: false
 CheckAnchors: true

--- a/tyk-docs/content/apim/open-source.md
+++ b/tyk-docs/content/apim/open-source.md
@@ -30,4 +30,4 @@ Please show your support for the Gateway by clicking the GitHub link, then addin
 
 ## Get Started
 
-To Get started, simply install [Tyk Open Source]({{< ref "apim/open-source/installation" >}}), and then create your first API!
+To Get started, simply install [Tyk Open Source]({{< ref "apim/open-source/installation#test-anchor-validation" >}}), and then create your first API!

--- a/tyk-docs/content/apim/open-source.md
+++ b/tyk-docs/content/apim/open-source.md
@@ -11,7 +11,7 @@ aliases:
   - /apim/open-source/getting-started/
 ---
 
-
+To Get started, simply install [Tyk Open Source]({{< ref "apim/open-source/installation/#other-tyk-open-source-components" >}}), and then create your first API!
 
 Open source is at the heart of what we do. Anything that is API Gateway-related, lives in the Gateway, or is critical for the Gateway to work is open and freely available via our [Github](https://github.com/TykTechnologies/).
 

--- a/tyk-docs/content/apim/open-source.md
+++ b/tyk-docs/content/apim/open-source.md
@@ -11,7 +11,7 @@ aliases:
   - /apim/open-source/getting-started/
 ---
 
-To Get started, simply install [Tyk Open Source]({{< ref "apim/open-source/installation/#other-tyk-open-source-components" >}}), and then create your first API!
+To Get started, simply install [Tyk Open Source]({{< ref "apim/open-source/installation#other-tyk-open-source-components" >}}), and then create your first API!
 
 Open source is at the heart of what we do. Anything that is API Gateway-related, lives in the Gateway, or is critical for the Gateway to work is open and freely available via our [Github](https://github.com/TykTechnologies/).
 


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Updated the anchor link in the 'Get Started' section of the documentation to ensure it points to the correct section for installation.
- This change is intended to validate the anchor link functionality and improve navigation within the documentation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>open-source.md</strong><dd><code>Update anchor link for installation reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/apim/open-source.md

<li>Updated the anchor link in the 'Get Started' section.<br> <li> Changed the reference to include a specific anchor for validation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5720/files#diff-dbdbda15a48850d568773b019bee9ddbfe83faf930d4b28ff7296839ff3fa512">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information