### PR TITLE
fix(docs): resolve H1 tag missing or empty on 4.0 homepage [SEO audit]

### DIFF
--- a/tyk-docs/content/documentation.md
+++ b/tyk-docs/content/documentation.md
@@ -2,7 +2,7 @@
 publishdate: 2020-03-09
 lastmod: 2020-04-09
 Title: Tyk API Gateway Documentation
-diffTitleName:
+diffTitleName: "Tyk Documentation"
 menu:
   main:
     name: Home


### PR DESCRIPTION
## What
Homepage (`content/documentation.md`) sets `diffTitle: true` with an empty `diffTitleName`. The theme's H1 logic in `themes/tykio/layouts/_default/baseof.html` only falls back to `<h1>{{.Title}}</h1>` when `diffTitle` is false; when true it renders `<h1>{{.Params.diffTitleName}}</h1>`, which is empty here — so no `<h1>` is emitted on the version root page at all.

Set `diffTitleName: "Tyk Documentation"`, matching the text the current site's homepage hero already uses, so the page carries exactly one on-page H1 without changing the rest of the layout.

## Why
Flagged by the docs SEO audit under **H1 tag missing or empty**.

> **Jira:** _not created this session per request — to be added before merge._