### PR TITLE
Merging to release-5.8: should be enable not enabled with d (#6549)

### DIFF
--- a/tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/configuration.md
+++ b/tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/configuration.md
@@ -631,7 +631,7 @@ PORTAL_CORS_ALLOWED_METHODS=GET,POST,HEAD
     "RetryDelay": 2000
   },
   "TIB": {
-    "Enabled": true
+    "Enable": true
   }
 }
 ```


### PR DESCRIPTION
### **User description**
should be enable not enabled with d (#6549)


___

### **PR Type**
Documentation


___

### **Description**
- Corrects configuration key from `Enabled` to `Enable`

- Updates documentation for TIB configuration accuracy


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.md</strong><dd><code>Correct TIB configuration key in documentation example</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/configuration.md

<li>Changed TIB config example key from <code>Enabled</code> to <code>Enable</code><br> <li> Ensures documentation matches actual configuration requirements


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6555/files#diff-bff942701e76bae5b357af2a798c59862dff033909d36d1d2bba2d878add91dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>