### PR TITLE
Added Time Range for EOD Report Generator GH

### DIFF
--- a/.github/workflows/eod-report-generator.yaml
+++ b/.github/workflows/eod-report-generator.yaml
@@ -7,8 +7,11 @@ on:
         description: "The GitHub user ID of the primary reviewer whose approval is required for the PR."
         required: true
         default: "sharadregoti"
-      PR_SCAN_DATE:
-        description: "The date when the report was generated. Defaults to the current date (e.g., 2025-02-04)."
+      START_DATE:
+        description: "The start date of report (e.g., 2025-02-21T00:00:00.000Z)."
+        required: true
+      END_DATE:
+        description: "The end date of report. Defaults to the current date (e.g., 2025-02-25T00:00:00.000Z)."
         required: false
 
 jobs:
@@ -35,6 +38,7 @@ jobs:
           node index.js
         env:
           MAIN_REVIEWER: ${{ inputs.MAIN_REVIEWER }}
-          PR_SCAN_DATE: ${{ inputs.PR_SCAN_DATE }}
+          START_DATE: ${{ inputs.START_DATE }}
+          END_DATE: ${{ inputs.END_DATE }}
           GITHUB_TOKEN: ${{ secrets.TYK_SCRIPTS_TOKEN }}  # GitHub Token for API calls
           ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_KEY }} # Org key already available

--- a/scripts/eod-report-generator/github.js
+++ b/scripts/eod-report-generator/github.js
@@ -97,13 +97,14 @@ export async function getPRReviews(owner, repo, pull_number) {
     }
 }
 
-export async function getMergedPRsAfterDate(owner, repo, mergeDate) {
+export async function getMergedPRsAfterDate(owner, repo, startDate, endDate) {
     try {
         // Convert the provided merge date to a Date object for comparison
-        const mergeDateObj = new Date(mergeDate);
+        const sd = new Date(startDate);
+        const ed = new Date(endDate);
 
         // Fetch all closed PRs (this includes merged PRs)
-        const allClosedPRs = await octokit.request(`GET /repos/${owner}/${repo}/pulls?state=closed&per_page=30`, {
+        const allClosedPRs = await octokit.request(`GET /repos/${owner}/${repo}/pulls?state=closed&per_page=100`, {
             owner: owner,
             repo: repo,
             headers: {
@@ -118,13 +119,13 @@ export async function getMergedPRsAfterDate(owner, repo, mergeDate) {
 
             if (pr.merged_at) {
                 const mergedAtDate = new Date(pr.merged_at);
-                // console.log("Merged date:", pr.merged_at, mergedAtDate, mergeDateObj);
-                return mergedAtDate > mergeDateObj; // Only consider merged PRs after the given date
+                // console.log("MergedAt Log", pr.title, mergedAtDate.toISOString(), ed.toISOString(), sd.toISOString(), mergedAtDate >= sd, mergedAtDate <= ed);
+                return mergedAtDate >= sd && mergedAtDate <= ed;
             }
             return false; // Exclude PRs that are closed but not merged
         });
 
-        console.log(`Total Closed PRs after date ${mergeDate}`, mergedPRs.length);
+        console.log(`Total Closed PRs after date ${startDate}`, mergedPRs.length);
         return mergedPRs;
     } catch (error) {
         console.error("Error fetching merged PRs after the specified date:", error);

--- a/scripts/eod-report-generator/index.js
+++ b/scripts/eod-report-generator/index.js
@@ -79,9 +79,10 @@ async function analyzePR(owner, repo, pr, ignoreBuger) {
     const owner = "TykTechnologies";
     const repo = "tyk-docs";
 
-    const date = process.env.PR_SCAN_DATE || new Date().toISOString();
-    console.log("Report Date:", date); // Example output: "2025-02-04T15:30:00Z"
-
+    const startDate = process.env.START_DATE || new Date().toISOString();
+    const endDate = process.env.END_DATE || new Date().toISOString();
+    console.log("Start Date:", startDate); // Example output: "2025-02-04T15:30:00Z"
+    console.log("End Date:", endDate); // Example output: "2025-02-04T15:30:00Z"
 
     try {
         // ###############################
@@ -104,7 +105,7 @@ async function analyzePR(owner, repo, pr, ignoreBuger) {
         // Get Merged PRs
         // ###############################
 
-        const mergedPrs = await getMergedPRsAfterDate(owner, repo, date);
+        const mergedPrs = await getMergedPRsAfterDate(owner, repo, startDate, endDate);
 
         eod_report_result = []; //Reset array
         for (const pr of mergedPrs) {
@@ -122,7 +123,7 @@ async function analyzePR(owner, repo, pr, ignoreBuger) {
         console.log("============ Final Print ============")
 
         console.log(`
-Hi all, EOD status report for ${date}, is as follows:
+Hi all, EOD status report for ${endDate}, is as follows:
 :white_check_mark: New published pages :partywizard::partywizard::partywizard::partywizard:
 ================================
 ${merged}


### PR DESCRIPTION
### **User description**
### For internal users - Please add a Jira DX PR ticket to the subject!
<br>

---

### Preview Link
<!-- Add a direct preview link to make it easier for the reviewer to review. Best to add a few direct links to the pages in the PR -->
<br>

### Description
<!-- 1. Describe your changes in detail. Why is this change required? What problem does it solve?
     2. Please explain the change to the reviewer. Pay special attention to changes that are hard to spot, 
       for example:
       2.1. Name change in the file name or directory name - please flag it out since it’s hard 
            to compare text after such a change 
       2.2. Terminology change - flag it out to make sure the reviewer is aware before approving
     3. @mentions of the person to review the proposed changes. They need to be able to know the topic well in order to approve it.
-->
<br>

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have added a **preview link** to the PR description.
- [ ] I have reviewed the suggestions made by our AI (PR Agent) and updated them accordingly (spelling errors, rephrasing, etc.)
- [ ] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [ ] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [ ] Make sure you have started *your change* off *our latest `master`*.
- [x] **For Tyk Members** - Please add a Jira DX PR ticket to the subject!
- [x] **For Tyk Members** - I have added the appropriate release label to this PR:  
  - If it is for a future release, label it as **`future-release`** and specify the version (e.g., `future-release, 6.0`).  
  - If it should be merged into an older version, use the specific version label (e.g., `4.1`, `5.1`).  
  - If no label is added, it will be assumed that the PR should be merged into the latest current version (e.g., `5.5`) and `master`.
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for specifying start and end dates in EOD report generation.

- Updated filtering logic to include PRs merged within a date range.

- Enhanced workflow inputs to handle start and end dates.

- Improved console logging for better debugging and clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.js</strong><dd><code>Add date range support for merged PRs filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/eod-report-generator/github.js

<li>Modified <code>getMergedPRsAfterDate</code> to accept start and end dates.<br> <li> Updated filtering logic to include PRs merged within the specified <br>range.<br> <li> Adjusted API request to fetch up to 100 closed PRs.<br> <li> Improved console logging for debugging merged PRs.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6032/files#diff-6a4d725e4bd3d85ce1d61441bec68f11535d2849b55fe53007629f75c64bfdc9">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Update EOD report generator to use date range</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/eod-report-generator/index.js

<li>Replaced single date with start and end dates for report generation.<br> <li> Updated function calls to pass the new date range parameters.<br> <li> Enhanced console logs to display start and end dates.<br> <li> Adjusted EOD report message to reflect the end date.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6032/files#diff-a49a28f8eab4cc9ca5d1fc8146517f6cb60e9b6de011a0ac784fbe0cefcd24f3">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eod-report-generator.yaml</strong><dd><code>Update workflow to support date range inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/eod-report-generator.yaml

<li>Replaced <code>PR_SCAN_DATE</code> input with <code>START_DATE</code> and <code>END_DATE</code>.<br> <li> Updated workflow environment variables to include the new date inputs.<br> <li> Adjusted descriptions for the new inputs in the workflow.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6032/files#diff-a515776cf02ffeb0e92d47d13fd365b6bd31cfdc01cccfa9e876d4caad75e098">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>