### PR TITLE
[DX-1891] add h1 to right navigation

### DIFF
--- a/tyk-docs/static/js/docs-table-of-contents.js
+++ b/tyk-docs/static/js/docs-table-of-contents.js
@@ -7,7 +7,7 @@ var buildTableOfContents = function () {
     ToC = $(".documentation-table-of-contents"),
     ToContent = $(".toc__content"),
     ToClbl = $('<span class="toc__label">On this page</span>'),
-    contentTitles = $("h2, h3, h4, h5", "#main-content");
+    contentTitles = $("h1,h2, h3, h4, h5", "#main-content");
 
   if (!ToC[0]) {
     return;
@@ -27,8 +27,8 @@ var buildTableOfContents = function () {
     ToC.prepend(ToClbl);
     var title = $(this).text();
 
-    if ($(this).is("h2")) {
-      var h2 = $(this)
+    if ($(this).is("h1")) {
+      var h1 = $(this)
         .text()
         .replace(/[^a-zA-Z0-9]/g, "")
         .toLowerCase();
@@ -41,6 +41,27 @@ var buildTableOfContents = function () {
       });
       accordionItem.append(accordionHeader);
       accordionGroup.append(accordionItem);
+    }
+    if ($(this).is("h2")) {
+      var link = $(`<a href="#${$(this).attr("id")}" class="sub_toc__item">${title}</a>`);
+      var h2 = $(this)
+        .text()
+        .replace(/[^a-zA-Z0-9]/g, "")
+        .toLowerCase();
+      var link = $(`<a href="#${$(this).attr("id")}" class="sub_toc__item sub-accordion-title">${title}</a>`);
+      var accordionContent = $('<div class="accordion-content"></div>').append(link);
+      if (accordionGroup.find(".accordion-item:last").length) {
+        accordionGroup.find(".accordion-item:last").append(accordionContent);
+      } else {
+        ToContent.append(accordionContent);
+      }
+
+      accordionContent.click(function () {
+        $(this).toggleClass("accordion-up");
+
+        // Toggle visibility of H4 elements under this H3
+        accordionContent.siblings(".sub-accordion-content").toggle();
+      });
     }
 
     if ($(this).is("h3")) {


### PR DESCRIPTION
### **PR Type**
- Enhancement



___

### **Description**
- Include H1 elements in table-of-contents selection.

- Change accordion grouping from H2 to H1.

- Add new accordion content section for H2 headings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs-table-of-contents.js</strong><dd><code>Refactor TOC building logic for improved heading support</code>&nbsp; </dd></summary>
<hr>

tyk-docs/static/js/docs-table-of-contents.js

<li>Updated selector to include h1 elements.<br> <li> Changed conditional from h2 to h1 for accordion header.<br> <li> Introduced new block to handle h2 accordion content.<br> <li> Added click handler for toggling sub-accordion content.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6104/files#diff-40b5987da19f3922c5bb623c69fab23fe13bf09c588f5a95852e49542a62440e">+24/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>