### PR TITLE
Merging to release-5.9: updated tyk ai studio image reference (#6977)

### DIFF
--- a/tyk-docs/content/ai-management/ai-studio/deployment-k8s.md
+++ b/tyk-docs/content/ai-management/ai-studio/deployment-k8s.md
@@ -117,7 +117,7 @@ spec:
     spec:
       containers:
       - name: ai-studio
-        image: tykio/ai-studio:latest
+        image: tykio/tyk-ai-studio:latest
         envFrom:
         - secretRef:
             name: tyk-ai-config
@@ -201,7 +201,7 @@ spec:
     spec:
       containers:
       - name: ai-studio
-        image: tykio/ai-studio:latest
+        image: tykio/tyk-ai-studio:latest
         envFrom:
         - secretRef:
             name: tyk-ai-config
@@ -315,7 +315,7 @@ spec:
     spec:
       containers:
       - name: ai-studio
-        image: tykio/ai-studio:latest
+        image: tykio/tyk-ai-studio:latest
         envFrom:
         - secretRef:
             name: tyk-ai-config
@@ -616,7 +616,7 @@ To upgrade an existing installation:
 kubectl apply -f your-deployment.yaml
 
 # Or update just the image
-kubectl set image deployment/tyk-ai-studio ai-studio=tykio/ai-studio:new-version -n tyk-ai-studio
+kubectl set image deployment/tyk-ai-studio ai-studio=tykio/tyk-ai-studio:new-version -n tyk-ai-studio
 ```
 
 ### Uninstalling


### PR DESCRIPTION
### **User description**
updated tyk ai studio image reference (#6977)

updated image reference

from tykio/ai-studio to tykio/tyk-ai-studio


___

### **PR Type**
Documentation


___

### **Description**
- Update container image path in docs

- Replace k8s examples with new repo

- Adjust upgrade command image reference


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DOCS["K8s deployment docs"] -- "replace image" --> OLD["tykio/ai-studio"]
  OLD -- "migrate to" --> NEW["tykio/tyk-ai-studio"]
  DOCS -- "update upgrade command" --> CMD["kubectl set image example"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment-k8s.md</strong><dd><code>Align k8s docs to new image repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/ai-management/ai-studio/deployment-k8s.md

<ul><li>Replace <code>tykio/ai-studio</code> with <code>tykio/tyk-ai-studio</code>.<br> <li> Update three deployment YAML snippets.<br> <li> Update <code>kubectl set image</code> upgrade example.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6978/files#diff-6290cda536da0f42458c3bc5d2a41ef31916f06373cca62ec6353a6115c62efd">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

