### PR TITLE
SEO: fix canonical map script to skip unresolvable entries (v5.1)

### DIFF
--- a/scripts/build_canonical_map.py
+++ b/scripts/build_canonical_map.py
@@ -151,7 +151,8 @@ def main():
                 if used_fallback:
                     docs_json_resolved.append((map_key, final_url))
             else:
-                canonical_map[map_key] = OLD_BASE + map_key.rstrip("/")
+                # Unresolvable — skip; baseof.html formula fallback handles these.
+                # They are logged to canonical_map_errors.json for manual resolution.
                 errors.append((map_key, final_url, status))
 
     print(f"\nResolved {len(urls)} URLs in {time.time()-start:.1f}s")


### PR DESCRIPTION
## Summary

Follow-up to the canonical map fix. Updates `scripts/build_canonical_map.py` so that URLs which cannot be resolved to a final 200 OK destination are **not** written to `canonical_map.json`.

Previously, unresolvable entries fell back to the old formula URL and were silently written to the map — meaning canonical tags could point to 404 pages. Now they are only logged to `canonical_map_errors.json` for manual resolution. The `baseof.html` formula fallback handles these pages instead.

## Change

In `main()`, the `else` branch no longer writes a formula fallback URL to `canonical_map`. It only appends to `canonical_map_errors.json`.

## Test plan
- [ ] Script logic reviewed — unresolvable entries skipped from map
- [ ] No changes to `canonical_map.json` or `baseof.html` (data files unchanged)