### PR TITLE
fix(docs): resolve leftover git merge-conflict markers in 5.3 mock response pages [SEO audit]

### DIFF
--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-middleware.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-middleware.md
@@ -7,11 +7,7 @@ aliases:
   - /getting-started/using-oas-definitions/mock-response/
 ---
 
-<<<<<<< HEAD
-A mock response is a simulated API response that can be returned by the API gateway without actually sending the request to the backend API service. Mock responses are an integral feature for API development, enabling developers to emulate API behaviour without the need for upstream execution. 
-=======
 A mock response is a simulated API response that can be returned by the API gateway without actually sending the request to the backend API service. Mock responses are an integral feature for API development, enabling developers to emulate API behavior without the need for upstream execution.
->>>>>>> b770f96a1... [TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)
 
 Tyk's mock response middleware offers this functionality by allowing the configuration of custom responses for designated endpoints. This capability is crucial for facilitating front-end development, conducting thorough testing, and managing unexpected scenarios or failures.
 

--- a/tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-tyk-classic.md
+++ b/tyk-docs/content/product-stack/tyk-gateway/middleware/mock-response-tyk-classic.md
@@ -13,7 +13,6 @@ The middleware is configured in the Tyk Classic API Definition. You can do this 
 
 If you're using the newer Tyk OAS APIs, then check out the [Tyk OAS]({{< ref "product-stack/tyk-gateway/middleware/mock-response-tyk-oas" >}}) page.
 
-<<<<<<< HEAD
 ### Endpoint parsing
 
 When you define an endpoint in your API Definition (for example `GET /anything`), Tyk will also match for `GET /anything/somepath` and any other sub-path based on the `GET /anything` route.
@@ -24,10 +23,7 @@ If you add a `$` at the end of the `listen_path` (in our example `GET /anything$
 
 Thus, if you enable the middleware for `GET /anything$` then `GET /anything/somepath` will be proxied to the upstream and will not trigger the mock response.
 
-## Configuring the middleware in the Tyk Classic API Definition
-=======
 ## Configuring the middleware in the Tyk Classic API Definition {#tyk-classic}
->>>>>>> b770f96a1... [TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)
 
 If you're using Tyk Operator then check out the [configuring the middleware in Tyk Operator](#tyk-operator) section below.
 
@@ -117,8 +113,6 @@ Use the *save* or *create* buttons to save the changes and activate the middlewa
 
 For the mock response to be enabled, the endpoint must also be in a list. We recommend adding the path to an [allow list]({{< ref "advanced-configuration/transform-traffic/endpoint-designer#allowlist" >}}). If this isn't done, then the mock will not be saved when you save your API in the designer.
 {{< /note >}}
-<<<<<<< HEAD
-=======
 
 ## Configuring the middleware in Tyk Operator {#tyk-operator}
 
@@ -168,4 +162,3 @@ spec:
                     headers: {}
                 path: /foo
 ```
->>>>>>> b770f96a1... [TT-12871, TT-12550, TT-12865, DX-1678] Import draft of url matching (#5311)


### PR DESCRIPTION
## What
Removes unresolved git merge-conflict markers (`<<<<<<< HEAD` / `=======` / `>>>>>>>`) that shipped into two 5.3 pages from a bad merge of #5311:
- `product-stack/tyk-gateway/middleware/mock-response-middleware.md`
- `product-stack/tyk-gateway/middleware/mock-response-tyk-classic.md`

These rendered as broken content (and extra H1s) on `tyk.io/docs/5.3/`.

## Resolution
Mirrors how 5.4 merged cleanly, keeping all real content:
- **middleware**: keep the `behavior` wording.
- **tyk-classic**: keep the *Endpoint parsing* section **and** the `{#tyk-classic}` anchor, **and** the *Configuring the middleware in Tyk Operator* `{#tyk-operator}` section — so the in-page `#tyk-operator` / `#tyk-classic` links resolve. Verified no dangling anchors remain.

## Why
Flagged by the docs SEO audit under **Multiple H1 tags**. Diff is marker-removal only.

> **Jira:** _not created this session per request — to be added before merge._