### PR TITLE
Add missing alt text to gRPC class diagram (5.3)

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -24,7 +24,7 @@ The remainder of this document illustrates a class diagram and explins the attri
 
 The class diagram below illustrates the structure of the [Object](#object) message, dispatched by Tyk to a gRPC server that handles custom plugins.
 
-{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" >}}
+{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" alt="UML class diagram of the rich plugin Object data structure and its relationships to MiniRequestObject, SessionState, ResponseObject, ReturnOverrides, BasicAuthData, JWTData, Monitor, and Header" >}}
 
 ---
 


### PR DESCRIPTION
## Summary
- The `{{< img >}}` shortcode already supports and renders an `alt` attribute, but it was never passed at the call site for the gRPC rich-plugin class diagram in `rich-plugins-data-structures.md`, so the image rendered with `alt=""`.
- Adds descriptive alt text identifying it as a UML class diagram of the rich plugin `Object` data structure and its relationships to `MiniRequestObject`, `SessionState`, `ResponseObject`, `ReturnOverrides`, `BasicAuthData`, `JWTData`, `Monitor`, and `Header`.
- Fixes a missing-alt-text finding from an SEO/accessibility audit.

## Test plan
- [x] Confirmed the `img` shortcode (`tyk-docs/themes/tykio/layouts/shortcodes/img.html`) outputs the `alt` attribute from the `alt` parameter.
- [x] Verified only the single shortcode line changed (`git diff`), no other content touched.