### PR TITLE
Merging to release-5.9: Correct Helm Chart version 3.1 -> 4.0 [Dash] (#6993)

### DIFF
--- a/tyk-docs/content/developer-support/release-notes/dashboard.md
+++ b/tyk-docs/content/developer-support/release-notes/dashboard.md
@@ -58,7 +58,7 @@ There are no breaking changes in this release.
 | 5.9.2  | MDCB v2.8.4       | MDCB v2.8.4 |
 |        | Operator v1.2.0   | Operator v0.17 |
 |        | Sync v2.1.3       | Sync v2.1.0 |
-|        | Helm Chart v3.1.0 | Helm all versions |
+|        | Helm Chart v4.0   | Helm all versions |
 |        | EDP v1.14.1       | EDP all versions |
 |        | Pump v1.12.1      | Pump all versions |
 |        | TIB (if using standalone) v1.7.0 | TIB all versions |
@@ -104,7 +104,7 @@ If you are upgrading to 5.9.2, please follow the detailed [upgrade instructions]
     docker pull tykio/tyk-dashboard:v5.9.2
     ```
 - Helm charts
-  - [tyk-charts v3.0.0]({{< ref "developer-support/release-notes/helm-chart#300-release-notes" >}})
+  - [tyk-charts v4.0.0]({{< ref "developer-support/release-notes/helm-chart#400-release-notes" >}})
 Please note that the Tyk Helm Charts are configured to install the LTS version of Tyk Dashboard. You will need to modify them to install v5.9.2.
 
 #### Changelog {#Changelog-v5.9.2}
@@ -149,7 +149,7 @@ Since 5.9.0, Tyk Dashboard automatically escapes dots (`.`) in OpenAPI endpoint 
 | 5.9.1  | MDCB v2.8.3       | MDCB v2.8.3 |
 |        | Operator v1.2.0   | Operator v0.17 |
 |        | Sync v2.1.2       | Sync v2.1.0 |
-|        | Helm Chart v3.1.0 | Helm all versions |
+|        | Helm Chart v4.0   | Helm all versions |
 |        | EDP v1.14.0       | EDP all versions |
 |        | Pump v1.12.0      | Pump all versions |
 |        | TIB (if using standalone) v1.7.0 | TIB all versions |
@@ -181,7 +181,7 @@ If you are upgrading to 5.9.1, please follow the detailed [upgrade instructions]
     docker pull tykio/tyk-dashboard:v5.9.1
     ```
 - Helm charts
-  - [tyk-charts v3.0.0]({{< ref "developer-support/release-notes/helm-chart#300-release-notes" >}})
+  - [tyk-charts v4.0.0]({{< ref "developer-support/release-notes/helm-chart#400-release-notes" >}})
 
 #### Changelog {#Changelog-v5.9.1}
 
@@ -230,7 +230,7 @@ Tyk is now fully compatible with [Valkey](https://valkey.io/), the open-source (
 | 5.9.0  | MDCB v2.8.2       | MDCB v2.8.2 |
 |        | Operator v1.2.0   | Operator v0.17 |
 |        | Sync v2.1.2       | Sync v2.1.0 |
-|        | Helm Chart v3.1.0 | Helm all versions |
+|        | Helm Chart v4.0   | Helm all versions |
 |        | EDP v1.14.0       | EDP all versions |
 |        | Pump v1.12.0      | Pump all versions |
 |        | TIB (if using standalone) v1.7.0 | TIB all versions |
@@ -262,7 +262,7 @@ If you are upgrading to 5.9.0, please follow the detailed [upgrade instructions]
     docker pull tykio/tyk-dashboard:v5.9.0
     ```
 - Helm charts
-  - [tyk-charts v3.0.0]({{< ref "developer-support/release-notes/helm-chart#300-release-notes" >}})
+  - [tyk-charts v4.0.0]({{< ref "developer-support/release-notes/helm-chart#400-release-notes" >}})
 
 #### Changelog {#Changelog-v5.9.0}
 


### PR DESCRIPTION
### **User description**
Correct Helm Chart version 3.1 -> 4.0 [Dash] (#6993)


___

### **PR Type**
Documentation


___

### **Description**
- Update Helm Chart to v4.0

- Fix links to Helm 4.0 notes

- Align 5.9.x tables consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  RN["Dashboard release notes (5.9.x)"] -- "Update version rows" --> Tables["Helm Chart v4.0"]
  RN -- "Fix references" --> Links["tyk-charts 4.0.0 release notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.md</strong><dd><code>Update Helm chart version and links to 4.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/developer-support/release-notes/dashboard.md

<ul><li>Replace "Helm Chart v3.1.0" with "Helm Chart v4.0" in <br>5.9.2/5.9.1/5.9.0 tables<br> <li> Update Helm charts links from 3.0.0 to 4.0.0 anchors</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/6994/files#diff-d33730d9b7b352e9a2ce2f71ef67fea53fb21ae531d4522472f799648ee5b22f">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

