### PR TITLE
Merging to release-5.8: Fix variable name in JS plugin (#6356)

### DIFF
--- a/tyk-docs/content/api-management/plugins/javascript.md
+++ b/tyk-docs/content/api-management/plugins/javascript.md
@@ -229,8 +229,8 @@ var testJSVMData = new TykJS.TykMiddleware.NewMiddleware({});
 testJSVMData.NewProcessRequest(function(request, session, config) {
   // Logic to determine if the request should be overridden
   if (someCondition) {
-      request.ReturnOverrides.response_code = 403;
-      request.ReturnOverrides.response_body = "Access Denied";
+      request.ReturnOverrides.ResponseCode = 403;
+      request.ReturnOverrides.ResponseBody = "Access Denied";
       request.ReturnOverrides.headers = {"X-Error": "the-condition"};
       // This stops the request from proceeding to the upstream
   }


### PR DESCRIPTION
### **User description**
Fix variable name in JS plugin (#6356)


___

### **PR Type**
Documentation


___

### **Description**
- Corrects variable names in JavaScript middleware documentation

- Updates `response_code` to `ResponseCode` in example code

- Updates `response_body` to `ResponseBody` in example code

- Ensures documentation matches actual API usage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>javascript.md</strong><dd><code>Correct ReturnOverrides variable names in JS middleware docs</code></dd></summary>
<hr>

tyk-docs/content/api-management/plugins/javascript.md

<li>Changed <code>response_code</code> to <code>ResponseCode</code> in example code<br> <li> Changed <code>response_body</code> to <code>ResponseBody</code> in example code<br> <li> Ensured documentation aligns with actual API usage


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6369/files#diff-855c04563724b8f3166bb13c7defef6be39504f32d21e020cd5395182adc6245">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>