### PR TITLE
Merging to release-5.8: removed .md from the internal links as it's not required (#6527)

### DIFF
--- a/tyk-docs/content/api-management/tyk-pump.md
+++ b/tyk-docs/content/api-management/tyk-pump.md
@@ -843,7 +843,7 @@ We ceated a defaulkt Tyk dashboard canvat to give our users an easier starting p
 #### Prerequisites
 
 - A working Datadog agent installed on your Environment. See the [Datadog Tyk integration docs](https://docs.datadoghq.com/integrations/tyk/) for more information.
-- Either a [Tyk Pro install]({{< ref "tyk-self-managed#installation-options-for-tyk-self-managed" >}}) or [Tyk OSS Gateway install]({{< ref "tyk-open-source#installation-options-for-tyk-gateway" >}}) along with a [Tyk Pump]({{< ref "tyk-pump.md" >}}) install.
+- Either a [Tyk Pro install]({{< ref "tyk-self-managed#installation-options-for-tyk-self-managed" >}}) or [Tyk OSS Gateway install]({{< ref "tyk-open-source#installation-options-for-tyk-gateway" >}}) along with a [Tyk Pump]({{< ref "tyk-pump" >}}) install.
 
 #### How it works
 

--- a/tyk-docs/content/developer-support/release-notes/portal.md
+++ b/tyk-docs/content/developer-support/release-notes/portal.md
@@ -1158,7 +1158,7 @@ Now when the [PORTAL_DCR_LOG_ENABLED]({{< ref "product-stack/tyk-enterprise-deve
 
 ##### Changed
 - Display an actual item title instead of a generic iterative name in the Pages and the Providers UI (e.g. "HeaderButtonLabel" instead of "ContentBlock 1" in the Pages menu).
-- When [PORTAL_DCR_LOG_ENABLED]({{< ref "product-stack/tyk-enterprise-developer-portal/deploy/configuration.md#portal_dcr_log_enabled" >}}) is enabled the portal now returns not only the status and status code of the request to the IdP but also actual payload returned by the IdP
+- When [PORTAL_DCR_LOG_ENABLED]({{< ref "product-stack/tyk-enterprise-developer-portal/deploy/configuration#portal_dcr_log_enabled" >}}) is enabled the portal now returns not only the status and status code of the request to the IdP but also actual payload returned by the IdP
 
 ##### Fixed
 - Fixed the bug where the database credentials were printed in the logs when bootstrapping the portal.

--- a/tyk-docs/content/developer-support/release-notes/pump.md
+++ b/tyk-docs/content/developer-support/release-notes/pump.md
@@ -637,10 +637,10 @@ From pump v1.8.1, the default MongoDB driver it uses is [mgo](https://github.com
 - GraphQL analytics records were being excluded from the _tyk_analytics_ collection for Mongo Pump. This has been fixed so that GraphQL analytic records are now included as expected.
 - Fixed MongoDB connection issue when using a password with URL escape characters (with mongo-go driver)
 - Fixed an issue in Prometheus pump when filtering fields , e.g. _API Name_, that contain `--` in their value. For example, `test--name`. Prometheus Pump filtered the field as two separate instances, e.g. `test` & `name`, instead of the expected `test--name`.
-- When [`omit_configfile`]({{< ref "tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.md#omit_config_file" >}}) is set to `true`, Pump will not try to load the config file and spit out error logs
+- When [`omit_configfile`]({{< ref "tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables#omit_config_file" >}}) is set to `true`, Pump will not try to load the config file and spit out error logs
 
 ##### Updated
-- Updated the default Hybrid Pump RPC pool size from 20 to 5 connections in order to reduce default CPU and memory footprint. See [Pump configurations]({{< ref "tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.md#pumpshybridmetarpcpoolsize" >}})
+- Updated the default Hybrid Pump RPC pool size from 20 to 5 connections in order to reduce default CPU and memory footprint. See [Pump configurations]({{< ref "tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables#pumpshybridmetarpcpoolsize" >}})
 - Import and use latest [storage library v1.0.5](https://github.com/TykTechnologies/storage/releases/tag/v1.0.5)
 - Updated default MongoDB driver to `mgo`. [Follow this guide to update the driver type](https://github.com/TykTechnologies/tyk-pump#driver-type)
 - Pump name is now case-insensitive. It will override two or more pumps with the same name but in different cases (e.g. _Mongo_ / _mongo_)


### PR DESCRIPTION
### **User description**
removed .md from the internal links as it's not required (#6527)

Co-authored-by: yuri <8012032+yurisasuke@users.noreply.github.com>


___

### **PR Type**
Documentation


___

### **Description**
- Removed `.md` extensions from internal documentation links

- Updated internal references to use anchor-only format

- Improved consistency of cross-references in documentation

- Ensured all affected links point to correct sections


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tyk-pump.md</strong><dd><code>Remove .md extension from Tyk Pump internal link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/api-management/tyk-pump.md

<li>Removed <code>.md</code> extension from internal link to <code>tyk-pump</code><br> <li> Ensured internal reference uses correct link format


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6528/files#diff-bb0e43b23015e578c530a000cb91ddff942822a17a0d6ba16f0eed7ebcafe321">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>portal.md</strong><dd><code>Update internal configuration link format in release notes</code></dd></summary>
<hr>

tyk-docs/content/developer-support/release-notes/portal.md

<li>Updated internal link to configuration section by removing <code>.md</code> <br>extension<br> <li> Ensured reference points to section anchor only


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6528/files#diff-82099d76ca6b72c670cf056d42fc939e01ae622e72a7ebd59b1f340efbde9902">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pump.md</strong><dd><code>Remove .md extension from environment variables links</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/developer-support/release-notes/pump.md

<li>Removed <code>.md</code> extension from two internal links to environment variables <br>documentation<br> <li> Updated links to use anchor-only format for section references


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6528/files#diff-aef1e2ab8d21678bffed3dece568852304a0b83d113140b7e37968d53bf84ec6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>