### PR TITLE
Add missing alt text to gRPC class diagram (5.6)

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -24,7 +24,7 @@ The remainder of this document illustrates a class diagram and explins the attri
 
 The class diagram below illustrates the structure of the [Object](#object) message, dispatched by Tyk to a gRPC server that handles custom plugins.
 
-{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" >}}
+{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" alt="UML class diagram of the rich plugin Object data structure and its relationships to MiniRequestObject, SessionState, ResponseObject, ReturnOverrides, BasicAuthData, JWTData, Monitor, and Header" >}}
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds missing `alt` text to the gRPC rich-plugin class diagram in `rich-plugins-data-structures.md`, fixing a missing image alt text finding from an SEO/accessibility audit.
- The `img` shortcode already supports an `alt` parameter and renders it — it just wasn't being passed at this call site, so the image rendered with `alt=""`.
- The alt text describes the diagram's content: the rich plugin `Object` data structure and its relationships to `MiniRequestObject`, `SessionState`, `ResponseObject`, `ReturnOverrides`, `BasicAuthData`, `JWTData`, `Monitor`, and `Header`.

## Test plan
- [ ] Confirm the page renders correctly with the new `alt` attribute on the `<img>` tag for `/img/grpc/grpc-class-diagram.svg`
- [ ] Confirm no other content on the page changed