### PR TITLE
Merging to release-5.8: [TT-14701] Update configuration.md (#6516)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/configuration.md
+++ b/tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/configuration.md
@@ -473,18 +473,18 @@ PORTAL_DATABASE_CONNECTION_MAX_LIFETIME=180000
 
 ### PORTAL_DATABASE_MAXRETRIES
 **Config file:** Database.MaxRetries <br/>
-**Type:** `boolean` <br/>
+**Type:** `int` <br/>
 **Description**: Defines how many times the portal will retry to connect to the database. Optional, the default value is 3.
 
 ### PORTAL_DATABASE_RETRYDELAY
-**Config file:** Database.MaxRetries <br/>
-**Type:** `boolean` <br/>
-**Description**: Defines delay between connect attempts (in milliseconds). Optional, the default value is 5000.
+**Config file:** Database.RetryDelay <br/>
+**Type:** `int` <br/>
+**Description**: Defines the delay between connect attempts (in milliseconds). Optional. Default value: 5000.
 
 ### PORTAL_DATABASE_MAX_OPEN_CONNECTIONS
 **Config file:** Database.MaxOpenConnections <br/>
 **Type:** `int` <br/>
-**Description**: Defines the maximum number of concurrent connections that the database can handle from the application. When the number of open connections reaches this limit, new requests will wait until a connection becomes available. Optional, the default value is unlimited.
+**Description**: Defines the maximum number of concurrent connections that the database can handle from the application. When the number of open connections reaches this limit, new requests will wait until a connection becomes available. Optional. Default value: unlimited.
 
 ### PORTAL_DATABASE_MAX_IDLE_CONNECTIONS
 **Config file:** Database.MaxIdleConnections <br/>


### PR DESCRIPTION
### **User description**
[TT-14701] Update configuration.md (#6516)

Update configuration.md

fix fields type and json name

Co-authored-by: Leonid Bugaev <leonsbox@gmail.com>

[TT-14701]: https://tyktech.atlassian.net/browse/TT-14701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Corrects types for `PORTAL_DATABASE_MAXRETRIES` and `PORTAL_DATABASE_RETRYDELAY`

- Updates config file names and descriptions for database settings

- Improves formatting and consistency in configuration documentation

- Clarifies default values for retry and connection parameters


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.md</strong><dd><code>Correct database config types, names, and descriptions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/configuration.md

<li>Changed <code>PORTAL_DATABASE_MAXRETRIES</code> type from boolean to int<br> <li> Corrected config file name and type for <code>PORTAL_DATABASE_RETRYDELAY</code><br> <li> Updated descriptions for retry delay and max open connections<br> <li> Improved formatting and consistency in documentation


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6526/files#diff-bff942701e76bae5b357af2a798c59862dff033909d36d1d2bba2d878add91dd">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>