### PR TITLE
Merging to release-5.7: Updating with proper documentation for plugin manifests. (#5936)

### DIFF
--- a/tyk-docs/content/plugins/how-to-serve-plugins/plugin-bundles.md
+++ b/tyk-docs/content/plugins/how-to-serve-plugins/plugin-bundles.md
@@ -55,6 +55,9 @@ A plugin bundle must include a manifest file (called `manifest.json`). The manif
 
 A sample manifest file looks like this:
 
+- The `name` is the function to be invoked upon a specific plugin hook.  
+- The `path` is the name of the file which contains the function. Note that you can not have nested paths or subdirectories in the path specification. 
+
 ```json
 {
   "file_list": [
@@ -64,12 +67,14 @@ A sample manifest file looks like this:
   "custom_middleware": {
     "pre": [
       {
-        "name": "PreMiddleware"
+        "name": "PreMiddleware",
+        "path": "middleware.py"
       }
     ],
     "post": [
       {
-        "name": "PostMiddleware"
+        "name": "PostMiddleware",
+        "path": "middleware.py"
       }
     ],
     "driver": "python"


### PR DESCRIPTION
### **User description**
Updating with proper documentation for plugin manifests. (#5936)


___

### **PR Type**
Documentation


___

### **Description**
- Updated `manifest.json` example to include "path" field.

- Added explanations for "name" and "path" fields in manifest.

- Clarified restrictions on nested paths in "path" field.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin-bundles.md</strong><dd><code>Updated `manifest.json` example and field explanations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/plugins/how-to-serve-plugins/plugin-bundles.md

<li>Added "path" field to <code>manifest.json</code> example.<br> <li> Explained "name" and "path" fields in manifest.<br> <li> Clarified restrictions on nested paths in "path".


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5975/files#diff-56b47499862d45992e9fc7d3403746ef403818831c39d78e0a4b5aa14a7216c0">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>