### PR TITLE
[TT-13740] Add explanation for sse_use_post

### DIFF
--- a/tyk-docs/content/api-management/graphql.md
+++ b/tyk-docs/content/api-management/graphql.md
@@ -2007,7 +2007,7 @@ The values for subscription types are the same on all API types:
 
 ##### HTTP method for Server-Sent Event subscription
 
-When using `subscription_type=sse`, Tyk will use the HTTP `GET` method to subscribe to the upstream service. For some use cases, for example to support larger subscription payloads or to increase security by keeping the subscription payload out of server logs, the upstream requires HTTP `POST`. In Tyk 5.9.0 we have added `POST` support for SSE with the introduction of the boolean `use_sse_post` option which is only relevant if `subscription_type=sse`.
+When using `subscription_type=sse`, Tyk will use the HTTP `GET` method to subscribe to the upstream service. For some use cases, for example, to support larger subscription payloads or to increase security by keeping the subscription payload out of server logs, the upstream requires HTTP `POST`. In Tyk 5.9.0, we have added `POST` support for SSE with the introduction of the boolean `use_sse_post` option, which is only relevant if `subscription_type=sse`.
 
 ```json
 {

--- a/tyk-docs/content/api-management/graphql.md
+++ b/tyk-docs/content/api-management/graphql.md
@@ -2005,6 +2005,24 @@ The values for subscription types are the same on all API types:
 - `graphql-transport-ws`
 - `sse` (Server-Sent Events)
 
+##### HTTP method for Server-Sent Event subscription
+
+When using `subscription_type=sse`, Tyk will use the HTTP `GET` method to subscribe to the upstream service. For some use cases, for example to support larger subscription payloads or to increase security by keeping the subscription payload out of server logs, the upstream requires HTTP `POST`. In Tyk 5.9.0 we have added `POST` support for SSE with the introduction of the boolean `use_sse_post` option which is only relevant if `subscription_type=sse`.
+
+```json
+{
+  "graphql": {
+    "proxy": {
+      "subscription_type": "sse",
+      "sse_use_post": true
+    }
+  }
+}
+```
+
+If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `false`.
+
+
 ##### GraphQL Proxy
 
 ```


### PR DESCRIPTION
### **User description**
## Contributor checklist

- [ ] Reviewed *PR Code suggestions* and updated accordingly
- [ ] **Tyklings:** Labled the PR with the relevant releases
- [ ] **Tyklings:** Added Jira DX PR ticket to the subject

---

## New Contributors 
- [ ] Start the PR branch from our latest `master`
- [ ] I have read the [repository contribution guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md)
- [ ] I have read the [repository technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md)

---


___

### **PR Type**
Documentation


___

### **Description**
- Added explanation for `sse_use_post` option in GraphQL config

- Documented HTTP method selection for SSE subscriptions

- Provided example configuration for enabling POST with SSE

- Clarified default behavior and usage scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  doc["GraphQL Documentation"] -- "add section" --> ssePost["Explain sse_use_post option"]
  ssePost -- "provide example" --> configJson["JSON config snippet"]
  ssePost -- "clarify usage" --> usageNote["GET vs POST explanation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graphql.md</strong><dd><code>Documented `sse_use_post` option for SSE in GraphQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/api-management/graphql.md

<ul><li>Added section on HTTP method for SSE subscriptions<br> <li> Explained new <code>sse_use_post</code> boolean option<br> <li> Included JSON example for enabling POST<br> <li> Clarified default GET behavior and use cases</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6769/files#diff-f11ba6924d8e0993ee912457bd4104a38fcdc0b853b5c53960c711e550195dbf">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

