### PR TITLE
docs: fix broken /docs/js/cookie.js reference to restore cookie banner (fixes 404)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/cookie-notice.html
+++ b/tyk-docs/themes/tykio/layouts/partials/cookie-notice.html
@@ -17,4 +17,4 @@
 	   </div>
 	</div>
 </div>
-<script src="/docs/js/cookie.js"></script>
+<script src="{{ "js/cookie.js" | relURL }}"></script>


### PR DESCRIPTION
## Problem (docs audit — Medium)

`https://tyk.io/docs/js/cookie.js` returns **HTTP 404**, breaking JavaScript on every page of the v3.1 docs. This is part of the audit's *"Page has broken JavaScript"* finding (1,718 pages) and its companion *"JavaScript broken"* row.

## Root cause

The `cookie-notice.html` partial hardcodes an **absolute** path:

```html
<script src="/docs/js/cookie.js"></script>
```

Each docs version publishes its assets under its own baseURL (`//tyk.io/docs/3.1/`), so the file actually lives at `/docs/3.1/js/cookie.js`. The hardcoded root path `/docs/js/cookie.js` is not published by any version → 404 on every page.

## Fix

Use Hugo's `relURL` helper — matching **every other asset in this theme** (e.g. `css/cookie.css`, `js/modernizr.min.js`):

```html
<script src="{{ "js/cookie.js" | relURL }}"></script>
```

Resolves to `/docs/3.1/js/cookie.js`, where the file is published. This is proven correct by analogy: `css/cookie.css` in the same theme uses the identical `relURL` syntax and is not flagged as broken.

## Effect

- Eliminates the 404 across all v3.1 pages.
- Restores the cookie banner + Accept/Reject buttons. Today the banner never appears (the JS 404s), so the consent gate on GTM/HubSpot tracking is dead — this re-enables genuine opt-out.

## Note

Requires a **Netlify rebuild/redeploy** of the v3.1 subsite for the fix to reach the live site and clear the audit.
