### PR TITLE
[TT-15980] Update documentation for master

### DIFF
--- a/tyk-docs/assets/others/gateway-swagger.yml
+++ b/tyk-docs/assets/others/gateway-swagger.yml
@@ -30,7 +30,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.8.3
+  version: 5.8.7
 servers:
 - url: https://{tenant}
   variables:

--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -293,6 +293,18 @@ A value of zero (default) means that no maximum is set and API requests will not
 See more information about setting request size limits here:
 https://tyk.io/docs/api-management/traffic-transformation/#request-size-limits
 
+### http_server_options.max_response_body_size
+ENV: <b>TYK_GW_HTTPSERVEROPTIONS_MAXRESPONSEBODYSIZE</b><br />
+Type: `int64`<br />
+
+MaxResponseBodySize configures an upper limit for the size of the response body (payload) in bytes.
+
+This limit is currently applied only if the Response Body Transform middleware is enabled.
+
+The Gateway will return `HTTP 500 Response Body Too Large` if the response payload exceeds MaxResponseBodySize+1 bytes.
+
+A value of zero (default) means that no maximum is set and response bodies will not be limited.
+
 ### version_header
 ENV: <b>TYK_GW_VERSIONHEADER</b><br />
 Type: `string`<br />

--- a/tyk-docs/content/shared/x-tyk-gateway.md
+++ b/tyk-docs/content/shared/x-tyk-gateway.md
@@ -204,7 +204,7 @@ Active enables the API so that Tyk will listen for and process requests made to 
 Tyk classic API definition: `active`.
 
 **Field: `internal` (`boolean`)**
-This field controls the exposure of the API on the Gateway. When set to `true`, the API will not be made available for external access and will not be included in API listings returned by the Gateway's management APIs; it will be accessible only via [internal looping]({{< ref "advanced-configuration/transform-traffic/looping" >}}) or as a [child API version]({{< ref "api-management/api-versioning#base-and-child-apis" >}}).
+Internal makes the API accessible only internally.
 
 Tyk classic API definition: `internal`.
 
@@ -592,7 +592,7 @@ Tyk classic API definition: `proxy.listen_path`.
 **Field: `strip` (`boolean`)**
 Strip removes the inbound listen path (as accessed by the client) when generating the outbound request for the upstream service.
 
-For example, consider the scenario where the Tyk base address is `http://acme.com/`, the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
+For example, consider the scenario where the Tyk base address is `http://acme.com/', the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
 
 - If the client application sends a request to `http://acme.com/example/get` then the request will be proxied to `http://httpbin.org/example/get`
 - If stripListenPath is set to `true`, the `example` listen path is removed and the request would be proxied to `http://httpbin.org/get`.
@@ -865,7 +865,7 @@ Tyk classic API definition: `dont_set_quota_on_create`.
 
 ### **Operations**
 
-Operations holds Operation definitions. The string key in this object is the `operationID`, which is a unique identifier for each API operation. 
+Operations holds Operation definitions.
 
 Type defined as object of `Operation` values, see [Operation](#operation) definition.
 
@@ -1693,6 +1693,46 @@ Value is the value of custom plugin config data.
 
 Tyk classic API definition: `config_data`.
 
+### **CustomPlugin**
+
+CustomPlugin configures custom plugin.
+
+**Field: `enabled` (`boolean`)**
+Enabled activates the custom plugin.
+
+
+Tyk classic API definition: `custom_middleware.pre[].disabled`, `custom_middleware.post_key_auth[].disabled`,.
+`custom_middleware.post[].disabled`, `custom_middleware.response[].disabled` (negated).
+
+**Field: `functionName` (`string`)**
+FunctionName is the name of authentication method.
+
+
+Tyk classic API definition: `custom_middleware.pre[].name`, `custom_middleware.post_key_auth[].name`,.
+`custom_middleware.post[].name`, `custom_middleware.response[].name`.
+
+**Field: `path` (`string`)**
+Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
+
+
+Tyk classic API definition: `custom_middleware.pre[].path`, `custom_middleware.post_key_auth[].path`,.
+`custom_middleware.post[].path`, `custom_middleware.response[].path`.
+
+**Field: `rawBodyOnly` (`boolean`)**
+RawBodyOnly if set to true, do not fill body in request or response object.
+
+
+Tyk classic API definition: `custom_middleware.pre[].raw_body_only`, `custom_middleware.post_key_auth[].raw_body_only`,.
+`custom_middleware.post[].raw_body_only`, `custom_middleware.response[].raw_body_only`.
+
+**Field: `requireSession` (`boolean`)**
+RequireSession if set to true passes down the session information for plugins after authentication.
+RequireSession is used only with JSVM custom middleware.
+
+
+Tyk classic API definition: `custom_middleware.pre[].require_session`, `custom_middleware.post_key_auth[].require_session`,.
+`custom_middleware.post[].require_session`, `custom_middleware.response[].require_session`.
+
 ### **Headers**
 
 Headers is an array of Header.
@@ -1787,46 +1827,6 @@ Name is the name of the header.
 
 **Field: `value` (`string`)**
 Value is the value of the header.
-
-### **CustomPlugin**
-
-CustomPlugin configures custom plugin.
-
-**Field: `enabled` (`boolean`)**
-Enabled activates the custom plugin.
-
-
-Tyk classic API definition: `custom_middleware.pre[].disabled`, `custom_middleware.post_key_auth[].disabled`,.
-`custom_middleware.post[].disabled`, `custom_middleware.response[].disabled` (negated).
-
-**Field: `functionName` (`string`)**
-FunctionName is the name of authentication method.
-
-
-Tyk classic API definition: `custom_middleware.pre[].name`, `custom_middleware.post_key_auth[].name`,.
-`custom_middleware.post[].name`, `custom_middleware.response[].name`.
-
-**Field: `path` (`string`)**
-Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
-
-
-Tyk classic API definition: `custom_middleware.pre[].path`, `custom_middleware.post_key_auth[].path`,.
-`custom_middleware.post[].path`, `custom_middleware.response[].path`.
-
-**Field: `rawBodyOnly` (`boolean`)**
-RawBodyOnly if set to true, do not fill body in request or response object.
-
-
-Tyk classic API definition: `custom_middleware.pre[].raw_body_only`, `custom_middleware.post_key_auth[].raw_body_only`,.
-`custom_middleware.post[].raw_body_only`, `custom_middleware.response[].raw_body_only`.
-
-**Field: `requireSession` (`boolean`)**
-RequireSession if set to true passes down the session information for plugins after authentication.
-RequireSession is used only with JSVM custom middleware.
-
-
-Tyk classic API definition: `custom_middleware.pre[].require_session`, `custom_middleware.post_key_auth[].require_session`,.
-`custom_middleware.post[].require_session`, `custom_middleware.response[].require_session`.
 
 ### **IDExtractorConfig**
 
@@ -2406,8 +2406,6 @@ Block request by allowance.
 **Field: `ignoreAuthentication` ([Allowance](#allowance))**
 IgnoreAuthentication ignores authentication on request by allowance.
 
-Tyk classic API definition: version_data.versions..extended_paths.ignored[].
-
 **Field: `internal` ([Internal](#internal))**
 Internal makes the endpoint only respond to internal requests.
 
@@ -2497,10 +2495,7 @@ Connect holds plugin configuration for CONNECT requests.
 
 ### **Paths**
 
-Paths is a mapping of API endpoints to Path plugin configurations. This field is part of the [Middleware](#middleware) structure.
-
-
-The string keys in this object represent URL path patterns (e.g. `/users`, `/users/{id}`, `/api/*`) that match API endpoints.
+Paths is a mapping of API endpoints to Path plugin configurations.
 
 Type defined as object of `Path` values, see [Path](#path) definition.
 
@@ -2516,8 +2511,6 @@ Block request by allowance.
 
 **Field: `ignoreAuthentication` ([Allowance](#allowance))**
 IgnoreAuthentication ignores authentication on request by allowance.
-
-Tyk Classic API definition: version_data.versions..extended_paths.ignored[].
 
 **Field: `transformRequestMethod` ([TransformRequestMethod](#transformrequestmethod))**
 TransformRequestMethod allows you to transform the method of a request.


### PR DESCRIPTION
### **User description**
Triggered by: sharadregoti

Included:

Tyk Gateway: true
Tyk Dashboard: false
Tyk MDCB false
Tyk Pump false

Intended for: master
Changes sourced from: release-5.8.7
Config info generator branch: main

Note: <none> (branch suffix: docs-2)

JIRA: https://tyktech.atlassian.net/browse/TT-15980


___

### **PR Type**
Documentation


___

### **Description**
- Bump Gateway API spec version to 5.8.7

- Add max response body size setting

- Clarify and simplify field descriptions

- Reorganize CustomPlugin docs section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ver["Gateway Swagger version 5.8.7"]
  conf["Add http_server_options.max_response_body_size"]
  simplify["Simplify field descriptions"]
  reorder["Move CustomPlugin section"]
  ver -- "reflect release" --> conf
  conf -- "document new config" --> simplify
  simplify -- "cleanup/remove duplicates" --> reorder
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-swagger.yml</strong><dd><code>Bump Gateway Swagger spec version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/others/gateway-swagger.yml

- Update API version from `5.8.3` to `5.8.7`.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/7095/files#diff-86641d5f43d842a51680c692c0ca3cd7d7e67776df7bf1409cf97f83a885ad99">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway-config.md</strong><dd><code>Document response body size limit option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/gateway-config.md

<ul><li>Add <code>http_server_options.max_response_body_size</code> section.<br> <li> Document env var, type, behavior, defaults, and errors.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/7095/files#diff-0a53845669feaeb0d62d4b17d24bfee5fc23482ec7562bd52e23db03373f14d0">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-gateway.md</strong><dd><code>Clarify fields and dedupe CustomPlugin docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/content/shared/x-tyk-gateway.md

<ul><li>Simplify <code>internal</code> field description.<br> <li> Fix examples/wording in <code>strip</code> and <code>Operations</code>.<br> <li> Move and deduplicate <code>CustomPlugin</code> section earlier.<br> <li> Remove duplicate classic mapping notes and clean paths text.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/7095/files#diff-c4c21855fe9a7bb5c25d2f53fd19b2c5afec3ef3f8ca54c0105d8bfe197ff31c">+44/-51</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

