### PR TITLE
Merging to release-5.8: TT-14827 Update the Upgrading guide note, that says Tyk sync doesn t support exporting OAS APIs (#6391)

### DIFF
--- a/tyk-docs/content/developer-support/upgrading.md
+++ b/tyk-docs/content/developer-support/upgrading.md
@@ -1255,7 +1255,7 @@ If you are using Self Managed deployment then we recommend that you use [Tyk Syn
 
 ### Export And Restore APIs and Policies
 
-To facilitate backing up APIs and policies we have provided a Bash script [backup](https://github.com/TykTechnologies/backup) that can be used to export and restore all Tyk API definitions and Policies from Tyk Dashboard. This will be done by the *export* and *import* commands respectively. The script can be used on both Tyk Cloud and Self Managed deployments. The script is helpful for Tyk Cloud users who want to export their Tyk OAS APIs since *tyk-sync* does not currently support it on Tyk Cloud.
+To facilitate backing up APIs and policies we have provided a Bash script [backup](https://github.com/TykTechnologies/backup) that can be used to export and restore all Tyk API definitions and Policies from Tyk Dashboard. This will be done by the *export* and *import* commands respectively. The script can be used on both Tyk Cloud and Self Managed deployments.
 
 #### Export APIs and Policies
 


### PR DESCRIPTION
### **User description**
TT-14827 Update the Upgrading guide note, that says Tyk sync doesn t support exporting OAS APIs (#6391)

Co-authored-by: Leonid Bugaev <leonsbox@gmail.com>


___

### **PR Type**
Documentation


___

### **Description**
- Removed outdated note about OAS API export support.

- Clarified backup script works for Cloud and Self Managed.

- Improved accuracy of upgrading guide documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upgrading.md</strong><dd><code>Clarified OAS API export support in upgrading guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/developer-support/upgrading.md

<li>Removed statement that tyk-sync does not support exporting OAS APIs.<br> <li> Clarified that the backup script applies to both Tyk Cloud and Self <br>Managed.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6396/files#diff-06a642c850b894ec1aead2a74317998b9c6265ea1c4b0dadcef82ccb3443c901">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>