### PR TITLE
fix(docs): resolve Title tag missing or empty on 4.3 (2 pages) [SEO audit]

### DIFF
--- a/tyk-docs/content/tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc.md
+++ b/tyk-docs/content/tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc.md
@@ -1,5 +1,6 @@
 ---
 date: 2022-06-28T12:16:37.959Z
+title: "Tyk OAS API Object"
 linktitle: TYK OAS API Object
 menu:
   main:

--- a/tyk-docs/content/tyk-stack/tyk-pump/tyk-dash-analytics.md
+++ b/tyk-docs/content/tyk-stack/tyk-pump/tyk-dash-analytics.md
@@ -1,4 +1,4 @@
-<!-- ---
+---
 date: 2017-03-24T15:49:11Z
 title: Tyk Dashboard Analytics
 weight: 1
@@ -14,4 +14,4 @@ Tyk has two types of analytics:
 1. Per request. Per request statistics contains information about each request, like path or status. It is also possible to enable "detailed request logging" where it will log base64 encoded data.
 2. Aggregate. Aggregate statistics, aggregated by hour are available for the following keys: `APIID`, `ResponseCode`, `APIVersion`, `APIKey`, `OauthID`, `Geo`, `Tags` and `TrackPath`.
 
-When you make a request to the Tyk Gateway, it creates analytics records and stores them in a temporary Redis list, which is synced (and then flushed) every 10 seconds by the Tyk Pump. The Pump processes all synced analytic records, and forwards them to configured pumps. By default, to make the Tyk Dashboard work, there are 2 pumps: `mongo` (per request) and `mongo_aggregate` (for aggregate).  -->
+When you make a request to the Tyk Gateway, it creates analytics records and stores them in a temporary Redis list, which is synced (and then flushed) every 10 seconds by the Tyk Pump. The Pump processes all synced analytic records, and forwards them to configured pumps. By default, to make the Tyk Dashboard work, there are 2 pumps: `mongo` (per request) and `mongo_aggregate` (for aggregate).


### PR DESCRIPTION
## What
Two of the three root causes from the 4.1 fix (TykTechnologies/tyk-docs-hugo#7178) — 4.3 has no empty `rbac` stub:
1. **`tyk-stack/tyk-pump/tyk-dash-analytics.md`** — frontmatter + intro were inside an HTML comment (`<!-- … -->`); un-commented and dropped the `url` override to keep the URL stable.
2. **`tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc.md`** — added `title: "Tyk OAS API Object"` (had `linktitle` only).

## Why
Flagged by the docs SEO audit under **Title tag missing or empty**.

> **Jira:** _not created this session per request — to be added before merge._