### PR TITLE
fix(docs): resolve Multiple H1 tags on 5.7 tyk-components [SEO audit]

### DIFF
--- a/tyk-docs/content/tyk-components.md
+++ b/tyk-docs/content/tyk-components.md
@@ -7,7 +7,7 @@ weight: 5
 menu: "main"
 ---
 
-# Understanding Tyk’s API Management Components
+## Understanding Tyk’s API Management Components
 
 Tyk offers a full ecosystem of API management tools, supporting every stage of the API lifecycle—from development and deployment to monitoring and scaling. With Tyk’s components, teams can seamlessly integrate, secure, and scale APIs across different environments, facilitating robust and reliable API operations.
 
@@ -191,7 +191,7 @@ Tyk’s components create a unified API management ecosystem, covering all aspec
 - **Unified Access**: UDG and Tyk Streams unify API Management by enabling seamless, multi-protocol data integration and delivery.
 - **Kubernetes Deployment**: Tyk Helm Charts simplifies deployment of Tyk on Kubernetes.
 
-# Conclusion
+## Conclusion
 
 Now that you’ve been introduced to the Tyk suite, you have a strong foundation in understanding how each component fits into a complete API management ecosystem. Whether you’re ready to start deploying APIs, securing them, or scaling across multiple environments, Tyk provides the tools and flexibility to bring your API projects to life.
 


### PR DESCRIPTION
## What
Demotes stray body `#` headings (*Understanding…*, *Conclusion*) to `##` in `tyk-components.md` so the page has a single `<h1>` (the frontmatter title).

## Why
Flagged by the docs SEO audit under **Multiple H1 tags**. Heading-level change only — 2 lines.

> **Jira:** _not created this session per request — to be added before merge._