### PR TITLE
Merging to release-5.7: url-matching.md - Prefix match - amend env var reference (#5866)

### DIFF
--- a/tyk-docs/content/getting-started/key-concepts/url-matching.md
+++ b/tyk-docs/content/getting-started/key-concepts/url-matching.md
@@ -218,7 +218,7 @@ For example, the pattern `/user` will match all of the following URLs:
 
 ### Prefix match
 
-When [TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHSUFFIXMATCHING]({{< ref "tyk-oss-gateway/configuration#http_server_optionsenable_path_prefix_matching" >}}) is enabled, the Gateway switches to prefix matching where it treats the configured pattern as a prefix which will only match against the beginning of the path. For example, a pattern such as `/json` will only match request URLs that begin with `/json`, rather than matching any URL containing `/json`.
+When [TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHPREFIXMATCHING]({{< ref "tyk-oss-gateway/configuration#http_server_optionsenable_path_prefix_matching" >}}) is enabled, the Gateway switches to prefix matching where it treats the configured pattern as a prefix which will only match against the beginning of the path. For example, a pattern such as `/json` will only match request URLs that begin with `/json`, rather than matching any URL containing `/json`.
 
 The gateway checks the request URL against several variations depending on whether path versioning is enabled:
 
@@ -228,7 +228,7 @@ The gateway checks the request URL against several variations depending on wheth
 
 The logic behind prefix matching is that it prepends the start of string symbol (`^`) if the URL begins with a `/`, to ensure that the URL begins with the specified pattern. For example, `/json` would be evaluated as `^/json`.
 
-For patterns that already start with `^`, the gateway will already perform prefix matching so `TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHSUFFIXMATCHING` will have no impact.
+For patterns that already start with `^`, the gateway will already perform prefix matching so `TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHPREFIXMATCHING` will have no impact.
 
 This option allows for more specific and controlled routing of API requests, potentially reducing unintended matches. Note that you may need to adjust existing route definitions when enabling this option.
 


### PR DESCRIPTION
### **User description**
url-matching.md - Prefix match - amend env var reference (#5866)


___

### **PR Type**
Documentation


___

### **Description**
- Corrected the environment variable reference in `url-matching.md`.

- Updated documentation for prefix matching configuration.

- Improved clarity on the impact of the configuration option.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>url-matching.md</strong><dd><code>Corrected environment variable reference in documentation</code></dd></summary>
<hr>

tyk-docs/content/getting-started/key-concepts/url-matching.md

<li>Corrected the environment variable name from <br><code>TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHSUFFIXMATCHING</code> to <br><code>TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHPREFIXMATCHING</code>.<br> <li> Updated references in two instances within the prefix matching <br>section.<br> <li> Ensured documentation aligns with the correct configuration option.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5872/files#diff-672ca9717aaee1c455840ae52a39c6116530032b0622d5a86edf0fa22861b3a2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information