### PR TITLE
Merging to release-5.7: Revert "[DX-1891] add h1 to right navigation" (#6115)

### DIFF
--- a/tyk-docs/static/js/docs-table-of-contents.js
+++ b/tyk-docs/static/js/docs-table-of-contents.js
@@ -7,7 +7,7 @@ var buildTableOfContents = function () {
     ToC = $(".documentation-table-of-contents"),
     ToContent = $(".toc__content"),
     ToClbl = $('<span class="toc__label">On this page</span>'),
-    contentTitles = $("h1,h2, h3, h4, h5", "#main-content");
+    contentTitles = $("h2, h3, h4, h5", "#main-content");
 
   if (!ToC[0]) {
     return;
@@ -27,8 +27,8 @@ var buildTableOfContents = function () {
     ToC.prepend(ToClbl);
     var title = $(this).text();
 
-    if ($(this).is("h1")) {
-      var h1 = $(this)
+    if ($(this).is("h2")) {
+      var h2 = $(this)
         .text()
         .replace(/[^a-zA-Z0-9]/g, "")
         .toLowerCase();
@@ -41,27 +41,6 @@ var buildTableOfContents = function () {
       });
       accordionItem.append(accordionHeader);
       accordionGroup.append(accordionItem);
-    }
-    if ($(this).is("h2")) {
-      var link = $(`<a href="#${$(this).attr("id")}" class="sub_toc__item">${title}</a>`);
-      var h2 = $(this)
-        .text()
-        .replace(/[^a-zA-Z0-9]/g, "")
-        .toLowerCase();
-      var link = $(`<a href="#${$(this).attr("id")}" class="sub_toc__item sub-accordion-title">${title}</a>`);
-      var accordionContent = $('<div class="accordion-content"></div>').append(link);
-      if (accordionGroup.find(".accordion-item:last").length) {
-        accordionGroup.find(".accordion-item:last").append(accordionContent);
-      } else {
-        ToContent.append(accordionContent);
-      }
-
-      accordionContent.click(function () {
-        $(this).toggleClass("accordion-up");
-
-        // Toggle visibility of H4 elements under this H3
-        accordionContent.siblings(".sub-accordion-content").toggle();
-      });
     }
 
     if ($(this).is("h3")) {


### PR DESCRIPTION
### **User description**
Revert "[DX-1891] add h1 to right navigation" (#6115)

Revert "[DX-1891] add h1 to right navigation (#6104)"

This reverts commit f8ebcf843db66e78ca50cc842f156305e6ebf711.

[DX-1891]: https://tyktech.atlassian.net/browse/DX-1891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1891]: https://tyktech.atlassian.net/browse/DX-1891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
- Other



___

### **Description**
- Revert h1 selection from table-of-contents.

- Restore h2-based accordion grouping.

- Remove extra h2 sub-accordion block.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Other</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs-table-of-contents.js</strong><dd><code>Restore h2 grouping and remove h1-based changes.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/static/js/docs-table-of-contents.js

<li>Removed "h1" from the selector for content titles.<br> <li> Changed header check from "h1" to "h2" for accordion grouping.<br> <li> Eliminated extra block handling h2 sub-accordion content.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6119/files#diff-40b5987da19f3922c5bb623c69fab23fe13bf09c588f5a95852e49542a62440e">+3/-24</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>