### PR TITLE
Add missing alt text to gRPC class diagram (5.5)

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -24,7 +24,7 @@ The remainder of this document illustrates a class diagram and explins the attri
 
 The class diagram below illustrates the structure of the [Object](#object) message, dispatched by Tyk to a gRPC server that handles custom plugins.
 
-{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" >}}
+{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" alt="UML class diagram of the rich plugin Object data structure and its relationships to MiniRequestObject, SessionState, ResponseObject, ReturnOverrides, BasicAuthData, JWTData, Monitor, and Header" >}}
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds descriptive `alt` text to the gRPC rich-plugin class diagram in `rich-plugins-data-structures.md`, which was rendering as `alt=""` because the `alt` parameter (already supported by the `img` shortcode) was never passed at this call site.
- Fixes an image-accessibility/SEO audit finding for a genuinely informative UML diagram (not decorative).

## Test plan
- [x] Confirmed the `img` shortcode (`tyk-docs/themes/tykio/layouts/shortcodes/img.html`) already renders the `alt` attribute when provided.
- [x] Verified only the single shortcode line changed via `git diff`.
- [ ] Preview build to confirm the diagram renders unchanged with the new alt text.