### PR TITLE
fix(docs): add nofollow to legacy Classic Portal noindex pages on 5.7 [SEO audit]

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -51,7 +51,7 @@
     {{ partial "site_schema.html" . }}
 
     {{ if eq .Params.robots "noindex" }}
-    <meta name="robots" content="noindex">
+    <meta name="robots" content="noindex, nofollow">
     {{ end }}
 
     {{ if and (isset .Params "algolia") (isset .Params.algolia "importance") }}


### PR DESCRIPTION
## What
All 41 pages on this branch that set `robots: "noindex"` in front matter are legacy Tyk Classic Portal content (Classic Portal, Portal API, related troubleshooting/FAQ pages). They render `<meta name="robots" content="noindex">` only - noindex but implicitly "follow" - so crawlers keep following their outbound links and passing link equity through a product we've deprecated and don't want appearing in search.

Since every current use of `robots: "noindex"` in this branch's content is this same legacy-portal case (verified all 41 files), the fix is a single shared conditional in `themes/tykio/layouts/_default/baseof.html` rather than 41 per-file edits: the rendered tag now reads `noindex, nofollow`.

## Why
Flagged by the docs SEO audit under **Noindex follow page**. Per Sharad: Tyk Classic Portal is a legacy product and should not appear in search, so intentionally noindexed pages should also stop passing link equity onward.

## Scope
This PR covers `release-5.7` only (as sampled by the audit). Other live Hugo versions were intentionally left out of scope for now.

> **Jira:** _not created this session per request — to be added before merge._