### PR TITLE
Merging to release-5.9: [TT-15546] Update documentation for Dashboard (5.8.5) (#6856)

### DIFF
--- a/tyk-docs/content/shared/dashboard-config.md
+++ b/tyk-docs/content/shared/dashboard-config.md
@@ -1385,3 +1385,15 @@ ENV: <b>TYK_DB_DISABLETELEMETRY</b><br />
 Type: `bool`<br />
 
 Enable or disable sending telemetry data such as analytics, API configurations, etc.
+<<<<<<< HEAD
+=======
+
+### escape_dots_in_oas_paths
+ENV: <b>TYK_DB_ESCAPEDOTSINOASPATHS</b><br />
+Type: `bool`<br />
+
+When enabled, dots in OAS field names will be escaped (to \\u002e ) and unescaped when required for compatibility with specific databases.
+
+Defaults to `false`.
+
+>>>>>>> 9fd031163... [TT-15546] Update documentation for Dashboard (5.8.5) (#6856)

--- a/tyk-docs/content/shared/dashboard-config.md
+++ b/tyk-docs/content/shared/dashboard-config.md
@@ -1385,8 +1385,6 @@ ENV: <b>TYK_DB_DISABLETELEMETRY</b><br />
 Type: `bool`<br />
 
 Enable or disable sending telemetry data such as analytics, API configurations, etc.
-<<<<<<< HEAD
-=======
 
 ### escape_dots_in_oas_paths
 ENV: <b>TYK_DB_ESCAPEDOTSINOASPATHS</b><br />
@@ -1396,4 +1394,3 @@ When enabled, dots in OAS field names will be escaped (to \\u002e ) and unescape
 
 Defaults to `false`.
 
->>>>>>> 9fd031163... [TT-15546] Update documentation for Dashboard (5.8.5) (#6856)


### PR DESCRIPTION
### **User description**
[TT-15546] Update documentation for Dashboard (5.8.5) (#6856)

[TT-15546]: https://tyktech.atlassian.net/browse/TT-15546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Add dashboard config option docs

- Document OAS dots escaping behavior

- Include env var and bool type

- Note database compatibility rationale


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DOCS["Dashboard config docs"] -- "add section" --> ESC["escape_dots_in_oas_paths"]
  ESC -- "env var" --> ENV["TYK_DB_ESCAPEDOTSINOASPATHS"]
  ESC -- "behavior" --> BEH["Escape dots to \\u002e"]
  BEH -- "reason" --> DB["DB compatibility (e.g., DocumentDB)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-config.md</strong><dd><code>Add OAS path dots escaping config docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/dashboard-config.md

<ul><li>Add <code>escape_dots_in_oas_paths</code> section<br> <li> Document env <code>TYK_DB_ESCAPEDOTSINOASPATHS</code><br> <li> Specify type <code>bool</code> and default <code>false</code><br> <li> Explain dot escaping to <code>\u002e</code> for DB compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6868/files#diff-2af548b55c5ac98b8a1c1c3f8e44cb38709a34e988c684247b81029f2b173433">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

