### PR TITLE
docs: fix invalid JSON in v5.7 WebPage structured data (quote url/@id)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/partials/site_schema.html
+++ b/tyk-docs/themes/tykio/layouts/partials/site_schema.html
@@ -4,11 +4,11 @@
     "@type": "WebPage",
     "mainEntityOfPage": {
         "@type": "WebPage",
-        "@id": {{ .Site.BaseURL | printf "%s" }}
+        "@id": "{{ .Site.BaseURL | replaceRE "^//" "https://" }}"
     },
     "name": "{{ .Title }}",
     "headline": "{{ .Title }}",
-    "description": "{{ if .Description }}{{ .Description }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ end }}{{ end }}",
+    "description": "{{ if .Description }}{{ .Description }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ end }}{{ end }}",
     "inLanguage": "en-US",
     "author": {
         "@type": "Organization",
@@ -18,7 +18,7 @@
         "@type": "Organization",
         "name": "Tyk"
     },
-    "url": {{ .Permalink | printf "%s" }},
+    "url": "{{ .Permalink | replaceRE "^//" "https://" }}",
     "keywords": [{{ if isset .Params "tags" }}{{ range $index, $tag := .Params.tags }}"{{ $tag }}"{{ if ne $index (sub (len $.Params.tags) 1) }},{{ end }}{{ end }}{{ end }}],
     "datePublished": "{{ .Date.Format "2006-01-02" }}",
     "dateModified": "{{ .Lastmod.Format "2006-01-02" }}"


### PR DESCRIPTION
## Problem

v5.7 isn't live yet, but its `site_schema.html` (from #6033 / DX-1841) renders **invalid JSON**: `@id` and `url` are emitted **unquoted** (`{{ .Permalink | printf "%s" }}` with no surrounding quotes) → e.g. `"url": //tyk.io/docs/5.7/…`. This would surface as a structured-data error the moment 5.7 deploys.

## Fix

- Quote `@id`/`url` and make them absolute `https://…` via `replaceRE "^//" "https://"`.
- Everything 5.7 already had correct — `Organization` author/copyrightHolder, `https` context, `datePublished`/`dateModified` — is preserved.

## Verification

Rendered with Hugo + parsed as JSON: valid JSON ✅, dates preserved, `url` absolute https.

## Note

Not in the current audit (5.7 isn't crawled yet); this pre-empts a future hit and aligns 5.7 with the 5.2–5.6 fixes. Needs a Netlify rebuild once 5.7 goes live.
