### PR TITLE
Merging to release-5.5: Fix issue of Links do not have descriptive text (#6375)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/cookie_notice.html
+++ b/tyk-docs/themes/tykio/layouts/partials/cookie_notice.html
@@ -13,7 +13,7 @@
 		    Reject
 		  </button>
 		  &nbsp;&nbsp;
-		  <a href="https://tyk.io/privacy-policy/" target="_blank"><b>Read More</b></a>
+		  <a href="https://tyk.io/privacy-policy/" target="_blank"><b>Tyk's Privacy Policy</b></a>
 	   </div>
 	</div>
 </div>


### PR DESCRIPTION
### **User description**
Fix issue of Links do not have descriptive text (#6375)

fix issue of Links do not have descriptive text


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved accessibility by updating link text in cookie notice.

- Changed "Read More" to "Tyk's Privacy Policy" for clarity.

- Enhanced user experience for privacy policy access.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cookie_notice.html</strong><dd><code>Update cookie notice link for better accessibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/themes/tykio/layouts/partials/cookie_notice.html

<li>Changed link text from "Read More" to "Tyk's Privacy Policy".<br> <li> Improved accessibility with more descriptive link text.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6378/files#diff-e6f5e0764e57eb99292f486eb7a53a66bb6111bdc3f5456a14d7df21c8fc8776">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>