### PR TITLE
Merging to release-5.8: [TT-10496] extra docs for gRPC high availability (#6462)

### DIFF
--- a/tyk-docs/content/api-management/plugins/rich-plugins.md
+++ b/tyk-docs/content/api-management/plugins/rich-plugins.md
@@ -239,28 +239,18 @@ The intended way of using a Coprocess middleware is to specify it as part of an 
 All hook types support chaining except the custom auth check (`auth_check`).
 {{< /note >}}
 
+---
+
 ## Rich Plugins Data Structures
 
-This page describes the data structures used by Tyk rich plugins, for the following plugin drivers:
+This section describes the data structures used by the Tyk rich plugins.
 
--   Python (built-in)
--   Lua (built-in)
--   gRPC (external, compatible with any supported [gRPC language](https://grpc.io/docs/))
+The coprocess object is a message dispatched by Tyk to the gRPC server handling the custom plugins.
 
 The Tyk [Protocol Buffer definitions](https://github.com/TykTechnologies/tyk/tree/master/coprocess/proto) are intended for users to generate their own bindings using the appropriate gRPC tools for the required target language.
 The remainder of this document illustrates a class diagram and explins the attributes of the protobuf messages.
 
----
-
-### Class Diagram
-
-The class diagram below illustrates the structure of the [Object](#object) message, dispatched by Tyk to a gRPC server that handles custom plugins.
-
-{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" >}}
-
----
-
-### Object
+### Coprocess Object
 
 The `Coprocess.Object` data structure wraps a `Coprocess.MiniRequestObject` and `Coprocess.ResponseObject` It contains additional fields that are useful for users that implement their own request dispatchers, like the middleware hook type and name.
 It also includes the session state object (`SessionState`), which holds information about the current key/user that's used for authentication.
@@ -276,6 +266,11 @@ message Object {
   ResponseObject response = 7;
 }
 ```
+
+This class diagram presents the structure of the object:
+
+{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" >}}
+
 
 #### Field Descriptions
 
@@ -299,8 +294,6 @@ Contains information about API definition, including `APIID`, `OrgID` and `confi
 
 `response`
 Contains information populated from the upstream HTTP response data, for response hooks. See [ResponseObject](#responseobject) for more details. All the field contents can be modified.
-
----
 
 ### MiniRequestObject
 
@@ -370,7 +363,7 @@ Contains the URL scheme, e.g. `http`, `https`.
 
 ### ResponseObject
 
-The `ResponseObject` exists within an [object](#object) for response hooks. The fields are populated with the upstream HTTP response data. All the field contents can be modified.
+The `ResponseObject` exists within an [object](#coprocess-object) for response hooks. The fields are populated with the upstream HTTP response data. All the field contents can be modified.
 
 ```protobuf
 syntax = "proto3";
@@ -1106,6 +1099,8 @@ These are some benchmarks performed on Python plugins. Python plugins run in a s
 
 {{< img src="/img/diagrams/pythonHitRate.png" alt="Python Performance" >}}
 
+---
+
 ## Using gRPC
 
 ### Overview
@@ -1122,9 +1117,14 @@ For supporting additional languages we have decided to integrate gRPC connection
 
 Tyk has built-in support for gRPC backends, enabling you to build rich plugins using any of the gRPC supported languages. See [gRPC by language](http://www.grpc.io/docs/) for further details.
 
----
+#### Use Cases
 
-#### Architectural overview
+Deploying an external gRPC server to handle plugins provides numerous technical advantages:
+
+- Allows for independent scalability of the service from the Tyk Gateway.
+- Utilizes a custom-designed server tailored to address specific security concerns, effectively mitigating various security risks associated with native plugins.
+
+#### gRPC Plugin Architectural Overview
 
 An example architecture is illustrated below.
 
@@ -1138,18 +1138,7 @@ Here we can see that Tyk Gateway sends requests to an external Java gRPC server 
 - The gRPC server sends the request back to Tyk.
 - Tyk proxies the request to your upstream API.
 
----
-
-#### Use cases
-
-Deploying an external gRPC server to handle plugins provides numerous technical advantages:
-
-- Allows for independent scalability of the service from the Tyk Gateway.
-- Utilizes a custom-designed server tailored to address specific security concerns, effectively mitigating various security risks associated with native plugins.
-
----
-
-#### Limitations
+#### Limitations of gRPC plugins
 
 At the time of writing the following features are currently unsupported and unavailable in the serialised request:
 - Client certificiates
@@ -1157,9 +1146,7 @@ At the time of writing the following features are currently unsupported and unav
 - For graphQL APIs details concerning the *max_query_depth* is unavailable
 - A request query parameter cannot be associated with multiple values
 
----
-
-#### Developer Resources
+#### gRPC Developer Resources
 
 The [Protocol Buffers](https://github.com/TykTechnologies/tyk/tree/master/coprocess/proto ) and [bindings](https://github.com/TykTechnologies/tyk/tree/master/coprocess/bindings) provided by Tyk should be used in order for successful ommunication between Tyk Gateway and your gRPC plugin server. Documentation for the protobuf messages is available in the [Rich Plugins Data Structures]({{< ref "api-management/plugins/rich-plugins#rich-plugins-data-structures" >}}) page.
 
@@ -1169,15 +1156,24 @@ You may re-use the bindings that were generated for our samples or generate the 
 
 If you wish to generate bindings for another target language you may generate the bindings yourself. The [Protocol Buffers](https://developers.google.com/protocol-buffers/) and [gRPC documentation](http://www.grpc.io/docs) provide specific requirements and instructions for each language.
 
+#### Load Balancing Between gRPC Servers
+
+Since Tyk 5.8.2 Tyk Gateway has had the ability to load balance between multiple gRPC servers.
+
+To implement this you must first specify the address of the load balanced service using the `dns:///` (note: triple slash) [protocol](https://github.com/grpc/grpc/blob/master/doc/naming.md) in Tyk Gateway's [gRPC server address]({{< ref "tyk-oss-gateway/configuration#coprocess_optionscoprocess_grpc_server" >}}) configuration (`TYK_GW_COPROCESSOPTIONS_COPROCESSGRPCSERVER`). Tyk will retrieve the list of addresses for each gRPC server from that service.
+
+You can control whether Tyk will implement load balancing using the [gRPC round robin load balancing]({{< ref "tyk-oss-gateway/configuration#coprocess_optionsgrpc_round_robin_load_balancing" >}})) config  (`TYK_GW_COPROCESSOPTIONS_GRPCROUNDROBINLOADBALANCING`):
+
+- If set to `true`, Tyk will balance load between the server addresses retrieved using a round robin approach.
+- If set to `false`, Tyk will implement a sticky session approach without load balancing.
+
+Note that Tyk will only query the DNS on start-up, so if you need to update the list of gRPC servers that you want Tyk to target, you must restart Tyk Gateway.
+
+If you are not load balancing, you can alternatively provide the `tcp://` address of the gRPC server in Tyk Gateway's [gRPC server address]({{< ref "tyk-oss-gateway/configuration#coprocess_optionscoprocess_grpc_server" >}}) configuration (`TYK_GW_COPROCESSOPTIONS_COPROCESSGRPCSERVER`) and set [gRPC round robin load balancing]({{< ref "tyk-oss-gateway/configuration#coprocess_optionsgrpc_round_robin_load_balancing" >}})  (`TYK_GW_COPROCESSOPTIONS_GRPCROUNDROBINLOADBALANCING`) to `false`.
+
 ---
 
-#### What's next?
-
-See our [getting started]({{< ref "api-management/plugins/rich-plugins#key-concepts" >}}) guide for an explanation of how to write and configure gRPC plugins.
-
----
-
-### Key Concepts
+### Getting Started: Key Concepts
 
 This document serves as a developer's guide for understanding the key concepts and practical steps for writing and configuring gRPC plugins for Tyk Gateway. It provides technical insights and practical guidance to seamlessly integrate Tyk plugins into your infrastructure through gRPC. The goal is to equip developers with the knowledge and tools needed to effectively utilize gRPC for enhancing Tyk Gateway functionalities.
 
@@ -1315,7 +1311,7 @@ For configurations directly embedded within the Tyk Gateway, plugin hooks can be
 }
 ```
 
-For example, a Post request plugin hook has been configured with name `MyPostMiddleware`. Before the request is sent upstream Tyk Gateway will serialize the request into a [Object protobuf message]({{< ref "api-management/plugins/rich-plugins#object" >}}) with the `hook_name` property set to `MyPostMiddleware` and the `hook_type` property set to `Post`. This message will then then be dispatched to the gRPC server for processing before the request is sent upstream.
+For example, a Post request plugin hook has been configured with name `MyPostMiddleware`. Before the request is sent upstream Tyk Gateway will serialize the request into a [Object protobuf message]({{< ref "api-management/plugins/rich-plugins#coprocess-object" >}}) with the `hook_name` property set to `MyPostMiddleware` and the `hook_type` property set to `Post`. This message will then then be dispatched to the gRPC server for processing before the request is sent upstream.
 
 </br>
 {{< note success >}}
@@ -1332,7 +1328,7 @@ Setting the `driver` configuring parameter to `gRPC` instructs Tyk Gateway to is
 
 **Pre plugin hook example**
 
-In this example we can see that a `custom_middleware` configuration block has been used to configure a gRPC Pre request plugin hook with name `HelloFromPre`. Before any middleware is executed Tyk Gateway will serialize the request into a [Object protobuf message]({{< ref "api-management/plugins/rich-plugins#object" >}}) with the `hook_name` property set to `HelloFromPre` and the `hook_type` property set to `Pre`. This message will then then be dispatched to the gRPC server.
+In this example we can see that a `custom_middleware` configuration block has been used to configure a gRPC Pre request plugin hook with name `HelloFromPre`. Before any middleware is executed Tyk Gateway will serialize the request into a [Object protobuf message]({{< ref "api-management/plugins/rich-plugins#coprocess-object" >}}) with the `hook_name` property set to `HelloFromPre` and the `hook_type` property set to `Pre`. This message will then then be dispatched to the gRPC server.
 
 ```yaml {linenos=table,hl_lines=["14-18"],linenostart=1}
 apiVersion: tyk.tyk.io/v1alpha1
@@ -1359,7 +1355,7 @@ spec:
 
 In the example we can see that a `custom_middleware` configuration block has been used to configure a gRPC Post plugin with name `HelloFromPost`. 
 
-Before the request is sent upstream Tyk Gateway will serialize the request and session details into a [Object protobuf message]({{< ref "api-management/plugins/rich-plugins#object" >}}) with the `hook_name` property set to `HelloFromPost` and the `hook_type` property set to `Post`. This message will then then be dispatched to the gRPC server for processing before the request is sent upstream.
+Before the request is sent upstream Tyk Gateway will serialize the request and session details into a [Object protobuf message]({{< ref "api-management/plugins/rich-plugins#coprocess-object" >}}) with the `hook_name` property set to `HelloFromPost` and the `hook_type` property set to `Post`. This message will then then be dispatched to the gRPC server for processing before the request is sent upstream.
 
 ```yaml {linenos=table,hl_lines=["14-18"],linenostart=1}
 apiVersion: tyk.tyk.io/v1alpha1
@@ -3214,7 +3210,7 @@ def set_response_error(object: coprocess_object_pb2.Object, code: int, message: 
 
 Our function accepts the following three parameters:
 
-- **object** is an instance of the [Object]({{< ref "api-management/plugins/rich-plugins#object" >}}) message representing the payload sent by Tyk Gateway to the *Dispatcher* service in our gRPC server. For further details of the payload structure dispatched by Tyk Gateway to a gRPC server please consult our gRPC documentation.
+- **object** is an instance of the [Object]({{< ref "api-management/plugins/rich-plugins#coprocess-object" >}}) message representing the payload sent by Tyk Gateway to the *Dispatcher* service in our gRPC server. For further details of the payload structure dispatched by Tyk Gateway to a gRPC server please consult our gRPC documentation.
 - **code** is the HTTP status code to return in the response.
 - **message** is the response message.
 
@@ -3482,6 +3478,8 @@ gRPC plugins may use different transports, we've tested TCP and Unix Sockets.
 {{< img src="/img/diagrams/unixResponseTime.png" alt="Unix Socket Response Times" >}}
 
 {{< img src="/img/diagrams/unixHitRate.png" alt="Unix Socket Hit Rate" >}}
+
+---
 
 ## Using Lua
 


### PR DESCRIPTION
### **User description**
[TT-10496] extra docs for gRPC high availability (#6462)

[TT-10496]: https://tyktech.atlassian.net/browse/TT-10496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Added detailed docs for highly available gRPC servers in Kubernetes

- Provided Go example for gRPC health checks and graceful shutdown

- Included Kubernetes deployment YAML with gRPC health probes

- Documented DNS-based gRPC load balancing in Tyk 5.8.2+


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Add gRPC HA section to advance-config.md"]
  B["Add Go example for health checks"]
  C["Add Kubernetes YAML with probes"]
  D["Document DNS-based gRPC load balancing"]
  E["Clarify and reorganize rich-plugins.md"]
  A -- "includes" --> B
  A -- "includes" --> C
  A -- "references" --> D
  D -- "explained in" --> E
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>advance-config.md</strong><dd><code>Add gRPC high availability and DNS protocol documentation</code></dd></summary>
<hr>

tyk-docs/content/api-management/plugins/advance-config.md

<li>Added comprehensive section on highly available gRPC servers in <br>Kubernetes<br> <li> Provided Go code example for readiness/liveness probes and graceful <br>shutdown<br> <li> Included example Kubernetes deployment and service YAML with health <br>probes<br> <li> Explained DNS-based load balancing for gRPC servers in Tyk 5.8.2+


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6745/files#diff-517d04be047e137f2e1aebfe8f230d24fb8d2abfc76d0fd5b7dd382a2b008f09">+251/-3</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rich-plugins.md</strong><dd><code>Clarify gRPC plugin docs and add DNS load balancing info</code>&nbsp; </dd></summary>
<hr>

tyk-docs/content/api-management/plugins/rich-plugins.md

<li>Clarified and reorganized gRPC plugin documentation structure<br> <li> Added section on DNS-based load balancing for gRPC servers<br> <li> Updated references to coprocess object and protobuf message links<br> <li> Improved explanations and developer guidance for gRPC plugins


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6745/files#diff-03d48be01df3be3c0e8c31731a7f5cc6a09410dd59b954101f9284d857450308">+41/-43</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>