### PR TITLE
fix: revert concepts.md link and add trailing slash to mutual-tls url (release-4.1)

### DIFF
--- a/tyk-docs/content/basic-config-and-security/security/mutual tls/concepts.md
+++ b/tyk-docs/content/basic-config-and-security/security/mutual tls/concepts.md
@@ -113,7 +113,7 @@ instead of getting TLS error, a client will receive 403 HTTP error.
 ## Authentication 
 Tyk can be configured to guess a user authentication key based on the provided client certificate. In other words, a user does not need to provide any key, except the certificate, and Tyk will be able to identify the user, apply policies, and do the monitoring - the same as with regular Keys.
 
-[Go here for more details](./client-mtls)
+[Go here for more details](../client-mtls)
 
 
 ### Using with Authorization 

--- a/tyk-docs/content/basic-config-and-security/security/mutual tls/mutual-tls.md
+++ b/tyk-docs/content/basic-config-and-security/security/mutual tls/mutual-tls.md
@@ -9,7 +9,7 @@ weight: 2
 aliases:
     - /basic-config-and-security/security/tls-and-ssl/mutual-tls/
     - /security/tls-and-ssl/mutual-tls/
-url: "/basic-config-and-security/security/mutual-tls"
+url: "/basic-config-and-security/security/mutual-tls/"
 ---
 
 The main requirement to make it work is that SSL traffic should be terminated by Tyk itself. If you are using a load balancer, you should configure it to work in TCP mode.


### PR DESCRIPTION
## Summary

Follow-up to #7157 (which was merged with an incorrect change).

## Changes

### concepts.md
Reverts the bad change from #7157. The original `../client-mtls` was correct — from the page URL `mutual-tls/concepts/`, `../` goes up to `mutual-tls/` and resolves to `mutual-tls/client-mtls/`.

```diff
-[Go here for more details](./client-mtls)
+[Go here for more details](../client-mtls)
```

### mutual-tls.md
The real source of the crawl 404 at `security/client-mtls`: the custom `url:` field had no trailing slash. A crawler reading the sitemap URL `/security/mutual-tls` (no slash) and following `./client-mtls` resolves to `security/client-mtls` instead of `security/mutual-tls/client-mtls`.

```diff
-url: "/basic-config-and-security/security/mutual-tls"
+url: "/basic-config-and-security/security/mutual-tls/"
```

## Test plan
- [ ] Confirm `../client-mtls` link on concepts page resolves to `mutual-tls/client-mtls/`
- [ ] Confirm `./client-mtls` link on mutual-tls page resolves to `mutual-tls/client-mtls/`