### PR TITLE
Merging to release-5.8: [DX-2101] EDP Custom Rate Limit Key Docs list invalid metadata (#6948)

### DIFF
--- a/tyk-docs/content/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/configuring-custom-rate-limit-keys.md
+++ b/tyk-docs/content/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/configuring-custom-rate-limit-keys.md
@@ -34,7 +34,7 @@ The Tyk Enterprise Developer Portal facilitates the configuration of various rat
 To achieve this, the portal, by default, populates the following attributes in the credential metadata, which can be used as part of a custom rate limit key:
 - **ApplicationID**: The ID of the application to which the credential belongs.
 - **DeveloperID**: The ID of the developer who created the credential.
-- **OrganizationID**: The ID of the organization to which the developer belongs.
+- **OrganisationID**: The ID of the organization to which the developer belongs.
 
 Additionally, it's possible to attach [custom attribute values]({{< ref "portal/customization/user-model#add-custom-attributes-to-the-user-model" >}}) defined in a developer profile as metadata fields to credentials.
 


### PR DESCRIPTION
### **User description**
[DX-2101] EDP Custom Rate Limit Key Docs list invalid metadata (#6948)

[DX-2101]: https://tyktech.atlassian.net/browse/DX-2101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Correct metadata key spelling in docs

- Align field name with actual key


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Docs["EDP rate limit docs"] -- "rename field" --> Key["OrganisationID metadata key"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuring-custom-rate-limit-keys.md</strong><dd><code>Correct metadata key to OrganisationID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/configuring-custom-rate-limit-keys.md

<ul><li>Rename <code>OrganizationID</code> to <code>OrganisationID</code>.<br> <li> Clarify correct metadata key in list.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6957/files#diff-2aebeb5665b325084c7f04cba5bad49cdc302e796517f261980de7f7319aec64">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

