### PR TITLE
Merging to release-5.7: [DX-1884] Updated connectors on Tyk Streams (#6092)

### DIFF
--- a/tyk-docs/content/api-management/event-driven-apis.md
+++ b/tyk-docs/content/api-management/event-driven-apis.md
@@ -609,11 +609,9 @@ visibility into usage, performance, and errors.
 Tyk Streams provides out-of-the-box connectors for popular event brokers and async protocols, including:
 
 - [Apache Kafka](https://kafka.apache.org/documentation/)
-- [MQTT](https://mqtt.org/)
-- [RabbitMQ](https://www.rabbitmq.com/docs)
-- [Solace](https://docs.solace.com/Get-Started/Solace-PubSub-Platform.htm)
-- [RedPanda](https://docs.redpanda.com/current/home/)
-- [AMQP](https://www.amqp.org/)
+- [MQTT](https://mqtt.org/) (Coming Soon)
+- [Solace](https://docs.solace.com/Get-Started/Solace-PubSub-Platform.htm) (Coming Soon)
+- [AMQP](https://www.amqp.org/) (Coming Soon)
 - [WebSocket](https://websocket.org/guides/websocket-protocol/)
 - [Server-Sent Events](https://en.wikipedia.org/wiki/Server-sent_events) (SSE)
 - [Webhooks](https://en.wikipedia.org/wiki/Webhook)


### PR DESCRIPTION
### **User description**
[DX-1884] Updated connectors on Tyk Streams (#6092)

[DX-1884]: https://tyktech.atlassian.net/browse/DX-1884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Added "Coming Soon" labels for MQTT, Solace, and AMQP connectors

- Removed RabbitMQ and RedPanda connector entries

- Streamlined event-driven API connector documentation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event-driven-apis.md</strong><dd><code>Revise connector statuses in event-driven API docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/api-management/event-driven-apis.md

<li>Added (Coming Soon) tag for MQTT, Solace, and AMQP<br> <li> Removed RabbitMQ and RedPanda connector listings<br> <li> Updated connector statuses in documentation


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6114/files#diff-530f7da75b9df07a7d5a2637543ae7bd4acf2de73dbdc470281ee7e4e5427cf0">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>