### PR TITLE
Merging to release-5.8: Remove Bloblang reference from Tyk Streams

### DIFF
--- a/tyk-docs/content/api-management/event-driven-apis.md
+++ b/tyk-docs/content/api-management/event-driven-apis.md
@@ -849,7 +849,7 @@ pipeline:
 {{< note success >}}
 **Note:**
 
-Bloblang/Mapping is currently available and working, but it will be officially supported starting from version 5.9.0.
+The `Mapping` processor is currently available and working, but it will be officially supported starting from version 5.9.0.
 
 You’re welcome to explore and experiment with this feature in non-production environments today. For production use, we recommend waiting for the official release in 5.9.0 to ensure full support.
 {{< /note >}}
@@ -860,7 +860,7 @@ TODO: Official bloblang support from 5.9.0 onwards
 In this example:
 
 - **Tyk Streams Setup**: Consumes events from a Kafka topic called *orders*.
-- **Processor Block Configuration**: Utilizes a custom Bloblang script that performs the following operations:
+- **Processor Block Configuration**: Utilizes a custom `Mapping` script that performs the following operations:
     - **Filters** orders, only processing those with a value greater than 1000.
     - **Enriches** the high-value orders by retrieving the customer ID and email from a separate data source.
     - **Adds** a new high_value_order flag to each qualifying event.


### PR DESCRIPTION
### **User description**
Remove Bloblang reference from Tyk Streams


___

### **PR Type**
Documentation


___

### **Description**
- Removed references to Bloblang in Tyk Streams documentation

- Updated terminology to use `Mapping` processor instead

- Clarified feature availability and support version


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event-driven-apis.md</strong><dd><code>Update Tyk Streams docs to use Mapping processor terminology</code></dd></summary>
<hr>

tyk-docs/content/api-management/event-driven-apis.md

<li>Replaced "Bloblang/Mapping" with "<code>Mapping</code> processor" in feature note<br> <li> Updated processor block description from "Bloblang script" to "<code>Mapping</code> <br>script"<br> <li> Clarified documentation language for processor support and usage


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6458/files#diff-530f7da75b9df07a7d5a2637543ae7bd4acf2de73dbdc470281ee7e4e5427cf0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>