### PR TITLE
fix: add trailing slashes to tyk-cloud aliases to resolve 404s

### DIFF
--- a/tyk-docs/content/tyk-cloud/account-billing.md
+++ b/tyk-docs/content/tyk-cloud/account-billing.md
@@ -3,19 +3,19 @@ title: "Manage Accounts and Billing in Tyk Cloud"
 tags: ["Accounts", "Billing", "Tyk Cloud", "Control Plane"]
 description: "Learn how to manage your Tyk Cloud account, including payment plans, billing methods, and account retirement."
 aliases:
-  - /tyk-cloud/account-billing/add-payment-method
-  - /tyk-cloud/account-billing/managing-billing-admins
-  - /tyk-cloud/account-billing/plans
-  - /tyk-cloud/account-billing/retirement
-  - /tyk-cloud/account-billing/upgrade-free-trial
-  - /tyk-cloud/account-&-billing/plans
-  - /tyk-cloud/create-account
-  - /tyk-cloud/account--billing/plans
-  - /tyk-cloud/account--billing/retirement
-  - /tyk-cloud/account-and-billing/add-payment-method
-  - /tyk-cloud/account-and-billing/our-plans
-  - /tyk-cloud/account-and-billing/retirement
-  - /tyk-cloud/account-and-billing/upgrade-free-trial
+  - /tyk-cloud/account-billing/add-payment-method/
+  - /tyk-cloud/account-billing/managing-billing-admins/
+  - /tyk-cloud/account-billing/plans/
+  - /tyk-cloud/account-billing/retirement/
+  - /tyk-cloud/account-billing/upgrade-free-trial/
+  - /tyk-cloud/account-&-billing/plans/
+  - /tyk-cloud/create-account/
+  - /tyk-cloud/account--billing/plans/
+  - /tyk-cloud/account--billing/retirement/
+  - /tyk-cloud/account-and-billing/add-payment-method/
+  - /tyk-cloud/account-and-billing/our-plans/
+  - /tyk-cloud/account-and-billing/retirement/
+  - /tyk-cloud/account-and-billing/upgrade-free-trial/
 ---
 
 ## Introduction

--- a/tyk-docs/content/tyk-cloud/environments-deployments/_index.md
+++ b/tyk-docs/content/tyk-cloud/environments-deployments/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Environments & Deployments"
+description: "Manage your Tyk Cloud environments and deployments"
+aliases:
+  - /tyk-cloud/environments-&-deployments/
+  - /tyk-cloud/environments--deployments/
+---

--- a/tyk-docs/content/tyk-cloud/environments-deployments/hybrid-gateways.md
+++ b/tyk-docs/content/tyk-cloud/environments-deployments/hybrid-gateways.md
@@ -3,10 +3,10 @@ title: "Deploy Hybrid Gateways with Tyk Cloud"
 tags: ["Hybrid Gateways", "Tyk Cloud", "Control Plane", "Deployment"]
 description: "Learn how to deploy and manage hybrid gateways in Tyk Cloud, connecting your self-managed data planes to the Tyk Cloud control plane."
 aliases:
-  - /tyk-cloud/environments--deployments/hybrid-gateways
-  - /tyk-cloud/environments-&-deployments/hybrid-gateways
-  - /tyk-cloud/environments-deployments/hybrid-gateways-helm
-  - /get-started/with-tyk-hybrid
+  - /tyk-cloud/environments--deployments/hybrid-gateways/
+  - /tyk-cloud/environments-&-deployments/hybrid-gateways/
+  - /tyk-cloud/environments-deployments/hybrid-gateways-helm/
+  - /get-started/with-tyk-hybrid/
 ---
 
 ## Introduction

--- a/tyk-docs/content/tyk-cloud/environments-deployments/managing-control-planes.md
+++ b/tyk-docs/content/tyk-cloud/environments-deployments/managing-control-planes.md
@@ -3,8 +3,10 @@ title: "Managing Control Planes in Tyk Cloud"
 tags: ["Control Planes", "Tyk Cloud", "Control Plane", "Cloud Data Plane", "Auto Upgrade"]
 description: "Learn how to manage Control Planes in Tyk Cloud"
 aliases:
-  - /tyk-cloud/environments-&-deployments/managing-control-planes
-  - /tyk-cloud/environments-deployments/managing-control-planes
+  - /tyk-cloud/environments-&-deployments/managing-control-planes/
+  - /tyk-cloud/environments-&-deployments/managing-apis/
+  - /tyk-cloud/environments--deployments/managing-apis/
+  - /tyk-cloud/environments-deployments/managing-control-planes/
 ---
 
 ## Introduction

--- a/tyk-docs/content/tyk-cloud/environments-deployments/managing-environments.md
+++ b/tyk-docs/content/tyk-cloud/environments-deployments/managing-environments.md
@@ -3,10 +3,10 @@ title: "Managing Environments in Tyk Cloud"
 tags: ["Environments", "Tyk Cloud", "Control Plane", "Cloud Data Plane"]
 description: "Learn how to manage Environments in Tyk Cloud"
 aliases:
-  - /tyk-cloud/environments-&-deployments/managing-environments
-  - /tyk-cloud/environments-deployments/managing-environments
-  - /tyk-cloud/getting-started-tyk-cloud/setup-environment
-  - /tyk-cloud/create-environment
+  - /tyk-cloud/environments-&-deployments/managing-environments/
+  - /tyk-cloud/environments-deployments/managing-environments/
+  - /tyk-cloud/getting-started-tyk-cloud/setup-environment/
+  - /tyk-cloud/create-environment/
 ---
 
 ## Introduction

--- a/tyk-docs/content/tyk-cloud/environments-deployments/managing-gateways.md
+++ b/tyk-docs/content/tyk-cloud/environments-deployments/managing-gateways.md
@@ -3,7 +3,8 @@ title: "Managing Data Planes in Tyk Cloud"
 tags: ["Data Planes", "Tyk Cloud", "Control Plane", "Cloud Data Plane"]
 description: "Learn how to manage Data Planes in Tyk Cloud"
 aliases:
-
+  - /tyk-cloud/environments-&-deployments/managing-gateways/
+  - /tyk-cloud/environments--deployments/managing-gateways/
 ---
 
 ## Introduction

--- a/tyk-docs/content/tyk-cloud/environments-deployments/managing-organisations.md
+++ b/tyk-docs/content/tyk-cloud/environments-deployments/managing-organisations.md
@@ -3,9 +3,9 @@ title: "Managing Organizations in Tyk Cloud"
 tags: ["Organizations", "Tyk Cloud", "Control Plane", "Cloud Data Plane"]
 description: "Learn how to manage organizations in Tyk Cloud, including organization, teams, deployments, and environments."
 aliases:
-  - /tyk-cloud/environments-&-deployments/managing-organisations
-  - /tyk-cloud/environments-deployments/managing-organisations
-  - /tyk-cloud/setup-org
+  - /tyk-cloud/environments-&-deployments/managing-organisations/
+  - /tyk-cloud/environments-deployments/managing-organisations/
+  - /tyk-cloud/setup-org/
 ---
 
 ## Overview

--- a/tyk-docs/content/tyk-cloud/environments-deployments/monitoring-how-it-works.md
+++ b/tyk-docs/content/tyk-cloud/environments-deployments/monitoring-how-it-works.md
@@ -3,10 +3,12 @@ title: "How monitoring works in Tyk Cloud"
 tags: ["Monitoring", "Tyk Cloud", "Control Plane", "Data Plane"]
 description: "Learn how Tyk Cloud monitors throughput and storage metrics for your deployments."
 aliases:
-  - /tyk-cloud/environments-&-deployments/monitoring
-  - /tyk-cloud/environments-&-deployments/monitoring-usage
-  - /tyk-cloud/environments-deployments/monitoring
-  - /tyk-cloud/environments-deployments/monitoring-usage
+  - /tyk-cloud/environments-&-deployments/monitoring/
+  - /tyk-cloud/environments-&-deployments/monitoring-usage/
+  - /tyk-cloud/environments-&-deployments/monitoring-how-it-works/
+  - /tyk-cloud/environments--deployments/monitoring-how-it-works/
+  - /tyk-cloud/environments-deployments/monitoring/
+  - /tyk-cloud/environments-deployments/monitoring-usage/
 ---
 
 ### Tyk Cloud Monitor Metrics

--- a/tyk-docs/content/tyk-cloud/teams-users.md
+++ b/tyk-docs/content/tyk-cloud/teams-users.md
@@ -3,15 +3,15 @@ title: "Manage Teams and Users in Tyk Cloud"
 tags: ["Teams", "Users", "Tyk Cloud", "User Management", "User Roles"]
 description: "Learn how to manage teams and users in Tyk Cloud, including user roles, team management, and single sign-on (SSO) configuration."
 aliases:
-  - /tyk-cloud/setup-team
-  - /tyk-cloud/teams-&-users/managing-teams
-  - /tyk-cloud/teams-&-users/managing-users
-  - /tyk-cloud/teams-&-users/user-roles
-  - /tyk-cloud/teams-users/managing-teams
-  - /tyk-cloud/teams-users/managing-users
-  - /tyk-cloud/teams-users/user-roles
-  - /tyk-cloud/teams-&-users
-  - /tyk-cloud/getting-started-tyk-cloud/setup-team
+  - /tyk-cloud/setup-team/
+  - /tyk-cloud/teams-&-users/managing-teams/
+  - /tyk-cloud/teams-&-users/managing-users/
+  - /tyk-cloud/teams-&-users/user-roles/
+  - /tyk-cloud/teams-users/managing-teams/
+  - /tyk-cloud/teams-users/managing-users/
+  - /tyk-cloud/teams-users/user-roles/
+  - /tyk-cloud/teams-&-users/
+  - /tyk-cloud/getting-started-tyk-cloud/setup-team/
 ---
 
 ## Introduction

--- a/tyk-docs/content/tyk-cloud/teams-users/single-sign-on.md
+++ b/tyk-docs/content/tyk-cloud/teams-users/single-sign-on.md
@@ -2,6 +2,9 @@
 title: "Configure Single Sign-On (SSO) in Tyk Cloud"
 tags: ["Single Sign-On", "SSO", "Tyk Cloud", "Control Plane", "Configuration"]
 description: "Learn how to set up and manage Single Sign-On (SSO) in Tyk Cloud Control Plane deployments."
+aliases:
+  - /tyk-cloud/teams-&-users/single-sign-on/
+  - /tyk-cloud/teams--users/single-sign-on/
 ---
 
 ## What is SSO?

--- a/tyk-docs/content/tyk-cloud/telemetry.md
+++ b/tyk-docs/content/tyk-cloud/telemetry.md
@@ -3,7 +3,7 @@ title: "Configure Telemetry in Tyk Cloud"
 tags: ["Telemetry", "Tyk Cloud", "Control Plane", "Data Plane", "Distributed Tracing"]
 description: "Learn how to set up and manage telemetry in Tyk Cloud for distributed tracing of your APIs."
 aliases:
-  - /tyk-cloud/telemetry/enable-telemetry
+  - /tyk-cloud/telemetry/enable-telemetry/
 ---
 
 ## Introduction

--- a/tyk-docs/content/tyk-cloud/troubleshooting-support.md
+++ b/tyk-docs/content/tyk-cloud/troubleshooting-support.md
@@ -3,14 +3,14 @@ title: "Troubleshooting Tyk Cloud"
 tags: ["Troubleshooting", "Tyk Cloud", "FAQs", "Support"]
 description: "Learn how to troubleshoot common issues in Tyk Cloud, including FAQs and support resources."
 aliases:
-  - /tyk-cloud/troubleshooting-&-support/tyk-cloud-mdcb-supported-versions
-  - /tyk-cloud/troubleshooting-&-support
-  - /tyk-cloud/troubleshooting-&-support/faqs
-  - /tyk-cloud/troubleshooting-&-support/glossary
-  - /tyk-cloud/troubleshooting-support
-  - /tyk-cloud/troubleshooting-support/faqs
-  - /tyk-cloud/troubleshooting-support/glossary
-  - /tyk-cloud/troubleshooting-support/tyk-cloud-mdcb-supported-versions
+  - /tyk-cloud/troubleshooting-&-support/tyk-cloud-mdcb-supported-versions/
+  - /tyk-cloud/troubleshooting-&-support/
+  - /tyk-cloud/troubleshooting-&-support/faqs/
+  - /tyk-cloud/troubleshooting-&-support/glossary/
+  - /tyk-cloud/troubleshooting-support/
+  - /tyk-cloud/troubleshooting-support/faqs/
+  - /tyk-cloud/troubleshooting-support/glossary/
+  - /tyk-cloud/troubleshooting-support/tyk-cloud-mdcb-supported-versions/
   - /troubleshooting/tyk-multi-cloud/token-information-doesnt-appear-dashboard-tyk-multi-cloud-users
   - /troubleshooting/tyk-cloud-classic/301-moved-permanently
   - /troubleshooting/tyk-cloud-classic/413-request-entity-large

--- a/tyk-docs/content/tyk-cloud/using-plugins.md
+++ b/tyk-docs/content/tyk-cloud/using-plugins.md
@@ -3,16 +3,16 @@ title: "Configure Custom Plugins in Tyk Cloud"
 tags: ["Plugins", "Tyk Cloud", "Control Plane", "Data Plane"]
 description: "Learn how to set up and manage custom plugins in Tyk Cloud Control Plane deployments."
 aliases:
-  - /tyk-cloud/configuration-options/using-plugins/api-test
-  - /tyk-cloud/configuration-options/using-plugins/python-code-bundle
-  - /tyk-cloud/configuration-options/using-plugins/python-custom-auth
-  - /tyk-cloud/configuration-options/using-plugins/setup-control-plane
-  - /tyk-cloud/configuration-options/using-plugins/uploading-bundle
-  - /using-plugins/python-custom-auth-plugin
-  - /python-custom-auth-plugin/api-middleware-test
-  - /python-custom-auth-plugin/python-code-bundle
-  - /python-custom-auth-plugin/setup-control-plane
-  - /python-custom-auth-plugin/uploading-bundle
+  - /tyk-cloud/configuration-options/using-plugins/api-test/
+  - /tyk-cloud/configuration-options/using-plugins/python-code-bundle/
+  - /tyk-cloud/configuration-options/using-plugins/python-custom-auth/
+  - /tyk-cloud/configuration-options/using-plugins/setup-control-plane/
+  - /tyk-cloud/configuration-options/using-plugins/uploading-bundle/
+  - /using-plugins/python-custom-auth-plugin/
+  - /python-custom-auth-plugin/api-middleware-test/
+  - /python-custom-auth-plugin/python-code-bundle/
+  - /python-custom-auth-plugin/setup-control-plane/
+  - /python-custom-auth-plugin/uploading-bundle/
 ---
 
 ## Introduction


### PR DESCRIPTION
Adds trailing slashes to all Hugo alias entries in tyk-cloud content that were missing them. Without trailing slashes, Hugo creates alias redirect pages at paths that 404 when accessed without a trailing slash.