### PR TITLE
fix(docs): resolve Title tag missing or empty on 5.1 (2 pages) [SEO audit]

### DIFF
--- a/tyk-docs/content/api-management/manage-apis/deploy-apis/deploy-apis-overview.md
+++ b/tyk-docs/content/api-management/manage-apis/deploy-apis/deploy-apis-overview.md
@@ -1,3 +1,7 @@
+---
+title: "Deploy APIs Overview"
+---
+
 ## Tyk API Deployment Options
 
 At Tyk, we provide various deployment options to suit different stages of your API development lifecycle. Each option offers unique features and capabilities tailored to your specific needs.

--- a/tyk-docs/content/product-stack/tyk-dashboard/advanced-configurations/open-policy-agent/opa-permissions-example.md
+++ b/tyk-docs/content/product-stack/tyk-dashboard/advanced-configurations/open-policy-agent/opa-permissions-example.md
@@ -1,4 +1,6 @@
-
+---
+title: "OPA Permissions Example"
+---
 
 ## Introduction
 


### PR DESCRIPTION
## What
Both pages had **no frontmatter at all**, so `<title>` rendered empty. Added a `title`:
1. **`…/open-policy-agent/opa-permissions-example.md`** → `title: "OPA Permissions Example"`
2. **`…/manage-apis/deploy-apis/deploy-apis-overview.md`** → `title: "Deploy APIs Overview"`

## Why
Flagged by the docs SEO audit under **Title tag missing or empty**.

> **Jira:** _not created this session per request — to be added before merge._