### PR TITLE
Merging to release-5.8: [TT-9919] add docs for configuring cert-manager and webhooks (#6054)

### DIFF
--- a/tyk-docs/content/api-management/automations/operator.md
+++ b/tyk-docs/content/api-management/automations/operator.md
@@ -274,6 +274,8 @@ maintaining a single source of truth for your API configurations.
 Tyk Operator uses cert-manager to provision certificates for the webhook server. If you don't have cert-manager
 installed, you can follow this command to install it:
 
+Alternatively, you have the option to manually handle TLS certificates by disabling the `cert-manager` requirement. For more details, please refer to this [configuration]({{< ref "#webhook-configuration" >}}).
+
 ```console
 $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml
 ```
@@ -429,6 +431,10 @@ in `tyk-operator-system` namespace.
 
 **Helm configurations**
 
+{{< note warning >}} **Note**
+Starting from Tyk Operator v1.2.0, `webhookPort` is deprecated in favor of `webhooks.port`.
+{{< /note >}}
+
 | Key                                         | Type   | Default                                |
 | ------------------------------------------- | ------ | -------------------------------------- |
 | envFrom[0].secretRef.name                   | string | `"tyk-operator-conf"`                  |
@@ -461,6 +467,12 @@ in `tyk-operator-system` namespace.
 | resources                                   | object | `{}`                                   |
 | serviceMonitor                              | bool   | `false`                                |
 | webhookPort                                 | int    | `9443`                                 |
+| webhooks.enabled                        | bool   | `true`                                 |
+| webhooks.port                           | int    | `9443`                                 |
+| webhooks.annotations                    | object | `{}`                                   |
+| webhooks.tls.useCertManager             | bool   | `true`                                 |
+| webhooks.tls.secretName                 | string | `webhook-server-cert`                  |
+| webhooks.tls.certificatesMountPath      | string | `/tmp/k8s-webhook-server/serving-certs`|
 
 ### Upgrading Tyk Operator
 
@@ -512,6 +524,28 @@ To uninstall Tyk Operator, you need to run the following command:
 ```console
 $ helm delete tyk-operator -n tyk-operator-system
 ```
+
+### Webhook Configuration
+
+Starting from Operator v1.2.0 release, [Kubernetes Webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers) can now be configured using the Helm chart by specifying the necessary settings in the values.yaml file of the operator.
+Since webhooks are enabled by default, there will be no impact to existing users.
+
+```
+webhooks:
+  enabled: true
+  port: 9443
+  annotations: {}
+  tls:
+    useCertManager: true
+    secretName: webhook-server-cert
+    certificatesMountPath: "/tmp/k8s-webhook-server/serving-certs"
+```
+- `enabled`: Enables or disables webhooks.
+- `port`: Specifies the port for webhook communication.
+- `annotations`: Allows adding custom annotations.
+- `tls.useCertManager`: If true, Cert-Manager will handle TLS certificates.
+- `tls.secretName`: The name of the Kubernetes Secret storing the TLS certificate.
+- `tls.certificatesMountPath`: Path where the webhook server mounts its certificates.
 
 ## Set Up Tyk OAS API
 Setting up OpenAPI Specification (OAS) APIs with Tyk involves preparing an OAS-compliant API definition and configuring it within your Kubernetes cluster using Tyk Operator. This process allows you to streamline API management by storing the OAS definition in a Kubernetes ConfigMap and linking it to Tyk Gateway through a TykOasApiDefinition resource. 


### PR DESCRIPTION
### **User description**
[TT-9919] add docs for configuring cert-manager and webhooks (#6054)

[TT-9919]: https://tyktech.atlassian.net/browse/TT-9919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Introduced alternative manual TLS certificate setup.

- Deprecated `webhookPort` in favor of `webhooks.port`.

- Added new Helm chart values for webhooks configuration.

- Documented webhook configuration with detailed code snippet.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator.md</strong><dd><code>Enhance Helm Operator documentation for webhook configuration.</code></dd></summary>
<hr>

tyk-docs/content/api-management/automations/operator.md

<li>Inserted alternative TLS guidance with manual configuration.<br> <li> Added note about deprecating <code>webhookPort</code>.<br> <li> Expanded Helm chart values with new webhooks settings.<br> <li> Introduced a new "Webhook Configuration" section.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6280/files#diff-f350b9e1c29baaea3d31c1a47208d0ba5ba5b689cde768de7e00378da083c53e">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>