### PR TITLE
Merging to release-5.7: Remove Time From Page (#5928)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/page_metadata.html
+++ b/tyk-docs/themes/tykio/layouts/partials/page_metadata.html
@@ -8,15 +8,16 @@
 <p class="last-modified-date">Last updated:
     <time datetime="2023-04-08T06:57:07.000Z">{{$lastmod}}</time>
     
-    <svg class="svg-icon" aria-hidden="true" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" width="18"
+    <!-- Uncomment the below code to show page read time -->
+    <!-- <svg class="svg-icon" aria-hidden="true" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" width="18"
     height="12" viewBox="0 0 512 512">
         <path
             d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z">
         </path>
-    </svg>
+    </svg> -->
 
-    {{ $readTime := cond (gt .ReadingTime 1) "minutes" "minute" }}
-    {{ .ReadingTime }} {{$readTime}} read.
+    <!-- {{ $readTime := cond (gt .ReadingTime 1) "minutes" "minute" }}
+    {{ .ReadingTime }} {{$readTime}} read. -->
 </p>
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
### **User description**
Remove Time From Page (#5928)


___

### **PR Type**
Enhancement


___

### **Description**
- Removed the display of page reading time.

- Commented out SVG icon and reading time code.

- Simplified metadata display logic for clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page_metadata.html</strong><dd><code>Removed page reading time and related SVG icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/themes/tykio/layouts/partials/page_metadata.html

<li>Commented out SVG icon for reading time.<br> <li> Disabled display of page reading time.<br> <li> Simplified metadata display logic for better clarity.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5929/files#diff-ce4884a133d16d61d088bd2f09168837aca7fbcc1b65734ec996847b5dbddec5">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>