### PR TITLE
SEO: exclude noindex pages from sitemap (5.7)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/sitemap.xml
+++ b/tyk-docs/themes/tykio/layouts/sitemap.xml
@@ -1,5 +1,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range .Site.RegularPages }}
+  {{ if ne .Params.robots "noindex" }}
   <url>
     <loc>https:{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -11,5 +12,6 @@
     </image:image>
     {{ end }}
   </url>
+  {{ end }}
   {{ end }}
 </urlset>


### PR DESCRIPTION
## Problem

41 pages on the 5.7 docs are marked `robots: "noindex"` (Classic Developer Portal, portal API/troubleshooting/FAQ pages, etc.) yet are still listed in `https://tyk.io/docs/5.7/sitemap.xml`. This sends crawlers conflicting signals — the sitemap says "index me", the page says "don't" — which is an SEO antipattern flagged in the audit.

Root cause: the sitemap template (`themes/tykio/layouts/sitemap.xml`) ranges over **all** `.Site.RegularPages` and never checks the page's robots setting.

## Fix

Skip pages whose `.Params.robots` is `"noindex"` — the exact same condition `baseof.html` uses to emit the `<meta name="robots" content="noindex">` tag, so the sitemap and the page-level directive now stay consistent.

```diff
   {{ range .Site.RegularPages }}
+  {{ if ne .Params.robots "noindex" }}
   <url>
     ...
   </url>
+  {{ end }}
   {{ end }}
```

## Verification

Local `hugo` build of the 5.7 site:
- All **41** `noindex` pages are dropped from the generated `sitemap.xml`.
- Indexable pages are unaffected (e.g. the legitimate `/api-management/graphql/` remains; the `noindex` `tyk-portal-classic/graphql` is removed).

## Note

The same template bug exists on `master` and the other release branches. Happy to open matching PRs if you'd like this propagated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)