### PR TITLE
Add missing alt text to heading copy-link icon (5.7)

### DIFF
--- a/tyk-docs/static/js/docs.js
+++ b/tyk-docs/static/js/docs.js
@@ -186,7 +186,7 @@ $(document).ready(function(e){
 			var id = heading.attr('id');
 
 			if (id) {
-				var linkIcon = $('<a href="#' + id + '" class="copy-anchor" title="Copy link"><img src="/docs/img/link.svg" class="copy-icon" /></a>');
+				var linkIcon = $('<a href="#' + id + '" class="copy-anchor" title="Copy link"><img src="/docs/img/link.svg" alt="Copy link" class="copy-icon" /></a>');
 				heading.append(linkIcon);
 
 				linkIcon.on('click', function (e) {
@@ -198,10 +198,12 @@ $(document).ready(function(e){
 
 						// Change to check.svg
 						img.attr('src', '/docs/img/check.svg');
+						img.attr('alt', 'Copied to clipboard');
 
 						// Reset back to link.svg after 2 seconds
 						setTimeout(() => {
 							img.attr('src', '/docs/img/link.svg');
+							img.attr('alt', 'Copy link');
 						}, 2000);
 					}).catch(err => {
 						console.error("Failed to copy:", err);


### PR DESCRIPTION
## Summary
- Fixes a Google Search Console/SEO audit finding: "Missing alt text" flagged on ~137 pages of the release-5.7 docs, all pointing back to the same copy-link icon injected next to every heading by `docs.js`.
- Adds `alt="Copy link"` on the icon (matching its existing `title="Copy link"`), and updates the alt to "Copied to clipboard" while it briefly swaps to the checkmark state after a successful copy.

## Test plan
- [ ] Netlify preview: hover/click a heading's copy-link icon, confirm it still copies the anchor URL and swaps to the checkmark visually as before