### PR TITLE
Add missing alt text to nav-center.png prev/next icon (4.2)

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -201,7 +201,7 @@
 
         <nav class="docs-navigation clear" {{if .Params.hideSidebar}}style="display: none !important"{{end}}>
           <a id="previousArticle"></a>
-          <img src="/docs/img/nav-center.png" /> 
+          <img src="/docs/img/nav-center.png" alt="Page forward and back image" />
           <a id="nextArticle"></a>
         </nav>
 


### PR DESCRIPTION
## Summary
- Fixes a Google Search Console/SEO audit finding: "Missing alt text" flagged on ~576 pages of the release-4.2 docs, all pointing back to the same prev/next navigation icon in the theme's `baseof.html`.
- Every other Hugo release branch (4, 4.1, 4.3, 5, 5.1–5.7) already sets `alt="Page forward and back image"` on this icon — release-4.2 was the only branch missing it.

## Test plan
- [x] Confirmed the `alt` attribute matches the wording used on every other Hugo branch for consistency
- [ ] Netlify preview renders the prev/next nav correctly with no visual change