### PR TITLE
Merging to release-5.7: [TT-13742] Update documentation for master (#5840)

### DIFF
--- a/tyk-docs/assets/others/dashboard-swagger.yml
+++ b/tyk-docs/assets/others/dashboard-swagger.yml
@@ -38,7 +38,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Dashboard API
-  version: 5.7.0
+  version: 5.7.1
 servers:
 - url: https://{tenant}
   variables:

--- a/tyk-docs/assets/others/gateway-swagger.yml
+++ b/tyk-docs/assets/others/gateway-swagger.yml
@@ -30,7 +30,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.7.0
+  version: 5.7.1
 servers:
 - url: https://{tenant}
   variables:

--- a/tyk-docs/content/shared/dashboard-config.md
+++ b/tyk-docs/content/shared/dashboard-config.md
@@ -838,6 +838,18 @@ Type: `string`<br />
 
 When using SAML with embedded identity broker, is required to upload a certificate that is encoded by the gateway to store it safely, TIB needs the private key as well, hence it needs the same encoding secret so the information is decoded successfully. This value should match with the encoding secret set in the gateway config file, if not set then it will use by default tyk_api_config.secret to attempt to decode the certificate.
 
+### security.forbid_admin_view_access_token
+ENV: <b>TYK_DB_SECURITY_FORBIDADMINVIEWACCESSTOKEN</b><br />
+Type: `bool`<br />
+
+ForbidAdminViewAccessToken is a security feature that allows you to prevent the admin user from viewing the access token of a user. The default is false.
+
+### security.forbid_admin_reset_access_token
+ENV: <b>TYK_DB_SECURITY_FORBIDADMINRESETACCESSTOKEN</b><br />
+Type: `bool`<br />
+
+ForbidAdminResetAccessToken is a security feature that allows you to prevent the admin user from resetting the access token of a user. The default is false.
+
 ### ui
 This section controls various settings for the look and feel of the Dashboard UI.
 

--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -725,6 +725,9 @@ If set to `true`, distributed rate limiter will be disabled for this node, and i
 If you set `db_app_conf_options.node_is_segmented` to `true` for multiple Gateway nodes, you should ensure that `management_node` is set to `false`.
 This is to ensure visibility for the management node across all APIs.
 {{< /note >}}
+For pro installations, `management_node` is not a valid configuration option.
+Always set `management_node` to `false` in pro environments.
+
 
 ### auth_override
 This is used as part of the RPC / Hybrid back-end configuration in a Tyk Enterprise installation and isn’t used anywhere else.


### PR DESCRIPTION
### **User description**
[TT-13742] Update documentation for master (#5840)

[TT-13742]: https://tyktech.atlassian.net/browse/TT-13742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Updated API versions in both `dashboard-swagger.yml` and `gateway-swagger.yml` files from `5.7.0` to `5.7.1`.
- Added two new security configuration options in `dashboard-config.md`:
  - `security.forbid_admin_view_access_token`: Prevents admin users from viewing user access tokens.
  - `security.forbid_admin_reset_access_token`: Prevents admin users from resetting user access tokens.
- Clarified the `management_node` configuration in `gateway-config.md` for pro installations, specifying it should always be set to `false`.
- Fixed a missing newline at the end of the `gateway-swagger.yml` file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-swagger.yml</strong><dd><code>Update API version in Dashboard Swagger file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/others/dashboard-swagger.yml

- Updated the API version from `5.7.0` to `5.7.1`.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5847/files#diff-97d3961fa92a4034f55bb3ca902c734bec0a55b4f9b4fc6466f6750da7ca5021">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway-swagger.yml</strong><dd><code>Update API version in Gateway Swagger file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/others/gateway-swagger.yml

<li>Updated the API version from <code>5.7.0</code> to <code>5.7.1</code>.<br> <li> Fixed newline at the end of the file.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5847/files#diff-86641d5f43d842a51680c692c0ca3cd7d7e67776df7bf1409cf97f83a885ad99">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboard-config.md</strong><dd><code>Add new security configuration options for Dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/dashboard-config.md

<li>Added two new security configuration options: <br><code>security.forbid_admin_view_access_token</code> and <br><code>security.forbid_admin_reset_access_token</code>.<br> <li> Documented their environment variables, types, and default values.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5847/files#diff-2af548b55c5ac98b8a1c1c3f8e44cb38709a34e988c684247b81029f2b173433">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway-config.md</strong><dd><code>Clarify `management_node` configuration for pro installations</code></dd></summary>
<hr>

tyk-docs/content/shared/gateway-config.md

<li>Added a note clarifying the <code>management_node</code> configuration for pro <br>installations.<br> <li> Specified that <code>management_node</code> should always be set to <code>false</code> in pro <br>environments.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5847/files#diff-0a53845669feaeb0d62d4b17d24bfee5fc23482ec7562bd52e23db03373f14d0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information