### PR TITLE
Corrected version number for gRPC Load Balancing in LTS

### DIFF
--- a/tyk-docs/content/api-management/plugins/rich-plugins.md
+++ b/tyk-docs/content/api-management/plugins/rich-plugins.md
@@ -1158,7 +1158,7 @@ If you wish to generate bindings for another target language you may generate th
 
 #### Load Balancing Between gRPC Servers
 
-Since Tyk 5.8.2 Tyk Gateway has had the ability to load balance between multiple gRPC servers.
+Since Tyk 5.8.3 Tyk Gateway has had the ability to load balance between multiple gRPC servers.
 
 To implement this you must first specify the address of the load balanced service using the `dns:///` (note: triple slash) [protocol](https://github.com/grpc/grpc/blob/master/doc/naming.md) in Tyk Gateway's [gRPC server address]({{< ref "tyk-oss-gateway/configuration#coprocess_optionscoprocess_grpc_server" >}}) configuration (`TYK_GW_COPROCESSOPTIONS_COPROCESSGRPCSERVER`). Tyk will retrieve the list of addresses for each gRPC server from that service.
 


### PR DESCRIPTION
### **User description**
The load balancing control appeared in 5.8.3, not 5.8.2.

## Contributor checklist

- [ ] Reviewed *PR Code suggestions* and updated accordingly
- [ ] **Tyklings:** Labled the PR with the relevant releases
- [ ] **Tyklings:** Added Jira DX PR ticket to the subject

---

## New Contributors 
- [ ] Start the PR branch from our latest `master`
- [ ] I have read the [repository contribution guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md)
- [ ] I have read the [repository technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md)

---


___

### **PR Type**
Documentation


___

### **Description**
- Corrected the version number for gRPC load balancing feature

- Updated documentation to reflect accurate feature introduction


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Documentation: gRPC load balancing version"] -- "Update version from 5.8.2 to 5.8.3" --> B["Accurate feature introduction in docs"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rich-plugins.md</strong><dd><code>Corrected gRPC load balancing feature version in docs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/api-management/plugins/rich-plugins.md

<li>Updated the mentioned Tyk Gateway version for gRPC load balancing<br> <li> Changed version from 5.8.2 to 5.8.3 in documentation


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6756/files#diff-03d48be01df3be3c0e8c31731a7f5cc6a09410dd59b954101f9284d857450308">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>