### PR TITLE
Merging to release-5.9: Removed bug fix not included in 5.8.6 (#7003)

### DIFF
--- a/tyk-docs/content/developer-support/release-notes/dashboard.md
+++ b/tyk-docs/content/developer-support/release-notes/dashboard.md
@@ -506,14 +506,6 @@ Fixed an issue where updates to [global webhooks]({{< ref "api-management/gatewa
 </details>
 </li>
 
-<li>
-<details>
-<summary>Fixed GraphQL API creation via upstream introspection when OPA rules modify requests</summary>
-
-Fixed an issue where creating GraphQL APIs using upstream introspection in the Dashboard could fail with `HTTP 502 Bad Gateway` errors when OPA rules (typically using `patch_request`) modified the introspection request body. The problem occurred because the Dashboard did not recalculate the `Content-Length` header after OPA modifications, causing length mismatches that resulted in proxy errors. The Dashboard now correctly recalculates the content length for modified introspection requests, ensuring reliable GraphQL API creation regardless of OPA rule configurations.
-</details>
-</li>
-
 </ul>
 
 


### PR DESCRIPTION
### **User description**
Removed bug fix not included in 5.8.6 (#7003)


___

### **PR Type**
Documentation


___

### **Description**
- Remove unreleased fix from notes

- Correct Dashboard 5.8.6 release details

- Prevent confusion about pending fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  RN["Dashboard release notes"] -- "remove unreleased fix" --> Clean["Accurate 5.8.6 notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.md</strong><dd><code>Remove unreleased GraphQL/OPA fix from notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/developer-support/release-notes/dashboard.md

<ul><li>Remove GraphQL introspection/OPA 502 fix entry<br> <li> Align 5.8.6 notes with actual release content</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/7004/files#diff-d33730d9b7b352e9a2ce2f71ef67fea53fb21ae531d4522472f799648ee5b22f">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

