### PR TITLE
docs: fix WebPage structured-data schema.org validation error

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/site_schema.html
+++ b/tyk-docs/themes/tykio/layouts/partials/site_schema.html
@@ -1,19 +1,24 @@
 <script type="application/ld+json">
 {
-    "@context" : "http://schema.org",
+    "@context": "https://schema.org",
     "@type": "WebPage",
     "mainEntityOfPage": {
-         "@type": "WebPage",
-         "@id": "{{ .Site.BaseURL }}"
+        "@type": "WebPage",
+        "@id": "{{ .Site.BaseURL | replaceRE "^//" "https://" }}"
     },
-    "name" : "{{ .Title }}",
-    "headline" : "{{ .Title }}",
-    "description" : "{{ if .Description }}{{ .Description }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ end }}{{ end }}",
-    "inLanguage" : "en-US",
-    "author" : "tyk ",
-    "copyrightHolder" : "Tyk",
-    "url" : "{{ .Permalink }}",
-    "keywords" : [{{ if isset .Params "tags" }}{{ range $index, $tag := .Params.tags }}"{{ $tag }}"{{ if ne $index (sub (len $.Params.tags) 1) }},{{ end }}{{ end }}{{ end }}]
-
+    "name": "{{ .Title }}",
+    "headline": "{{ .Title }}",
+    "description": "{{ if .Description }}{{ .Description }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ end }}{{ end }}",
+    "inLanguage": "en-US",
+    "author": {
+        "@type": "Organization",
+        "name": "Tyk"
+    },
+    "copyrightHolder": {
+        "@type": "Organization",
+        "name": "Tyk"
+    },
+    "url": "{{ .Permalink | replaceRE "^//" "https://" }}",
+    "keywords": [{{ if isset .Params "tags" }}{{ range $index, $tag := .Params.tags }}"{{ $tag }}"{{ if ne $index (sub (len $.Params.tags) 1) }},{{ end }}{{ end }}{{ end }}]
 }
 </script>


### PR DESCRIPTION
## Problem (docs audit — Medium)

The `WebPage` structured data on all **v5.3** docs pages is flagged *"Schema.org validation error"* — part of the audit's 4,680-page finding across v5.2–v5.6.

## Root cause

`themes/tykio/layouts/partials/site_schema.html` emits a JSON-LD `WebPage` block with:

- `author` and `copyrightHolder` as **plain strings** (`"tyk "`, `"Tyk"`) — schema.org's range for these is `Person`/`Organization`.
- **Protocol-relative URLs** in `url`/`@id` (`//tyk.io/…`, no scheme).
- `@context` on `http://` rather than `https://`.

The canonical schema.org validator tolerates these, but the stricter audit crawler flags them. This matches the team's own 5.7 rework (#6033), which converted author/copyrightHolder to `Organization`.

## Fix

- `author`/`copyrightHolder` → `Organization` objects.
- `url`/`@id` → absolute `https://…` via `replaceRE "^//" "https://"`, kept **quoted** (valid JSON — unlike 5.7's unquoted form).
- `@context` → `https://schema.org`.

## Verification

Rendered with Hugo against a protocol-relative baseURL and parsed as JSON:
- Valid JSON ✅
- `url` = `https://tyk.io/docs/5.3/…`; `author`/`copyrightHolder` = `Organization` ✅

## Note

Requires a **Netlify rebuild/redeploy** of the v5.3 subsite for the fix to reach the live crawl and clear the audit.
