### PR TITLE
Merging to release-5.8: [TT-14838] GW 5.8.3 Update documentation  (#6629)

### DIFF
--- a/tyk-docs/assets/others/gateway-swagger.yml
+++ b/tyk-docs/assets/others/gateway-swagger.yml
@@ -30,7 +30,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.8.0
+  version: 5.8.3
 servers:
 - url: https://{tenant}
   variables:

--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -1044,7 +1044,22 @@ The reason this value is configurable is because sample data takes up space in y
 ENV: <b>TYK_GW_HEALTHCHECKENDPOINTNAME</b><br />
 Type: `string`<br />
 
-Enables you to rename the /hello endpoint
+HealthCheckEndpointName Enables you to change the liveness endpoint.
+Default is "/hello"
+
+### readiness_check_endpoint_name
+ENV: <b>TYK_GW_READINESSCHECKENDPOINTNAME</b><br />
+Type: `string`<br />
+
+ReadinessCheckEndpointName Enables you to change the readiness endpoint
+Default is "/ready"
+
+### graceful_shutdown_timeout_duration
+ENV: <b>TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION</b><br />
+Type: `int`<br />
+
+GracefulShutdownTimeoutDuration sets how many seconds the gateway should wait for an existing connection
+to finish before shutting down the server. Defaults to 30 seconds.
 
 ### oauth_refresh_token_expire
 ENV: <b>TYK_GW_OAUTHREFRESHEXPIRE</b><br />
@@ -1623,6 +1638,12 @@ ENV: <b>TYK_GW_COPROCESSOPTIONS_GRPCAUTHORITY</b><br />
 Type: `string`<br />
 
 Authority used in GRPC connection
+
+### coprocess_options.grpc_round_robin_load_balancing
+ENV: <b>TYK_GW_COPROCESSOPTIONS_GRPCROUNDROBINLOADBALANCING</b><br />
+Type: `bool`<br />
+
+GRPCRoundRobinLoadBalancing enables round robin load balancing for gRPC services; you must provide the address of the load balanced service using `dns:///` protocol in `coprocess_grpc_server`.
 
 ### coprocess_options.python_path_prefix
 ENV: <b>TYK_GW_COPROCESSOPTIONS_PYTHONPATHPREFIX</b><br />

--- a/tyk-docs/content/shared/x-tyk-gateway.md
+++ b/tyk-docs/content/shared/x-tyk-gateway.md
@@ -520,7 +520,7 @@ This struct allows you to specify a custom proxy and set the minimum TLS version
 
 Example:
 
-	``` 
+	```
 	{
 	  "proxy_url": "http(s)://proxy.url:1234",
 	  "minVersion": "1.0",
@@ -531,7 +531,8 @@ Example:
 	  ],
 	  "insecureSkipVerify": true,
 	  "forceCommonNameCheck": false
-	} ```
+	}
+	```
 
 Tyk classic API definition: `proxy.transport`
 
@@ -1416,7 +1417,7 @@ Tyk classic API definition: `version_data.versions..extended_paths.transform_hea
 ContextVariables holds the configuration related to Tyk context variables.
 
 **Field: `enabled` (`boolean`)**
-Enabled enables context variables to be passed to Tyk middleware.
+Enabled provides access to context variables from specific Tyk middleware (URL rewrite, header and body transform).
 
 
 Tyk classic API definition: `enable_context_vars`.
@@ -2254,7 +2255,7 @@ Tyk classic API definition: `version_data.versions..extended_paths.hard_timeouts
 ### **ExternalOAuth**
 
 ExternalOAuth holds configuration for an external OAuth provider.
-ExternalOAuth support will be deprecated starting from 5.7.0.
+Deprecated: ExternalOAuth support has been deprecated from 5.7.0.
 To avoid any disruptions, we recommend that you use JSON Web Token (JWT) instead,
 as explained in https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/ext-oauth-middleware/.
 


### PR DESCRIPTION
### **User description**
[TT-14838] GW 5.8.3 Update documentation  (#6629)

[TT-14838]: https://tyktech.atlassian.net/browse/TT-14838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Updated Gateway API version to 5.8.3 in Swagger file

- Added new configuration options to gateway config docs
  - readiness_check_endpoint_name and graceful_shutdown_timeout_duration
  - coprocess_options.grpc_round_robin_load_balancing

- Improved explanations and formatting in config and API docs

- Marked ExternalOAuth as deprecated from 5.7.0 in API docs


___

### **Changes diagram**

```mermaid
flowchart LR
  A["gateway-swagger.yml"] -- "Update API version" --> B["Gateway API docs"]
  C["gateway-config.md"] -- "Add new config options" --> B
  D["x-tyk-gateway.md"] -- "Clarify & deprecate features" --> B
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-swagger.yml</strong><dd><code>Bump Gateway API version to 5.8.3 in Swagger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/others/gateway-swagger.yml

- Updated the API version from 5.8.0 to 5.8.3


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6743/files#diff-86641d5f43d842a51680c692c0ca3cd7d7e67776df7bf1409cf97f83a885ad99">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway-config.md</strong><dd><code>Add and document new gateway config options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/gateway-config.md

<li>Added readiness_check_endpoint_name and <br>graceful_shutdown_timeout_duration options<br> <li> Documented coprocess_options.grpc_round_robin_load_balancing<br> <li> Improved descriptions for health check and shutdown settings


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6743/files#diff-0a53845669feaeb0d62d4b17d24bfee5fc23482ec7562bd52e23db03373f14d0">+22/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-gateway.md</strong><dd><code>Clarify API docs and mark ExternalOAuth deprecated</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/x-tyk-gateway.md

<li>Fixed code block formatting in proxy transport section<br> <li> Clarified context variable middleware access<br> <li> Marked ExternalOAuth as deprecated from 5.7.0


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6743/files#diff-c4c21855fe9a7bb5c25d2f53fd19b2c5afec3ef3f8ca54c0105d8bfe197ff31c">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>