### PR TITLE
Merging to release-5.7: typo (casing) (#5803)

### DIFF
--- a/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-throttling.md
+++ b/tyk-docs/content/basic-config-and-security/control-limit-traffic/request-throttling.md
@@ -41,5 +41,5 @@ Yes, you can. If you set `throttle_interval` and `throttle_retry_limit` values t
 
 ## Set Request Throttling in the object
 
-Get the policy object with `GET /api/portal/policies/` or the key's session object via `GET /api/apis/{aPI-ID}/keys/` and then  set two fields, `throttle_interval` and `throttle_retry_limit` in the object and create a new object or update the exsiting one.
+Get the policy object with `GET /api/portal/policies/` or the key's session object via `GET /api/apis/{API-ID}/keys/` and then  set two fields, `throttle_interval` and `throttle_retry_limit` in the object and create a new object or update the exsiting one.
    


### PR DESCRIPTION
### **User description**
typo (casing) (#5803)

Update request-throttling.md


___

### **PR Type**
Documentation


___

### **Description**
- Corrected the casing of `API-ID` in the endpoint example to ensure consistency and accuracy in the documentation.
- Added a newline at the end of the file to adhere to formatting standards.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>request-throttling.md</strong><dd><code>Fix casing and formatting in request throttling documentation</code></dd></summary>
<hr>

tyk-docs/content/basic-config-and-security/control-limit-traffic/request-throttling.md

<li>Corrected the casing of <code>API-ID</code> in the endpoint example.<br> <li> Added a newline at the end of the file for proper formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5810/files#diff-46913219c9a964789a868bb0f471e2ba7dfeae5b850d926f2b1090ae63412eab">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information