### PR TITLE
Merging to release-5.6: Fix operator license instruction (#5743)

### DIFF
--- a/tyk-docs/content/api-management/automations.md
+++ b/tyk-docs/content/api-management/automations.md
@@ -340,6 +340,8 @@ Tyk Stack, Tyk Control Plane or Tyk OSS helm chart by setting `global.license.op
 key via a Kubernetes secret using `global.secrets.useSecretName` field. The secret should contain a key called
 `OperatorLicense`
 
+Note: If you are using `global.secrets.useSecretName`, you must configure the operator license in the referenced Kubernetes secret. `global.license.operator` will not be used in this case.
+
 #### Option 2: Install Tyk Operator via stand-alone Helm Chart
 
 If you prefer to install Tyk Operator separately, follow this section to install Tyk Operator using Helm.

--- a/tyk-docs/content/product-stack/tyk-charts/tyk-control-plane-chart.md
+++ b/tyk-docs/content/product-stack/tyk-charts/tyk-control-plane-chart.md
@@ -468,6 +468,8 @@ global:
 
 It can be configured via `global.license.operator` as a plain text or Kubernetes secret which includes `OperatorLicense` key in it. Then, this secret must be referenced via `global.secrets.useSecretName`.
 
+Note: If you are using `global.secrets.useSecretName`, you must configure the operator license in the referenced Kubernetes secret. `global.license.operator` will not be used in this case.
+
 ### Gateway Configurations
 
 {{< note success >}}

--- a/tyk-docs/content/product-stack/tyk-charts/tyk-oss-chart.md
+++ b/tyk-docs/content/product-stack/tyk-charts/tyk-oss-chart.md
@@ -217,6 +217,8 @@ global:
 
 It can be configured via `global.license.operator` as a plain text or Kubernetes secret which includes `OperatorLicense` key in it. Then, this secret must be referenced via `global.secrets.useSecretName`.
 
+Note: If you are using `global.secrets.useSecretName`, you must configure the operator license in the referenced Kubernetes secret. `global.license.operator` will not be used in this case.
+
 ### Create a Kubernetes Secret for Tyk Operator
 
 When `operatorSecret.enabled` is set to `true`, `tyk-oss` chart will create a Kubernetes Secret named `tyk-operator-conf` in the same namespace. It can be used by Tyk Operator to connect to Gateway to manage Tyk API resources.

--- a/tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md
+++ b/tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md
@@ -457,6 +457,8 @@ global:
 
 It can be configured via `global.license.operator` as a plain text or Kubernetes secret which includes `OperatorLicense` key in it. Then, this secret must be referenced via `global.secrets.useSecretName`.
 
+Note: If you are using `global.secrets.useSecretName`, you must configure the operator license in the referenced Kubernetes secret. `global.license.operator` will not be used in this case.
+
 ### Gateway Configurations
 
 This section explains how to configure the `tyk-gateway` section for updating the Gateway version, enabling TLS, enabling autoscaling etc.


### PR DESCRIPTION
### **User description**
Fix operator license instruction (#5743)

Co-authored-by: Sharad Regoti <sharadregoti15@gmail.com>


___

### **PR Type**
Documentation


___

### **Description**
- Added clarification notes in multiple documentation files regarding the use of `global.secrets.useSecretName` for operator license configuration.
- Specified that when using `global.secrets.useSecretName`, the operator license must be configured in the referenced Kubernetes secret, and `global.license.operator` will not be used.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>automations.md</strong><dd><code>Clarify operator license configuration with Kubernetes secrets</code></dd></summary>
<hr>

tyk-docs/content/api-management/automations.md

<li>Added a note about using <code>global.secrets.useSecretName</code>.<br> <li> Clarified that <code>global.license.operator</code> is not used when using <br><code>global.secrets.useSecretName</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5755/files#diff-5382e34a07c0b329592a0b4f3159e7024d8a42e2577f472a548cbb2f50e23b4c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-control-plane-chart.md</strong><dd><code>Clarify operator license configuration with Kubernetes secrets</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-charts/tyk-control-plane-chart.md

<li>Added a note about using <code>global.secrets.useSecretName</code>.<br> <li> Clarified that <code>global.license.operator</code> is not used when using <br><code>global.secrets.useSecretName</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5755/files#diff-1bb3ae7ce6b5aec344682558fe28a0e91ef5504473fbed884ae4651089784cf7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-oss-chart.md</strong><dd><code>Clarify operator license configuration with Kubernetes secrets</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-charts/tyk-oss-chart.md

<li>Added a note about using <code>global.secrets.useSecretName</code>.<br> <li> Clarified that <code>global.license.operator</code> is not used when using <br><code>global.secrets.useSecretName</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5755/files#diff-53fd570dd4fbaa9b39eca159ac973030b7f820da118b68df42df490432741dd5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-stack-chart.md</strong><dd><code>Clarify operator license configuration with Kubernetes secrets</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md

<li>Added a note about using <code>global.secrets.useSecretName</code>.<br> <li> Clarified that <code>global.license.operator</code> is not used when using <br><code>global.secrets.useSecretName</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5755/files#diff-f6e45bbf530fa763d587dec798584c8eb6294229ef353d3212ab01bf6b0a1d7c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information