### PR TITLE
[DX-1891] add divider and css for h1 in content

### DIFF
--- a/tyk-docs/assets/scss/_docs.scss
+++ b/tyk-docs/assets/scss/_docs.scss
@@ -873,3 +873,21 @@ iframe {
   top: 0;
   background-size: 100%;
 }
+
+#main-content h1 {
+  padding-top: 30px; /* Space above the h1 */
+  margin-top: 0; /* Remove default margin */
+  position: relative;
+}
+
+#main-content h1::before {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 0.9px; /* Divider thickness */
+  background-color: #ccc; /* Divider color */
+  margin-bottom: 30px; /* Space between the h1 and the divider */
+}
+
+
+

--- a/tyk-docs/assets/scss/_docs.scss
+++ b/tyk-docs/assets/scss/_docs.scss
@@ -874,13 +874,13 @@ iframe {
   background-size: 100%;
 }
 
-#main-content h1 {
+#main-content h1:not(#home-page-title) {
   padding-top: 30px; /* Space above the h1 */
   margin-top: 0; /* Remove default margin */
   position: relative;
 }
 
-#main-content h1::before {
+#main-content h1:not(#home-page-title)::before {
   content: "";
   display: block;
   width: 100%;

--- a/tyk-docs/themes/tykio/layouts/index.html
+++ b/tyk-docs/themes/tykio/layouts/index.html
@@ -4,7 +4,7 @@
       <div class="row">
         <div class="col">
           <div class="my-5">
-            <h1 style="font-size: 36px" class="fw-bold mb-3 lh-normal fs-normal">Tyk Documentation</h1>
+            <h1 id="home-page-title" style="font-size: 36px" class="fw-bold mb-3 lh-normal fs-normal">Tyk Documentation</h1>
             <p class="mb-4 fs-16 font-400 lh-normal text-sec">
               The hub for Tyk API management. Whether you're new or experienced, get started with Tyk, explore our
               product stack and core concepts, access in-depth guides, and actively contribute to our ever-evolving


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add custom CSS rule for #main-content h1 styling.

- Insert divider using ::before pseudo-element.

- Adjust spacing using padding and margins.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_docs.scss</strong><dd><code>Enhance h1 style with divider and spacing.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/scss/_docs.scss

<li>Added CSS selectors for #main-content h1.<br> <li> Introduced ::before pseudo-element as a divider.<br> <li> Defined padding, margin, and divider styling.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6107/files#diff-d29767519ca2fa4d8fce78b76e949905e03684c9f9d6572ff6b4f23888480e7e">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>