### PR TITLE
fix(docs): resolve Title tag missing or empty on 4.1 (3 pages) [SEO audit]

### DIFF
--- a/tyk-docs/content/tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc.md
+++ b/tyk-docs/content/tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc.md
@@ -1,5 +1,6 @@
 ---
 date: 2022-06-28T12:16:37.959Z
+title: "Tyk OAS API Object"
 linktitle: TYK OAS API Object
 menu:
   main:

--- a/tyk-docs/content/tyk-stack/tyk-pump/tyk-dash-analytics.md
+++ b/tyk-docs/content/tyk-stack/tyk-pump/tyk-dash-analytics.md
@@ -1,11 +1,10 @@
-<!-- ---
+---
 date: 2017-03-24T15:49:11Z
 title: Tyk Dashboard Analytics
 weight: 1
 menu: 
     main:
         parent: Tyk Pump
-url: "/tyk-dashboard-analytics"
 ---
 
 The Tyk Dashboard has a full set of analytics functions and graphs that you can use to segment and view your API traffic and activity. The Dashboard offers a great way for you to debug your APIs and quickly pin down where errors might be cropping up and for what clients.
@@ -15,4 +14,4 @@ Tyk has two types of analytics:
 1. Per request. Per request statistics contains information about each request, like path or status. It is also possible to enable "detailed request logging" where it will log base64 encoded data.
 2. Aggregate. Aggregate statistics, aggregated by hour are available for the following keys: `APIID`, `ResponseCode`, `APIVersion`, `APIKey`, `OauthID`, `Geo`, `Tags` and `TrackPath`.
 
-When you make a request to the Tyk Gateway, it creates analytics records and stores them in a temporary Redis list, which is synced (and then flushed) every 10 seconds by the Tyk Pump. The Pump processes all synced analytic records, and forwards them to configured pumps. By default, to make the Tyk Dashboard work, there are 2 pumps: `mongo` (per request) and `mongo_aggregate` (for aggregate).  -->
+When you make a request to the Tyk Gateway, it creates analytics records and stores them in a temporary Redis list, which is synced (and then flushed) every 10 seconds by the Tyk Pump. The Pump processes all synced analytic records, and forwards them to configured pumps. By default, to make the Tyk Dashboard work, there are 2 pumps: `mongo` (per request) and `mongo_aggregate` (for aggregate).


### PR DESCRIPTION
## What
Fixes empty `<title>` on three 4.1 pages, each a different root cause:
1. **`tyk-stack/tyk-pump/tyk-dash-analytics.md`** — the whole frontmatter *and* the first two intro paragraphs were wrapped in an HTML comment (`<!-- … -->`), so the `title` never applied and the intro was hidden. Un-commented; **dropped the `url: /tyk-dashboard-analytics` override** so the page keeps its current URL.
2. **`tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc.md`** — had `linktitle` but no `title`. Added `title: "Tyk OAS API Object"`.
3. **`getting-started/key-concepts/rbac.md`** — empty 0-byte stub that shadowed the alias `getting-started/key-concepts/rbac` declared on `tyk-dashboard-rbac.md`. **Deleted** so the existing redirect to `/tyk-dashboard/rbac` fires (matches release-4.3, which already has no stub).

## Why
Flagged by the docs SEO audit under **Title tag missing or empty**.

> **Jira:** _not created this session per request — to be added before merge._