### PR TITLE
[DX-2130] Fix Dashboard Swagger Policies API Example Request Body

### DIFF
--- a/tyk-docs/assets/others/dashboard-swagger.yml
+++ b/tyk-docs/assets/others/dashboard-swagger.yml
@@ -7090,7 +7090,7 @@ paths:
           application/json:
             example:
               access_rights:
-                Itachi API:
+                8ddd91f3cda9453442c477b06c4e2da4:
                   allowed_urls:
                   - methods:
                     - GET
@@ -7274,7 +7274,7 @@ paths:
             application/json:
               example:
                 access_rights:
-                  Itachi API:
+                  8ddd91f3cda9453442c477b06c4e2da4:
                     allowed_urls:
                     - methods:
                       - GET
@@ -7378,8 +7378,9 @@ paths:
         content:
           application/json:
             example:
+              _id: "363635373039383964393864643030303031646131376631"
               access_rights:
-                Itachi API:
+                8ddd91f3cda9453442c477b06c4e2da4:
                   allowed_urls:
                   - methods:
                     - GET

--- a/tyk-docs/assets/others/dashboard-swagger.yml
+++ b/tyk-docs/assets/others/dashboard-swagger.yml
@@ -7378,7 +7378,6 @@ paths:
         content:
           application/json:
             example:
-              _id: "363635373039383964393864643030303031646131376631"
               access_rights:
                 8ddd91f3cda9453442c477b06c4e2da4:
                   allowed_urls:


### PR DESCRIPTION
### **User description**

Jira: https://tyktech.atlassian.net/browse/DX-2130

## Contributor checklist

- [ ] Reviewed *PR Code suggestions* and updated accordingly
- [ ] **Tyklings:** Labled the PR with the relevant releases
- [ ] **Tyklings:** Added Jira DX PR ticket to the subject

---

## New Contributors 
- [ ] Start the PR branch from our latest `master`
- [ ] I have read the [repository contribution guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md)
- [ ] I have read the [repository technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md)

---


___

### **PR Type**
Documentation


___

### **Description**
- Correct policy examples use API IDs

- Replace name keys with UUID-like IDs

- Add example `_id` in update payload


___

### Diagram Walkthrough


```mermaid
flowchart LR
  swagger["Dashboard Swagger YAML"] -- "fix examples" --> examples["Policy access_rights keys use API IDs"]
  swagger -- "add field" --> updateExample["_id added in update example"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-swagger.yml</strong><dd><code>Align Swagger policy examples with API ID usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-docs/assets/others/dashboard-swagger.yml

<ul><li>Replace <code>Itachi API</code> key with API ID <code>8ddd91f3cda9453442c477b06c4e2da4</code> in <br>examples.<br> <li> Apply changes across POST, GET, and PUT policy examples.<br> <li> Add <code>_id</code> field to the PUT policy request example.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs-hugo/pull/7119/files#diff-97d3961fa92a4034f55bb3ca902c734bec0a55b4f9b4fc6466f6750da7ca5021">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

