### PR TITLE
Merging to release-5.7: Add Missing Release Note to 5.7.0 (#5793)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.7.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.7.md
@@ -203,6 +203,13 @@ Resolved a bug where path-based permissions in policies were not preserved when 
 </li>
 <li>
 <details>
+<summary>Resolved API Routing Issue with Trailing Slashes and Overlapping Listen Paths</summary>
+
+Fixed a routing issue that caused incorrect API matching when dealing with APIs that lacked a trailing slash, used custom domains, or had similar listen path patterns. Previously, the router prioritized APIs with longer subdomains and shorter listen paths, leading to incorrect matches when listen paths shared prefixes. This fix ensures accurate API matching, even when subdomains and listen paths overlap.
+</details>
+</li>
+<li>
+<details>
 <summary>Optimized Gateway Handling for Large Payloads</summary>
 
 Fixed an issue that caused increased memory consumption when proxying large response payloads. The Gateway now handles large payloads more efficiently in terms of speed and memory usage.


### PR DESCRIPTION
### **User description**
Add Missing Release Note to 5.7.0 (#5793)


___

### **PR Type**
Documentation


___

### **Description**
- Added a missing release note to the Tyk Gateway version 5.7.0 change log.
- Documented the resolution of an API routing issue involving trailing slashes, custom domains, and overlapping listen paths.
- Clarified how the fix ensures accurate API matching in complex scenarios.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version-5.7.md</strong><dd><code>Added release note for API routing issue fix.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-gateway/release-notes/version-5.7.md

<li>Added a new release note entry for resolving an API routing issue.<br> <li> Detailed the fix for incorrect API matching with trailing slashes, <br>custom domains, and overlapping listen paths.<br> <li> Clarified how the fix ensures accurate API matching in complex <br>scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5802/files#diff-c6078f491c561bb077c045907f614b4555511fa140b378c67c5d5f3ef515ead5">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information