### PR TITLE
Merging to release-5.9: Add a Note on the availability of `ctx.GetSession(r)` in the middleware chain (#6959)

### DIFF
--- a/tyk-docs/content/api-management/plugins/golang.md
+++ b/tyk-docs/content/api-management/plugins/golang.md
@@ -518,6 +518,13 @@ func MyPluginFunction(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+{{< note warning >}}
+**Note**  
+
+Tyk Gateway sets the session in the [Authentication layer]({{< ref "api-management/traffic-transformation#request-middleware-chain" >}}) of the middleware chain. Because of this, the session object does not exist until the middleware chain runs after the authentication middleware. If you call `ctx.GetSession` inside a custom auth plugin, it will always return an empty object.
+
+{{< /note >}}
+
 The invocation of `ctx.GetSession(r)` returns an SessionState object.
 The Go data structure can be found [here](https://github.com/TykTechnologies/tyk/blob/master/user/session.go#L106).
 


### PR DESCRIPTION
### **User description**
Add a Note on the availability of `ctx.GetSession(r)` in the middleware chain (#6959)


___

### **PR Type**
Documentation


___

### **Description**
- Warn about session availability timing

- Clarify ctx.GetSession behavior pre/post-auth

- Add note block to Go plugins docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PreAuth["Pre-auth/custom auth plugins"] -- "ctx.GetSession => empty" --> Auth["Authentication layer"]
  Auth -- "sets Session" --> PostAuth["Post-auth middleware"]
  PostAuth -- "ctx.GetSession => valid" --> Handlers["Downstream handlers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>golang.md</strong><dd><code>Document session availability for Go plugin ctx.GetSession</code></dd></summary>
<hr>

tyk-docs/content/api-management/plugins/golang.md

<ul><li>Add warning note shortcode about session timing.<br> <li> Explain session is set in authentication layer.<br> <li> State ctx.GetSession returns empty in custom auth plugins.<br> <li> Keep reference to SessionState structure.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/7008/files#diff-0c36572e2685d145460b6acda22c4249165e6b52ccb9736e3e4a28974d7fc6ee">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

