### PR TITLE
Merging to release-5.8: [DX-2025] The release notes for 5.7.1 and 5.7.2 say that golang 1.23 was used but in fact it was 1.22  (#6466)

### DIFF
--- a/tyk-docs/content/developer-support/release-notes/dashboard.md
+++ b/tyk-docs/content/developer-support/release-notes/dashboard.md
@@ -321,7 +321,7 @@ Tyk Dashboard now runs on Golang 1.23, bringing security and performance improve
 - removal of 3DES cipher suites
 - updates to X509KeyPair handling.
 
-**You may need to adjust your setup for compatibility**. For more detail please see the official Go [release notes](https://go.dev/doc/go1.23).
+**You may need to adjust your setup for compatibility**. For more details, please see the official Go [release notes](https://go.dev/doc/go1.23).
 </details>
 </li>
 <li>
@@ -418,11 +418,11 @@ There are no breaking changes in this release.
 | | Pump v1.11.1 | Pump all versions |
 | | TIB (if using standalone) v1.6.1 | TIB all versions |
 
-##### 3rd Party Dependencies & Tools {#3rdPartyTools-v5.7.1}
+##### 3rd Party Dependencies & Tools {#3rdPartyTools-v5.7.2}
 
 | Third Party Dependency                                     | Tested Versions        | Compatible Versions    | Comments | 
 | ---------------------------------------------------------- | ---------------------- | ---------------------- | -------- | 
-| [GoLang](https://go.dev/dl/)                               | 1.23       | 1.23       | [Go plugins]({{< ref "api-management/plugins/golang" >}}) must be built using Go 1.23 | 
+| [GoLang](https://go.dev/dl/)                               | 1.22       | 1.22       | [Go plugins]({{< ref "api-management/plugins/golang" >}}) must be built using Go 1.23 | 
 | [Redis](https://redis.io/download/)  | 6.2.x, 7.x  | 6.2.x, 7.x  | Used by Tyk Dashboard | 
 | [MongoDB](https://www.mongodb.com/try/download/community)  | 5.0.x, 6.0.x, 7.0.x  | 5.0.x, 6.0.x, 7.0.x  | Used by Tyk Dashboard | 
 | [PostgreSQL](https://www.postgresql.org/download/)         | 12.x - 16.x LTS        | 12.x - 16.x            | Used by Tyk Dashboard | 


### PR DESCRIPTION
### **User description**
[DX-2025] The release notes for 5.7.1 and 5.7.2 say that golang 1.23 was used but in fact it was 1.22  (#6466)

Update dashboard.md

[DX-2025]: https://tyktech.atlassian.net/browse/DX-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Corrected Go version from 1.23 to 1.22 in release notes

- Updated section heading for 3rd party dependencies to 5.7.2

- Improved wording for compatibility note in release notes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.md</strong><dd><code>Correct Go version and clarify release notes wording</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/developer-support/release-notes/dashboard.md

<li>Changed Go version from 1.23 to 1.22 in compatibility table<br> <li> Updated section heading to reference 5.7.2 instead of 5.7.1<br> <li> Improved wording in compatibility note for clarity


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6468/files#diff-d33730d9b7b352e9a2ce2f71ef67fea53fb21ae531d4522472f799648ee5b22f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>