### PR TITLE
[DX-2098] RN for Tyk Sync 2.1.2 and 2.1.3

### DIFF
--- a/tyk-docs/content/developer-support/release-notes/sync.md
+++ b/tyk-docs/content/developer-support/release-notes/sync.md
@@ -17,7 +17,99 @@ Our minor releases are supported until our next minor comes out.
 
 ---
 
+{{< note success >}}
+**Note on Tyk Sync version 2.2.1**  
+
+Tyk Sync 2.1.1 was accidentally also released to DockerHub as Tyk Sync v2.2.1.
+<br>That version should not be used.
+<br>We recommend the most recent version of Tyk Sync, which is first in the following list.
+{{< /note >}}
+
 ## 2.1 Release Notes
+
+### 2.1.3 Release Notes
+
+#### Release Date 4 September 2025
+
+#### Release Highlights
+
+This patch release upgrades Tyk Sync to use Go 1.24 for enhanced security and stability.
+
+Please refer to the [changelog]({{< ref "#Changelog-v2.1.3">}}) below for detailed explanation.
+
+#### Breaking Changes
+
+This release has no breaking changes.
+
+#### Deprecations
+There are no deprecations in this release.
+
+#### Upgrade instructions
+For users currently on v2.1.2, we strongly recommend promptly upgrading to the latest release. If you are working with an older version, it is advisable to bypass version 2.1.2 and proceed directly to this latest patch release.
+<br/>
+Go to the [Upgrading Tyk](#upgrading-tyk) section for detailed upgrade Instructions.
+
+#### Downloads
+- [Docker image v2.1.3](https://hub.docker.com/r/tykio/tyk-sync/tags?page=&page_size=&ordering=-name&name=v2.1.3)
+  - ```bash
+    docker pull tykio/tyk-sync:v2.1.3
+    ```
+
+#### Changelog {#Changelog-v2.1.3}
+
+##### Updated
+<ul>
+<li>
+<details>
+<summary>Upgraded to Golang 1.24</summary>
+
+Tyk Sync now runs on Golang 1.24, bringing:
+
+  - Improved build performance and runtime efficiency
+  - Enhanced security with latest Go security patches
+  - Better dependency management and module support
+</details>
+</li>
+</ul>
+
+### 2.1.2 Release Notes
+
+#### Release Date 27 June 2025
+
+#### Release Highlights
+
+This patch release uplifts a dependent library for better interoperability with the rest of the Tyk stack. Please refer to the [changelog]({{< ref "#Changelog-v2.1.2">}}) below for detailed explanation.
+
+#### Breaking Changes
+
+This release has no breaking changes.
+
+#### Deprecations
+There are no deprecations in this release.
+
+#### Upgrade instructions
+For users currently on v2.1.1, we strongly recommend promptly upgrading to the latest release. If you are working with an older version, it is advisable to bypass version 2.1.1 and proceed directly to this latest patch release.
+<br/>
+Go to the [Upgrading Tyk](#upgrading-tyk) section for detailed upgrade Instructions.
+
+#### Downloads
+- [Docker image v2.1.2](https://hub.docker.com/r/tykio/tyk-sync/tags?page=&page_size=&ordering=-name&name=v2.1.2)
+  - ```bash
+    docker pull tykio/tyk-sync:v2.1.2
+    ```
+
+#### Changelog {#Changelog-v2.1.2}
+
+##### Updated
+<ul>
+<li>
+<details>
+<summary>Updated to use latest kin-openapi</summary>
+
+Upgraded to use the latest version of kin-openapi (v0.132.0). This ensures improved compatibility, full stack interoperability, and continued support for existing OpenAPI 3.0.x specifications.
+</details>
+</li>
+</ul>
 
 ### 2.1.1 Release Notes
 
@@ -26,6 +118,12 @@ Our minor releases are supported until our next minor comes out.
 #### Release Highlights
 
 This patch release contains a bug fix. Please refer to the [changelog]({{< ref "#Changelog-v2.1.1">}}) below for detailed explanation.
+
+{{< note success >}}
+**Note**  
+
+This release was accidentally also released to DockerHub as Tyk Sync v2.2.1. That version should not be used.
+{{< /note >}}
 
 #### Breaking Changes
 

--- a/tyk-docs/content/developer-support/release-notes/sync.md
+++ b/tyk-docs/content/developer-support/release-notes/sync.md
@@ -20,7 +20,7 @@ Our minor releases are supported until our next minor comes out.
 {{< note success >}}
 **Note on Tyk Sync version 2.2.1**  
 
-Tyk Sync 2.1.1 was accidentally also released to DockerHub as Tyk Sync v2.2.1.
+Tyk Sync 2.1.1 was accidentally also released to [DockerHub](https://hub.docker.com/layers/tykio/tyk-sync/v2.2.1/images/sha256-cf21fef955add971a9bdfeadd2674fc1f22fbee2d0bf12dab38a78bfae5b7716) as Tyk Sync v2.2.1.
 <br>That version should not be used.
 <br>We recommend the most recent version of Tyk Sync, which is first in the following list.
 {{< /note >}}
@@ -122,7 +122,7 @@ This patch release contains a bug fix. Please refer to the [changelog]({{< ref "
 {{< note success >}}
 **Note**  
 
-This release was accidentally also released to DockerHub as Tyk Sync v2.2.1. That version should not be used.
+This release was accidentally also released to [DockerHub](https://hub.docker.com/layers/tykio/tyk-sync/v2.2.1/images/sha256-cf21fef955add971a9bdfeadd2674fc1f22fbee2d0bf12dab38a78bfae5b7716) as Tyk Sync v2.2.1. That version should not be used.
 {{< /note >}}
 
 #### Breaking Changes

--- a/tyk-docs/data/releases/sync.json
+++ b/tyk-docs/data/releases/sync.json
@@ -1,8 +1,16 @@
 {
     "home": "tyk-sync",
     "licensed": true,
-    "latest": "2.1.1",
+    "latest": "2.1.3",
     "releaseNotesPath": "developer-support/release-notes/sync",
+    "2.1.3": {
+      "date": "04/09/2025",
+      "docker": "https://hub.docker.com/r/tykio/tyk-sync/tags?page=1&name=v2.1.3"
+    },
+    "2.1.2": {
+      "date": "27/06/2025",
+      "docker": "https://hub.docker.com/r/tykio/tyk-sync/tags?page=1&name=v2.1.2"
+    },
     "2.1.1": {
       "date": "13/05/2025",
       "docker": "https://hub.docker.com/r/tykio/tyk-sync/tags?page=1&name=v2.1.1"


### PR DESCRIPTION
### **User description**
Added retrospective release notes for Sync 2.1.2 and 2.1.3, with explanatory/warning note about 2.2.1 (erroneous release)


___

### **PR Type**
Documentation


___

### **Description**
- Add release notes for 2.1.2, 2.1.3

- Add warning about erroneous 2.2.1

- Include downloads and upgrade guidance

- Document Go 1.24, kin-openapi updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  RN["Release notes: Sync 2.1.x"] --> R213["Add 2.1.3 notes"]
  RN --> R212["Add 2.1.2 notes"]
  R213 --> GO["Note: Go 1.24 upgrade"]
  R212 --> KIN["Note: kin-openapi update"]
  RN --> WARN["Warning about 2.2.1 (erroneous)"]
  RN --> DL["Downloads and upgrade instructions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.md</strong><dd><code>Add Sync 2.1.2/2.1.3 notes and warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/developer-support/release-notes/sync.md

<ul><li>Add 2.1.3 release notes and changelog<br> <li> Add 2.1.2 release notes and changelog<br> <li> Insert notes warning about mis-tagged 2.2.1<br> <li> Provide downloads and upgrade guidance</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6916/files#diff-9682284dafc10da5caae99115ef84766747fc914103f0ca13885ef3ed269d35a">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

