### PR TITLE
[DX-1912]Update mdcb-configuration-options.md

### DIFF
--- a/tyk-docs/content/tyk-multi-data-centre/mdcb-configuration-options.md
+++ b/tyk-docs/content/tyk-multi-data-centre/mdcb-configuration-options.md
@@ -30,7 +30,7 @@ Environment variables (env var) can be used to override the settings defined in 
 |**Tyk Gateway**          |                |
 |Management API           |      8080      |
 |**MDCB**                 |                |
-|RPC services             |      9091      |
+|RPC services             |      9090      |
 |HTTP endpoints           |      8181      |
 
 


### PR DESCRIPTION
### **User description**
we need to change the default rpc port from 9091 to 9090 for mdcb


___

### **PR Type**
Documentation


___

### **Description**
- Update mdcb config to use new default RPC port

- Change port value from 9091 to 9090 in documentation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mdcb-configuration-options.md</strong><dd><code>Update RPC port in mdcb configuration document</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-multi-data-centre/mdcb-configuration-options.md

<li>Modified RPC services port value in the configuration table.<br> <li> Updated default port from 9091 to 9090.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6182/files#diff-284a406e876beedf98c1863e84eff6da7c713e16a6dbff32b332f905e003b3eb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>