### PR TITLE
Merging to release-5.8: Minor formatting fix in warning (#6942)

### DIFF
--- a/tyk-docs/content/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/dynamic-client-registration.md
+++ b/tyk-docs/content/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/dynamic-client-registration.md
@@ -79,7 +79,7 @@ The Curity Identity Server by default requires a {{< tooltip >}}nonce token{{< d
 
 When configuring the DCR endpoint in the Curity Identity Server to use `no-authentication`, ensure that the communication between Tyk and the Curity Identity Server is secured so that it is only accessible to Tyk.
 
-To configure this in the AdminUI of the Curity Identity Server, go to Profiles &#8594; Token Service &#8594; Dynamic Registration &#8594; scroll to the **Non-templatized** section and set **Authentication Method** to `no-authentication`.  
+To configure this in the AdminUI of the Curity Identity Server, go to Profiles &#8594; Token Service &#8594; Dynamic Registration &#8594; scroll to the Non-templatized section and set Authentication Method to `no-authentication`.  
 
 {{< /warning >}}
 


### PR DESCRIPTION
### **User description**
Minor formatting fix in warning (#6942)


___

### **PR Type**
Documentation


___

### **Description**
- Remove bold styling in warning text

- Keep code formatting for `no-authentication`

- Clarify Curity AdminUI navigation wording


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CurityDoc["Dynamic Client Registration doc"] -- "cleanup warning text" --> WarningBlock["Warning shortcode content"]
  WarningBlock -- "remove **bold**" --> PlainText["Plain section names"]
  WarningBlock -- "retain code style" --> CodeSpan["`no-authentication`"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dynamic-client-registration.md</strong><dd><code>Clean up warning formatting and wording</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/dynamic-client-registration.md

<ul><li>Removed bold from section names in warning<br> <li> Kept code span for <code>no-authentication</code><br> <li> Minor prose consistency improvement</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6944/files#diff-dae8afc86acebb3da945f81b1896a65e103528c1bdf359cc04cf654eea38ab4c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

