### PR TITLE
Merging to release-5.7: [DX-1814] Correct error in Tyk OAS auth examples (#5976)

### DIFF
--- a/tyk-docs/content/api-management/gateway-config-tyk-oas.md
+++ b/tyk-docs/content/api-management/gateway-config-tyk-oas.md
@@ -330,6 +330,7 @@ securitySchemes: {
         "petstore_auth": {
           "enabled": true,
           "header": {
+            "enabled": true,
             "name": "Authorization"
           }
         }
@@ -367,6 +368,7 @@ securitySchemes: {
         "petstore_auth": {
           "enabled": true,
           "header": {
+            "enabled": true,
             "name": "Authorization"
           }
         }
@@ -417,6 +419,7 @@ Example:
             "petstore_auth": {
               "enabled": true,
               "header": {
+                "enabled": true,
                 "name": "Authorization"
               },
               "allowedAccessTypes": [
@@ -504,17 +507,7 @@ For the above OAS configuration, Tyk looks at only the first `security` object:
 ```
 Please observe the presence of the `baseIdentityProvider` field, as this is required when enabling multiple authentication mechanisms at the same time. See [Multiple Auth documentation]({{< ref "api-management/client-authentication#combine-authentication-methods" >}}) for more details.
 
-#### Other Authentication mechanisms
-
-For now, the only authentication mechanisms enabled with OAS API Definition configuration are: 
-- Authentication Token
-- Basic Authentication
-- JSON Web Token (JWT)
-- Tyk as OAuth authorization server
-
-To find out about the other client authentication methods supported by Tyk, see [Client Authentication]({{< ref "api-management/client-authentication" >}}).
-
-#### Automatically protecting OAS API Definition APIs
+#### Automatically protecting Tyk OAS APIs
 
 All the Authentication mechanisms documented above can be automatically configured by Tyk at the time of import if the request is followed by the `authentication=true` query parameter. (Import task link)
 


### PR DESCRIPTION
### **User description**
[DX-1814] Correct error in Tyk OAS auth examples (#5976)

[DX-1814]: https://tyktech.atlassian.net/browse/DX-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Added `enabled` field to Tyk OAS auth examples.

- Updated section title for protecting Tyk OAS APIs.

- Removed redundant details on other authentication mechanisms.

- Enhanced clarity and accuracy of Tyk OAS documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-config-tyk-oas.md</strong><dd><code>Fix and enhance Tyk OAS authentication documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/api-management/gateway-config-tyk-oas.md

<li>Added <code>enabled</code> field in multiple Tyk OAS auth examples.<br> <li> Updated section title for automatically protecting Tyk OAS APIs.<br> <li> Removed redundant details on other authentication mechanisms.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/5982/files#diff-4ab5595e48e7421884aeb23c345cff8eef8e0e2f5729c9e8eec5baafc927da50">+4/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>