### PR TITLE
docs: fix broken images by repointing to versioned /docs/<v>/img path

### DIFF
--- a/tyk-docs/content/graphql/field-based-permissions.md
+++ b/tyk-docs/content/graphql/field-based-permissions.md
@@ -45,4 +45,4 @@ When a field is restricted and used in a GraphQL operation, the consumer will re
 4. Enable **Field-Based Permissions** for the selected API.
 5. By default all *Types* and *Fields* will be checked. By unchecking a *Type* or *Field* you will disallow to use it for any GraphQL operation associated with the key.
 
-![field-based-permissions](/docs/img/dashboard/system-management/field_based_permissions.png)
+![field-based-permissions](/docs/4.1/img/dashboard/system-management/field_based_permissions.png)

--- a/tyk-docs/content/shared/create-portal-entry-include.md
+++ b/tyk-docs/content/shared/create-portal-entry-include.md
@@ -97,4 +97,4 @@ To save the API, click **SAVE**.
 
 You can now visit your portal to see the API catalogue entry. Select **Open Your Portal** from the **Your Developer Portal** menu:
 
-![Portal nav menu location](/docs/img/2.10/portal_menu.png)
+![Portal nav menu location](/docs/4.1/img/2.10/portal_menu.png)

--- a/tyk-docs/content/tyk-cloud/configuration-options/portal-configuration/portal-configuration.md
+++ b/tyk-docs/content/tyk-cloud/configuration-options/portal-configuration/portal-configuration.md
@@ -21,20 +21,20 @@ Watch our video on configuring your Tyk Cloud Developer Portal.
 1. From the Control Plane Dashboard, select **Pages** from the **Portal Management** menu
 2. Click **Add Page**
 
-![Add Portal Page](/docs/img/2.10/portal-home-page-add.png)
+![Add Portal Page](/docs/4.1/img/2.10/portal-home-page-add.png)
 
 3. In the Settings, give your page a name and slug. Below we've called it Home
 4. Select **Check to make this page the Home page**
 5. Select **Default Home page template** from the Page type drop-down list
 6. You can leave the Registered Fields sections for now
 
-![Portal Home page settings](/docs/img/2.10/portal-home-page-settings.png)
+![Portal Home page settings](/docs/4.1/img/2.10/portal-home-page-settings.png)
 
 7. Click **Save**.
 
 You should now be able to access your Portal from **Open Your Portal** from the **Your Developer Portal** menu.
 
-![Portal Menu](/docs/img/2.10/portal_menu.png)
+![Portal Menu](/docs/4.1/img/2.10/portal_menu.png)
 
 ## Further Portal Configuration
 

--- a/tyk-docs/content/tyk-stack/universal-data-graph/concepts/arguments.md
+++ b/tyk-docs/content/tyk-stack/universal-data-graph/concepts/arguments.md
@@ -33,4 +33,4 @@ We can do this by using templating syntax to inject it into the URL which can be
 https://example.com/user/{{ .arguments.id }}
 ``` 
 
-![Create New API](/docs/img/dashboard/udg/concepts/arguments.gif)
+![Create New API](/docs/4.1/img/dashboard/udg/concepts/arguments.gif)


### PR DESCRIPTION
## Problem (docs audit — Medium: "Page has broken image" / "Image broken")

Pages on **v4.1** reference 5 images via the version-less root path `/docs/img/…`, which returns **404**:

- `img/2.10/portal_menu.png`
- `img/2.10/portal-home-page-add.png`
- `img/2.10/portal-home-page-settings.png`
- `img/dashboard/system-management/field_based_permissions.png`
- `img/dashboard/udg/concepts/arguments.gif`

## Root cause

The root `/docs/img/…` namespace is served by the **Mintlify (Vercel)** deployment (`x-matched-path: /_mintlify/static/…`), and these 5 files are absent there. The images **do** exist in this version's own Hugo static and serve correctly at the versioned path `/docs/4.1/img/…` (verified 200).

## Fix

Repoint the 6 broken references (5 unique images across 4 content files) from `/docs/img/…` to `/docs/4.1/img/…`, so they resolve against this version's own Hugo-served static instead of the root Mintlify namespace. Only the broken references are changed; other (working) refs are left untouched.

Files changed:
- `content/graphql/field-based-permissions.md`
- `content/shared/create-portal-entry-include.md`
- `content/tyk-cloud/configuration-options/portal-configuration/portal-configuration.md`
- `content/tyk-stack/universal-data-graph/concepts/arguments.md`

## Verification

All 5 target URLs return **200** at `/docs/4.1/img/…` (checked live).

## Note

Requires a Netlify rebuild of the v4.1 subsite for the fix to reach the live crawl.
