### PR TITLE
fix(docs): resolve links to broken page on 5.7 (migration-to-tyk) [SEO audit]

### DIFF
--- a/tyk-docs/content/product-stack/tyk-charts/tyk-oss-chart.md
+++ b/tyk-docs/content/product-stack/tyk-charts/tyk-oss-chart.md
@@ -30,7 +30,7 @@ For quick start guide, please see [Quick Start with Tyk OSS Helm Chart]({{<ref "
 
 * [Kubernetes 1.19+](https://kubernetes.io/docs/setup/)
 * [Helm 3+](https://helm.sh/docs/intro/install/)
-* [Redis](https://tyk.io/docs/migration-to-tyk#configure-legacy-tyk-headless-helm-chart) should already be installed or accessible by the gateway. 
+* Redis should already be installed or accessible by the gateway.
 
 ## Tyk OSS Installations
 ### Installing the Chart
@@ -429,7 +429,7 @@ Please make sure you are installing MongoDB versions that are supported by Tyk. 
 
 Follow notes from the installation output to get connection details and update them in the `values.yaml` file.
 
-NOTE:  Please make sure you are installing a mongo helm chart that matches a supported [version](https://tyk.io/docs/migration-to-tyk#database-management/).
+NOTE:  Please make sure you are installing a mongo helm chart that matches a supported [version]({{< ref "api-management/dashboard-configuration#supported-database" >}}).
 
 *Important Note regarding MongoDB:* This helm chart enables the PodDisruptionBudget for MongoDB with an arbiter replica-count of 1. If you intend to perform system maintenance on the node where the MongoDB pod is running and this maintenance requires for the node to be drained, this action will be prevented due the replica count being 1. Increase the replica count in the helm chart deployment to a minimum of 2 to remedy this issue.
 

--- a/tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md
+++ b/tyk-docs/content/product-stack/tyk-charts/tyk-stack-chart.md
@@ -37,7 +37,7 @@ For quick start guide, please see [Quick Start with Helm Chart and PostgreSQL]({
 
 * [Kubernetes 1.19+](https://kubernetes.io/docs/setup/)
 * [Helm 3+](https://helm.sh/docs/intro/install/)
-* [Redis](https://tyk.io/docs/migration-to-tyk#configure-legacy-tyk-headless-helm-chart) should already be installed or accessible by the gateway and dashboard.
+* Redis should already be installed or accessible by the gateway and dashboard.
 * [MongoDB](https://www.mongodb.com) or [PostgreSQL](https://www.postgresql.org) should already be installed or accessible by dashboard. Please consult the list of [supported versions]({{< ref "api-management/dashboard-configuration#supported-database" >}}) that are compatible with Tyk.
 
 {{< note success >}}

--- a/tyk-docs/content/shared/dashboard-config.md
+++ b/tyk-docs/content/shared/dashboard-config.md
@@ -355,7 +355,7 @@ The hostname for the Redis collection and can be an IP address.
 ENV: <b>TYK_DB_REDISADDRS</b><br />
 Type: `[]string`<br />
 
-Used for configuring Redis clusters. See [Redis Cluster and Tyk Dashboard](https://tyk.io/docs/migration-to-tyk#configure-redis-cluster/) for more info. Example:
+Used for configuring Redis clusters. Example:
 ```
    "addrs": [
      "server1:6379",

--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -1980,8 +1980,6 @@ global session lifetime, in seconds.
 ENV: <b>TYK_GW_KV_KV</b><br />
 Type: `struct`<br />
 
-See more details https://tyk.io/docs/migration-to-tyk#store-configuration-with-key-value-store/
-
 ### kv.consul.address
 ENV: <b>TYK_GW_KV_CONSUL_ADDRESS</b><br />
 Type: `string`<br />
@@ -2094,7 +2092,7 @@ Sample Override Message Setting
 ENV: <b>TYK_GW_CLOUD</b><br />
 Type: `bool`<br />
 
-Cloud flag shows the Gateway runs in migration-to-tyk#begin-with-tyk-cloud.
+Cloud flag shows the Gateway runs in Tyk Cloud.
 
 ### jwt_ssl_insecure_skip_verify
 ENV: <b>TYK_GW_JWTSSLINSECURESKIPVERIFY</b><br />


### PR DESCRIPTION
## What
Several 5.7 pages linked to `https://tyk.io/docs/migration-to-tyk#<anchor>` — a page that was drafted on the abandoned `migrate-to-tyk` branch (last touched Nov 2024, ~20 months ago) but never merged into any release branch. The target has always 404'd; no equivalent content exists live anywhere in the docs.

- `shared/dashboard-config.md`, `shared/gateway-config.md`, `tyk-oss-chart.md`, `tyk-stack-chart.md` (also covers the `tyk-helm-tyk-stack` alias): de-linked the dead references, keeping the surrounding text.
- `tyk-oss-chart.md`'s mongo-version-compat link was repointed instead of stripped — to the existing, equivalent "Supported Database" section on `api-management/dashboard-configuration.md#supported-database`, which covers the same MongoDB-version-compatibility guidance.

## Why
Flagged by the docs SEO audit under **Page has links to broken page**.

> **Jira:** _not created this session per request — to be added before merge._