### PR TITLE
Merging to release-5.8: [TT-14696] Explainer for CVEs in Plugin Compiler (#6777)

### DIFF
--- a/tyk-docs/content/api-management/plugins/golang.md
+++ b/tyk-docs/content/api-management/plugins/golang.md
@@ -66,6 +66,30 @@ We provide the [Tyk Plugin Compiler]({{< ref "api-management/plugins/golang#plug
 - https://github.com/golang/go/issues/19004
 - https://www.reddit.com/r/golang/comments/qxghjv/plugin_already_loaded_when_a_plugin_is_loaded/
 
+#### Understanding Plugin Compiler Security Scans
+
+The Tyk Plugin Compiler Docker image is a development tool used exclusively during the build phase to compile custom Go plugins for the Tyk Gateway. This tool:
+
+1. **Is not a runtime component** - It is never deployed as part of your production Tyk environment
+2. **Operates in isolated build environments** - It should only be used in controlled development or CI/CD pipelines
+3. **Is not designed to be network-exposed** - It should never be deployed as a service or exposed to untrusted networks
+
+##### Technical Context
+The Plugin Compiler is built on Debian Bullseye to ensure binary compatibility with RHEL8 environments, which are commonly used in enterprise Tyk deployments. Security scanning tools may flag numerous Common Vulnerabilities and Exposures (CVEs) in the base Debian Bullseye libraries included in this image.
+
+##### Security Clarification
+These CVEs do not represent an exploitable attack surface in your Tyk deployment for several reasons:
+
+1. **Build-time vs. Runtime Separation:** The Plugin Compiler is strictly a build-time tool. The compiled plugins that it produces are what get deployed to your Tyk Gateway, not the compiler itself.
+
+2. **Ephemeral Usage Pattern**: The recommended usage pattern is to run the compiler only when needed to generate plugin binaries, then discard the container.
+
+3. **Air-gapped Operation**: The compilation process typically occurs in development environments or CI/CD pipelines that are separate from production systems.
+
+4. **No Persistent Deployment**: Unlike the Tyk Gateway, Dashboard, and other runtime components, the Plugin Compiler is never deployed as a long-running service in your API management infrastructure.
+
+For optimal security, we recommend running the Plugin Compiler in isolated build environments and transferring only the compiled plugin binaries to your production Tyk deployment.
+
 
 ### Setting up your environment
 


### PR DESCRIPTION
### **User description**
[TT-14696] Explainer for CVEs in Plugin Compiler (#6777)


___

### **PR Type**
Documentation


___

### **Description**
- Adds detailed explanation of Plugin Compiler CVE scan results

- Clarifies Plugin Compiler's role as a non-runtime, build-only tool

- Provides security best practices for using the Plugin Compiler

- Recommends isolated environments for compilation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  doc["Golang Plugin Docs"] -- "add section" --> cveSection["Plugin Compiler Security Scans"]
  cveSection -- "explains" --> usage["Build-only, not runtime"]
  cveSection -- "explains" --> security["CVE context & best practices"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>golang.md</strong><dd><code>Add Plugin Compiler CVE security explainer section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/api-management/plugins/golang.md

<ul><li>Adds a new section explaining Plugin Compiler CVE scan results<br> <li> Details why flagged CVEs are not exploitable in production<br> <li> Outlines best practices for secure usage of the Plugin Compiler<br> <li> Emphasizes separation between build-time and runtime components</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6778/files#diff-0c36572e2685d145460b6acda22c4249165e6b52ccb9736e3e4a28974d7fc6ee">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

