### PR TITLE
Merging to release-5.8: Improve SQLITE deprecation message in Tyk Dashboard RN (#6713)

### DIFF
--- a/tyk-docs/content/developer-support/release-notes/dashboard.md
+++ b/tyk-docs/content/developer-support/release-notes/dashboard.md
@@ -905,15 +905,43 @@ An example is given below for illustrative purposes only. Tested Versions and Co
 | [OpenAPI Specification](https://spec.openapis.org/oas/v3.0.3) | v3.0.x      | v3.0.x          | Supported by [Tyk OAS]({{< ref "api-management/gateway-config-tyk-oas" >}})|
 
 #### Deprecations
-<!-- Required. Use the following statement if there are no deprecations, or explain if there are -->
-In 5.7.0, we have deprecated the dedicated [External OAuth]({{< ref "api-management/client-authentication#integrate-with-external-authorization-server-deprecated" >}})  (Tyk Classic: `external_oauth`, Tyk OAS: `server.authentication.securitySchemes.externalOAuth`) and [OpenID Connect]({{< ref "api-management/client-authentication#integrate-with-openid-connect-deprecated" >}})  (Tyk Classic: `auth_configs.oidc`, Tyk OAS: `server.authentication.oidc`) authentication methods. We advise users to switch to [JWT Authentication]({{< ref "basic-config-and-security/security/authentication-authorization/json-web-tokens" >}}).
 
-Additionally, SQLite has reached its End of Life in this release, enabling a fully static, CGO-free Tyk Dashboard optimised for RHEL8. Sqlite was previously recommended only to be used in basic proofs of concept. Now, for such scenarios and for production, we recommend migrating to PostgreSQL or MongoDB for better scalability and support.
-<!-- Optional section!
-Used to share and notify users about our plan to deprecate features, configs etc.
-Once you put an item in this section, we must keep this item listed in all the following releases till the deprecation happens. -->
-<!-- ###### Future deprecations
--->
+This section highlights features and dependencies that have been deprecated.
+
+##### Authentication Methods
+
+We’ve deprecated the following authentication methods in this release:
+
+* **[External OAuth]({{< ref "api-management/client-authentication#integrate-with-external-authorization-server-deprecated" >}})**
+
+  * Tyk Classic: `external_oauth`
+  * Tyk OAS: `server.authentication.securitySchemes.externalOAuth`
+
+* **[OpenID Connect (OIDC)]({{< ref "api-management/client-authentication#integrate-with-openid-connect-deprecated" >}})**
+
+  * Tyk Classic: `auth_configs.oidc`
+  * Tyk OAS: `server.authentication.oidc`
+
+We recommend migrating to **[JWT Authentication]({{< ref "basic-config-and-security/security/authentication-authorization/json-web-tokens" >}})** for improved flexibility and long-term support.
+
+##### SQLite End of Life
+
+SQLite has reached **End of Life** for the Tyk Dashboard in this release. It was previously intended for **proof-of-concept** use only and is no longer supported.
+
+We now recommend using **PostgreSQL** or **MongoDB** for both development and production deployments, as they provide greater scalability and long-term support.
+
+**Why This Matters**
+
+* SQLite is written in **C**, and using it in Go projects typically requires [**CGO**](https://golang.org/cmd/cgo/), which enables Go code to call C libraries.
+* As long as the Dashboard had support for SQLite, CGO was required.
+* With SQLite removed, the Tyk Dashboard can now be compiled with `CGO_ENABLED=0`, resulting in a **fully static binary**.
+
+This change enables:
+
+* Easier cross-platform builds
+* Better compatibility with **RHEL8**
+* Fewer dependencies and improved portability
+
 #### Upgrade instructions {#upgrade-5.7.0}
 If you are upgrading to 5.7.0, please follow the detailed [upgrade instructions](#upgrading-tyk). 
 


### PR DESCRIPTION
### **User description**
Improve SQLITE deprecation message in Tyk Dashboard RN (#6713)


___

### **PR Type**
Documentation


___

### **Description**
- Expanded and clarified deprecation notice for authentication methods.

- Added detailed explanation of SQLite End of Life.

- Provided migration recommendations to PostgreSQL or MongoDB.

- Explained technical benefits of removing SQLite dependency.


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Old Deprecation Notice"] -- "Replaced with" --> B["Expanded Auth Methods Deprecation"]
  A -- "Replaced with" --> C["Detailed SQLite End of Life Section"]
  B -- "Recommends" --> D["JWT Authentication"]
  C -- "Recommends" --> E["PostgreSQL or MongoDB"]
  C -- "Explains" --> F["Benefits: Static Binary, No CGO, RHEL8 Support"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.md</strong><dd><code>Expanded and clarified deprecation and migration guidance</code></dd></summary>
<hr>

tyk-docs/content/developer-support/release-notes/dashboard.md

<li>Rewrote and expanded the deprecation section for clarity.<br> <li> Added detailed rationale for SQLite deprecation and migration advice.<br> <li> Provided technical explanation of CGO/static binary benefits.<br> <li> Improved formatting and structure for easier reading.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6755/files#diff-d33730d9b7b352e9a2ce2f71ef67fea53fb21ae531d4522472f799648ee5b22f">+36/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>