### PR TITLE
Merging to release-5.8: [TT-14953] Remove deprecated kube-rbac-proxy from operator config (#6470)

### DIFF
--- a/tyk-docs/content/api-management/automations/operator.md
+++ b/tyk-docs/content/api-management/automations/operator.md
@@ -458,9 +458,6 @@ Starting from Tyk Operator v1.2.0, `webhookPort` is deprecated in favor of `webh
 | nodeSelector                                | object | `{}`                                   |
 | podAnnotations                              | object | `{}`                                   |
 | podSecurityContext.allowPrivilegeEscalation | bool   | `false`                                |
-| rbac.image.pullPolicy                       | string | `"IfNotPresent"`                       |
-| rbac.image.repository                       | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` |
-| rbac.image.tag                              | string | `"v0.8.0"`                             |
 | rbac.port                                   | int    | `8443`                                 |
 | rbac.resources                              | object | `{}`                                   |
 | replicaCount                                | int    | `1`                                    |


### PR DESCRIPTION
### **User description**
[TT-14953] Remove deprecated kube-rbac-proxy from operator config (#6470)

[TT-14953]: https://tyktech.atlassian.net/browse/TT-14953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Remove deprecated kube-rbac-proxy configuration from operator docs

- Update operator configuration table to exclude deprecated fields

- Ensure only current rbac options are documented

- Clarify supported rbac configuration options


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator.md</strong><dd><code>Remove deprecated kube-rbac-proxy fields from operator config table</code></dd></summary>
<hr>

tyk-docs/content/api-management/automations/operator.md

<li>Removed documentation for deprecated kube-rbac-proxy image fields<br> <li> Updated configuration table to exclude deprecated rbac.image fields<br> <li> Ensured only current rbac options are listed


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6481/files#diff-f350b9e1c29baaea3d31c1a47208d0ba5ba5b689cde768de7e00378da083c53e">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>