### PR TITLE
add governance fix

### DIFF
--- a/tyk-docs/content/tyk-governance/api-labeling.md
+++ b/tyk-docs/content/tyk-governance/api-labeling.md
@@ -85,7 +85,7 @@ A successful request will return a 200 OK status code and the newly created labe
 - The values field is optional. If provided, it defines the allowed values for this label
 - If values is empty, the label will accept any value (free text)
 - Only users with admin privileges can create labels
-- Once created, labels can be applied to APIs using the /api/{api-id}/labels endpoint
+- Once created, labels can be applied to APIs using the `/api/{api-id}/labels` endpoint
 - After creating a custom label, it will be available for selection when labeling APIs, either through the UI or via the API labeling endpoints.
 
 ### Validation


### PR DESCRIPTION
### **User description**
## Contributor checklist

- [ ] Reviewed *PR Code suggestions* and updated accordingly
- [ ] **Tyklings:** Labled the PR with the relevant releases
- [ ] **Tyklings:** Added Jira DX PR ticket to the subject

---

## New Contributors 
- [ ] Start the PR branch from our latest `master`
- [ ] I have read the [repository contribution guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md)
- [ ] I have read the [repository technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md)

---


___

### **PR Type**
Documentation


___

### **Description**
- Fixed formatting for API endpoint in documentation.

- Clarified usage of backticks for endpoint reference.

- Improved readability of API labeling instructions.


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Old API endpoint formatting"] -- "Update formatting" --> B["API endpoint in backticks"]
  B -- "Improved documentation clarity" --> C["Better user guidance"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-labeling.md</strong><dd><code>Fix API endpoint formatting and clarity in documentation</code>&nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-governance/api-labeling.md

<li>Updated API endpoint reference to use backticks.<br> <li> Enhanced clarity in label application instructions.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6735/files#diff-161bca62d749318d2cba7eaeb96557aaf250e5a768df5dec122d1a9be797d4e8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>