### PR TITLE
Merging to release-5.8: [TT-14794] change behavior explanation when path does not match for a stream (#6524)

### DIFF
--- a/tyk-docs/content/api-management/event-driven-apis.md
+++ b/tyk-docs/content/api-management/event-driven-apis.md
@@ -586,7 +586,7 @@ sequenceDiagram
 1.  **Request Arrival & Gateway Pre-processing**: A client sends a request to an API endpoint managed by Tyk Gateway. The request passes through the initial middleware, such as authentication, key validation, and rate limiting.
 2.  **Streaming Middleware Interception**: The request reaches the `Stream Middleware`. It checks the request path against the stream routes defined in the API configuration.
 3.  **Path Matching**:
-    *   **If No Match**: The request is not destined for a stream. The `Stream Middleware` does nothing, and the request continues down the standard Tyk middleware chain, typically being proxied to the configured upstream service. <!-- TODO: this behavior is true until 5.8.x. From 5.9.0 onwards it will return 404 Not Found. -->
+    *   **If No Match**: The `Stream Middleware` will respond with a `404 Not Found` status code.
     *   **If Match**: The request is intended for a stream. The `Stream Middleware` takes control of the request handling.
 4.  **Stream Manager Coordination**: The middleware interacts with the `Stream Manager` associated with the API's stream configuration. The `Stream Manager` ensures the required `Stream Instance`(s) are initialized and running based on the loaded configuration. This might involve creating a new instance or reusing a cached one.
 5.  **Stream Instance Execution**: The instance then executes its defined logic, interacting with the configured `Upstream Service / Event Broker` (e.g., publishing a message to Kafka, subscribing to an MQTT topic, forwarding data over a WebSocket).


### PR DESCRIPTION
### **User description**
[TT-14794] change behavior explanation when path does not match for a stream (#6524)

[TT-14794]: https://tyktech.atlassian.net/browse/TT-14794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Updated documentation for stream path mismatch behavior.

- Clarified that unmatched stream paths return 404 Not Found.

- Removed outdated note about previous behavior.

- Specified new behavior for versions 5.9.0 and above.


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Request arrives at Gateway"]
  B["Stream Middleware checks path"]
  C["No stream path match"]
  D["Return 404 Not Found"]
  E["Stream path matches"]
  F["Stream Middleware handles request"]

  A -- "to" --> B
  B -- "No match" --> D
  B -- "Match" --> F
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event-driven-apis.md</strong><dd><code>Update stream path mismatch explanation to 404 response</code>&nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/api-management/event-driven-apis.md

<li>Updated explanation for unmatched stream paths to state 404 response.<br> <li> Removed outdated comment about prior behavior.<br> <li> Clarified middleware behavior for stream route matching.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6744/files#diff-530f7da75b9df07a7d5a2637543ae7bd4acf2de73dbdc470281ee7e4e5427cf0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>