### PR TITLE
Add a Note on the availability of `ctx.GetSession(r)` in the middleware chain

### DIFF
--- a/tyk-docs/content/api-management/plugins/golang.md
+++ b/tyk-docs/content/api-management/plugins/golang.md
@@ -521,7 +521,8 @@ func MyPluginFunction(w http.ResponseWriter, r *http.Request) {
 {{< note warning >}}
 **Note**  
 
-The Session is set during the (custom) Authentication layer - meaning it won't be set until the middleware chain after the authentication middleware layer.    Trying to use `ctx.GetSession` in a custom auth plugin would always return an empty object.
+Tyk Gateway sets the session in the [Authentication layer]({{< ref "api-management/traffic-transformation#request-middleware-chain" >}}) of the middleware chain. Because of this, the session object does not exist until the middleware chain runs after the authentication middleware. If you call `ctx.GetSession` inside a custom auth plugin, it will always return an empty object.
+
 {{< /note >}}
 
 The invocation of `ctx.GetSession(r)` returns an SessionState object.

--- a/tyk-docs/content/api-management/plugins/golang.md
+++ b/tyk-docs/content/api-management/plugins/golang.md
@@ -518,6 +518,12 @@ func MyPluginFunction(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+{{< note warning >}}
+**Note**  
+
+The Session is set during the (custom) Authentication layer - meaning it won't be set until the middleware chain after the authentication middleware layer.    Trying to use `ctx.GetSession` in a custom auth plugin would always return an empty object.
+{{< /note >}}
+
 The invocation of `ctx.GetSession(r)` returns an SessionState object.
 The Go data structure can be found [here](https://github.com/TykTechnologies/tyk/blob/master/user/session.go#L106).
 


### PR DESCRIPTION
### **User description**
## Contributor checklist

- [ ] Reviewed *PR Code suggestions* and updated accordingly
- [ ] **Tyklings:** Labled the PR with the relevant releases
- [ ] **Tyklings:** Added Jira DX PR ticket to the subject

---

## New Contributors 
- [ ] Start the PR branch from our latest `master`
- [ ] I have read the [repository contribution guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md)
- [ ] I have read the [repository technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md)

---


___

### **PR Type**
Documentation


___

### **Description**
- Add warning note about session timing

- Clarify ctx.GetSession behavior in auth plugins


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Auth["Custom Authentication Middleware"] -- "sets Session" --> PostAuthMW["Post-auth Middleware Chain"]
  PreAuthMW["Pre-auth/custom auth plugins"] -- "ctx.GetSession => empty" --> Auth
  PostAuthMW -- "ctx.GetSession => valid" --> Handlers["Downstream Handlers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>golang.md</strong><dd><code>Add session timing warning for Go plugins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/api-management/plugins/golang.md

<ul><li>Add warning note shortcode block.<br> <li> Explain session set during authentication layer.<br> <li> State ctx.GetSession returns empty in custom auth plugin.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6959/files#diff-0c36572e2685d145460b6acda22c4249165e6b52ccb9736e3e4a28974d7fc6ee">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

