### PR TITLE
Removed bug fix not included in 5.8.6

### DIFF
--- a/tyk-docs/content/developer-support/release-notes/dashboard.md
+++ b/tyk-docs/content/developer-support/release-notes/dashboard.md
@@ -506,14 +506,6 @@ Fixed an issue where updates to [global webhooks]({{< ref "api-management/gatewa
 </details>
 </li>
 
-<li>
-<details>
-<summary>Fixed GraphQL API creation via upstream introspection when OPA rules modify requests</summary>
-
-Fixed an issue where creating GraphQL APIs using upstream introspection in the Dashboard could fail with `HTTP 502 Bad Gateway` errors when OPA rules (typically using `patch_request`) modified the introspection request body. The problem occurred because the Dashboard did not recalculate the `Content-Length` header after OPA modifications, causing length mismatches that resulted in proxy errors. The Dashboard now correctly recalculates the content length for modified introspection requests, ensuring reliable GraphQL API creation regardless of OPA rule configurations.
-</details>
-</li>
-
 </ul>
 
 


### PR DESCRIPTION
### **User description**
Fix for HTTP 502 errors when creating GQL APIs with introspection was not included in the 5.8.6 release, contrary to the original release note. Taking this out to avoid confusion. Will be added back in when fix is released

## Contributor checklist

- [ ] Reviewed *PR Code suggestions* and updated accordingly
- [ ] **Tyklings:** Labled the PR with the relevant releases
- [ ] **Tyklings:** Added Jira DX PR ticket to the subject

---

## New Contributors 
- [ ] Start the PR branch from our latest `master`
- [ ] I have read the [repository contribution guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md)
- [ ] I have read the [repository technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md)

---


___

### **PR Type**
Documentation


___

### **Description**
- Remove unreleased fix from 5.8.6 notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  RN["Dashboard release notes"] -- "remove unreleased item" --> CleanRN["Accurate 5.8.6 notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.md</strong><dd><code>Remove unreleased item from dashboard release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/developer-support/release-notes/dashboard.md

<ul><li>Remove GraphQL introspection/OPA 502 fix entry<br> <li> Update 5.8.6 notes to reflect actual contents</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/7003/files#diff-d33730d9b7b352e9a2ce2f71ef67fea53fb21ae531d4522472f799648ee5b22f">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

