### PR TITLE
Merging to release-5.8: update governance grpc connection string format (#6521)

### DIFF
--- a/tyk-docs/content/tyk-governance/installation.md
+++ b/tyk-docs/content/tyk-governance/installation.md
@@ -276,8 +276,8 @@ governanceDashboard:
   server:
     # The gRPC endpoint URL of the Tyk Governance service
     # Format: hostname:port (without protocol)
-    # This will be provided in your welcome email from Tyk
-    url: "your-governance-instance.tyk.io:50051"
+    # This is in the format of prefixing "grpc-" to your Governance Hub URL.
+    url: "grpc-your-governance-instance.tyk.io:443"
   
   auth:
     # Authentication token for this agent


### PR DESCRIPTION
### **User description**
update governance grpc connection string format (#6521)


___

### **PR Type**
Documentation


___

### **Description**
- Updated gRPC endpoint URL format in installation docs

- Clarified use of "grpc-" prefix for Governance Hub URL

- Improved documentation comment for connection string

- Minor formatting adjustment at file end


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>installation.md</strong><dd><code>Clarify and update gRPC connection string documentation</code>&nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-governance/installation.md

<li>Updated example gRPC endpoint URL to use "grpc-" prefix<br> <li> Clarified documentation comment for connection string format<br> <li> Minor formatting change at file end (newline)


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6534/files#diff-7dd2b75af22ea385180d503affd78ade2dace981fbb9a4ebc0cf61acae522c54">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>