### PR TITLE
[DX-2010] Add information about playground assets

### DIFF
--- a/tyk-docs/content/api-management/graphql.md
+++ b/tyk-docs/content/api-management/graphql.md
@@ -2103,6 +2103,11 @@ Tyk offers you two types of Playgrounds, depending on who should be authorized t
 * **Playground** tab in `API Designer`, that's only accessible via Tyk Dashboard and is always enabled. You need to log into the Tyk Dashboard to be able to use it.
 * **Public Playground** that you can enable for any GraphQL API and that is accessible for any consumer interacting with your GQL API. This playground will follow all security rules you set for your GQL API - authentication, authorization, etc.
 
+{{< note >}} Note
+The Public Playground relies on assets in the [template_path]({{< ref "tyk-oss-gateway/configuration#template_path" >}}). The default location for templates is `/opt/tyk-gateway/templates`, which includes a `playground` folder containing the necessary assets for the Public Playground to function.
+If you change the `template_path`, make sure to copy the playground folder to the new location. This ensures the public playground continues to work as expected.
+{{< /note >}}
+
 #### Enabling Public GraphQL Playground
 
 {{< tabs_start >}}

--- a/tyk-docs/content/api-management/graphql.md
+++ b/tyk-docs/content/api-management/graphql.md
@@ -2103,9 +2103,12 @@ Tyk offers you two types of Playgrounds, depending on who should be authorized t
 * **Playground** tab in `API Designer`, that's only accessible via Tyk Dashboard and is always enabled. You need to log into the Tyk Dashboard to be able to use it.
 * **Public Playground** that you can enable for any GraphQL API and that is accessible for any consumer interacting with your GQL API. This playground will follow all security rules you set for your GQL API - authentication, authorization, etc.
 
-{{< note >}} Note
-The Public Playground relies on assets in the [template_path]({{< ref "tyk-oss-gateway/configuration#template_path" >}}). The default location for templates is `/opt/tyk-gateway/templates`, which includes a `playground` folder containing the necessary assets for the Public Playground to function.
-If you change the `template_path`, make sure to copy the playground folder to the new location. This ensures the public playground continues to work as expected.
+{{< note >}}
+**Note** 
+
+The Public Playground relies on assets in the `playground` folder under [template_path]({{< ref "tyk-oss-gateway/configuration#template_path" >}}) (default: `/opt/tyk-gateway/templates`).
+If you change this path, be sure to copy the `playground` folder to the new location to preserve functionality.
+
 {{< /note >}}
 
 #### Enabling Public GraphQL Playground


### PR DESCRIPTION
### **User description**
Preview Link - https://deploy-preview-6401--tyk-docs.netlify.app/docs/nightly/api-management/graphql/#graphql-playgrounds-in-tyk

## Checklist

- [x] Added a **preview link**
- [x] Reviewed AI PR Agent suggestions
- [x] Added Jira DX PR ticket to the subject
- [x] Added the appropriate release labels (for fixes add the latest release)


___

### **PR Type**
Documentation


___

### **Description**
- Added note about Public Playground asset dependencies

- Explained default template path and playground folder location

- Provided instructions for updating asset location if template path changes

- Enhanced clarity on maintaining Public Playground functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graphql.md</strong><dd><code>Document Public Playground asset requirements and template path usage</code></dd></summary>
<hr>

tyk-docs/content/api-management/graphql.md

<li>Added a note explaining the asset dependency for the Public <br>Playground.<br> <li> Specified the default template path and playground folder location.<br> <li> Provided guidance for updating asset location if template path is <br>changed.<br> <li> Improved documentation for maintaining Public Playground <br>functionality.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6401/files#diff-f11ba6924d8e0993ee912457bd4104a38fcdc0b853b5c53960c711e550195dbf">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>