### PR TITLE
[TT-15663] Gateway Update configuration documentation for 5.8.6

### DIFF
--- a/tyk-docs/content/shared/x-tyk-gateway.md
+++ b/tyk-docs/content/shared/x-tyk-gateway.md
@@ -2255,7 +2255,7 @@ Tyk classic API definition: `version_data.versions..extended_paths.hard_timeouts
 ### **ExternalOAuth**
 
 ExternalOAuth holds configuration for an external OAuth provider.
-Deprecated: ExternalOAuth support has been deprecated from 5.7.0.
+Deprecated: ExternalOAuth support was deprecated in Tyk 5.7.0.
 To avoid any disruptions, we recommend that you use JSON Web Token (JWT) instead,
 as explained in https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/ext-oauth-middleware/.
 


### PR DESCRIPTION
### **User description**
Triggered by: andrei-tyk

Included:

Tyk Gateway: true
Tyk Dashboard: false
Tyk MDCB false
Tyk Pump false

Intended for: 5.8
Changes sourced from: release-5.8.6
Config info generator branch: main

Note: Gateway docs for v5.8.6 (branch suffix: docs-5-8-6)

JIRA: https://tyktech.atlassian.net/browse/TT-15663


___

### **PR Type**
Documentation


___

### **Description**
- Clarify ExternalOAuth deprecation wording

- Reference Tyk 5.7.0 explicitly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  docs["Gateway docs: ExternalOAuth section"] -- "clarify deprecation wording" --> deprecated["Explicitly states deprecation in Tyk 5.7.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-gateway.md</strong><dd><code>Refine ExternalOAuth deprecation statement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/x-tyk-gateway.md

<ul><li>Update deprecation phrasing for <code>ExternalOAuth</code><br> <li> Specify deprecation occurred in Tyk 5.7.0<br> <li> Keep guidance to use JWT with link</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6971/files#diff-c4c21855fe9a7bb5c25d2f53fd19b2c5afec3ef3f8ca54c0105d8bfe197ff31c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

