### PR TITLE
Merging to release-5.7: [DX-1812] Removed 14 day trial option of Tyk Self Managed (#5971)

### DIFF
--- a/tyk-docs/content/shared/self-managed-licensing-include.md
+++ b/tyk-docs/content/shared/self-managed-licensing-include.md
@@ -1,14 +1,10 @@
 ---
 ---
 
-Tyk Self-Managed is the easiest way to install Tyk Full Lifecycle API Management solution in your infrastructure. There is no calling home, and there are no usage limits. You have full control. 
+Tyk Self-Managed is the easiest way to install Tyk Full Lifecycle API Management solution in your infrastructure. There is no calling home, and there are no usage limits. You have complete control. 
 
 See [licensing and deployment models]({{< ref "tyk-self-managed#tyk-self-managed-licensepricing" >}}) to learn about the different deployment options for Self-Managed.
 
-Register here to get a 14-day temporary licenses for the Tyk Dashboard & Developer Portal:
-
-{{< button_left href="https://tyk.io/sign-up/" color="green" content="Free trial" >}}
-
-For longer duration trials, or to request trials of the other proprietary software please contact the Tyk Team and tell us about your plans:
+Contact us to get started with Tyk Self Managed.
 
 {{< button_left href="https://tyk.io/contact/" color="green" content="Contact us" >}}


### PR DESCRIPTION
### **User description**
[DX-1812] Removed 14 day trial option of Tyk Self Managed (#5971)

[DX-1812]: https://tyktech.atlassian.net/browse/DX-1812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Removed references to the 14-day trial for Tyk Self-Managed.

- Updated call-to-action to "Contact us" for inquiries.

- Simplified and clarified the description of Tyk Self-Managed.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>self-managed-licensing-include.md</strong><dd><code>Removed 14-day trial and updated call-to-action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/self-managed-licensing-include.md

<li>Removed mention of 14-day temporary licenses.<br> <li> Updated call-to-action to "Contact us" for inquiries.<br> <li> Simplified the description of Tyk Self-Managed.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5972/files#diff-b46c343a3cf502455a2e6f2507461b16ef81846d3ef643d79786035d023f46e1">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>