### PR TITLE
Add missing alt text to gRPC class diagram (5.4)

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -24,7 +24,7 @@ The remainder of this document illustrates a class diagram and explins the attri
 
 The class diagram below illustrates the structure of the [Object](#object) message, dispatched by Tyk to a gRPC server that handles custom plugins.
 
-{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" >}}
+{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" alt="UML class diagram of the rich plugin Object data structure and its relationships to MiniRequestObject, SessionState, ResponseObject, ReturnOverrides, BasicAuthData, JWTData, Monitor, and Header" >}}
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds descriptive `alt` text to the gRPC plugin class diagram (`/img/grpc/grpc-class-diagram.svg`) in `rich-plugins-data-structures.md`, fixing an SEO/accessibility audit finding for a missing image `alt` attribute.
- The `img` shortcode (`tyk-docs/themes/tykio/layouts/shortcodes/img.html`) already renders an `alt` attribute from an `alt` parameter — it just wasn't being passed at this call site, so it rendered as `alt=""`. No shortcode changes needed.

## Test plan
- [x] Confirmed the shortcode outputs `alt="{{ .Get "alt"}}"` and now receives a non-empty value.
- [x] Verified `git diff` only touches the single shortcode call line.
- [ ] Reviewer to spot-check rendered page to confirm alt text displays as expected.