### PR TITLE
Add missing alt text to gRPC class diagram (5.1)

### DIFF
--- a/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
+++ b/tyk-docs/content/plugins/supported-languages/rich-plugins/rich-plugins-data-structures.md
@@ -24,7 +24,7 @@ The remainder of this document illustrates a class diagram and explins the attri
 
 The class diagram below illustrates the structure of the [Object](#object) message, dispatched by Tyk to a gRPC server that handles custom plugins.
 
-{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" >}}
+{{< img src="/img/grpc/grpc-class-diagram.svg" width="600" alt="UML class diagram of the rich plugin Object data structure and its relationships to MiniRequestObject, SessionState, ResponseObject, ReturnOverrides, BasicAuthData, JWTData, Monitor, and Header" >}}
 
 ---
 


### PR DESCRIPTION
## Summary
- The gRPC plugin class diagram in `rich-plugins-data-structures.md` was rendered via the `img` shortcode without an `alt` attribute, so it output as `alt=""`.
- The shortcode (`tyk-docs/themes/tykio/layouts/shortcodes/img.html`) already reads and outputs an `alt` parameter — it just wasn't passed at this call site.
- Added descriptive alt text for this genuinely informative UML diagram, fixing an SEO/accessibility audit finding (missing image alt text).

## Test plan
- [x] Confirmed the `img` shortcode template outputs `alt="{{ .Get "alt"}}"`, so passing `alt` here is sufficient with no template changes needed.
- [x] Verified the diff is a single-line change limited to this one file.
- [ ] Reviewer to confirm rendered page shows the alt text on the image (e.g. via browser dev tools / accessibility inspector) once deployed to a preview.