### PR TITLE
Merging to release-5.7: Remove source download option for Tyk Sync (#5796)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-sync/release-notes/sync-2.0.md
+++ b/tyk-docs/content/product-stack/tyk-sync/release-notes/sync-2.0.md
@@ -40,7 +40,6 @@ Go to the [Upgrading Tyk](#upgrading-tyk) section for detailed upgrade Instructi
   - ```bash
     docker pull tykio/tyk-sync:v2.0.1
     ```
-- [Source code](https://github.com/TykTechnologies/tyk-sync/releases/tag/v2.0.1)
 
 ### Changelog {#Changelog-v2.0.1}
 
@@ -113,7 +112,6 @@ Go to the [Upgrading Tyk](#upgrading-tyk) section for detailed upgrade Instructi
   - ```bash
     docker pull tykio/tyk-sync:v2.0.0
     ```
-- [Source code](https://github.com/TykTechnologies/tyk-sync/releases/tag/v2.0.0)
 
 ### Changelog {#Changelog-v2.0.0}
 


### PR DESCRIPTION
### **User description**
Remove source download option for Tyk Sync (#5796)

Update sync-2.0.md


___

### **PR Type**
Documentation


___

### **Description**
- Removed the source code download links for Tyk Sync versions 2.0.0 and 2.0.1 from the release notes.
- Updated the documentation to align with the decision to no longer provide source code download options for these versions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync-2.0.md</strong><dd><code>Removed source code download links from Tyk Sync release notes</code></dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-sync/release-notes/sync-2.0.md

<li>Removed the source code download link for Tyk Sync version 2.0.1.<br> <li> Removed the source code download link for Tyk Sync version 2.0.0.<br> <li> Adjusted release notes to exclude source code download options.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5797/files#diff-6d788ccf1067cc6134cc78b88421f348cb9bb67eda9504442e9db45913938bf2">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information