### PR TITLE
Add missing alt text to badge shortcode images (5.1)

### DIFF
--- a/tyk-docs/content/apim/open-source/installation.md
+++ b/tyk-docs/content/apim/open-source/installation.md
@@ -17,27 +17,27 @@ The backbone of all our products is our open source Gateway. You can install our
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-docker/" image="/img/docker.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-docker/" image="/img/docker.png" alt="Docker logo">}}
 Install with Docker. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-kubernetes/" image="/img/k8s.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-kubernetes/" image="/img/k8s.png" alt="Kubernetes logo">}}
 Install with K8s. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-ansible/" image="/img/ansible.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-ansible/" image="/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-redhat-rhel-centos/" image="/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-redhat-rhel-centos/" image="/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on RHEL / CentOS. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-debian-ubuntu/" image="/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-debian-ubuntu/" image="/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Debian / Ubuntu. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/img/GitHub-Mark-64px.png">}}
+{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/img/GitHub-Mark-64px.png" alt="GitHub logo">}}
 Visit our Gateway GitHub Repo. 
 {{< /badge >}}
 

--- a/tyk-docs/content/content.md
+++ b/tyk-docs/content/content.md
@@ -20,15 +20,15 @@ url: /
 
 {{< grid >}}
 
-{{< badge read="10 mins" imageStyle="object-fit:contain" href="tyk-self-managed/install" image="/img/logos/tyk-logo-selfmanaged.svg">}}
+{{< badge read="10 mins" imageStyle="object-fit:contain" href="tyk-self-managed/install" image="/img/logos/tyk-logo-selfmanaged.svg" alt="Tyk Self-Managed logo">}}
 Includes Tyk API Gateway, Tyk Dashboard, Tyk Portal, Tyk UDG
 {{< /badge >}}
 
-{{< badge read="15 mins" imageStyle="object-fit:contain" href="tyk-cloud/" image="/img/logos/tyk-logo-cloud.svg" >}}
+{{< badge read="15 mins" imageStyle="object-fit:contain" href="tyk-cloud/" image="/img/logos/tyk-logo-cloud.svg" alt="Tyk Cloud logo" >}}
 Includes Tyk API Gateway, Tyk Dashboard, Tyk Portal, Tyk UDG
 {{< /badge >}}
 
-{{< badge read="7 mins" imageStyle="object-fit:contain" href="apim/open-source/" image="/img/logos/tyk-logo-opensource.svg">}}
+{{< badge read="7 mins" imageStyle="object-fit:contain" href="apim/open-source/" image="/img/logos/tyk-logo-opensource.svg" alt="Tyk Open Source logo">}}
 Install Tyk OSS Gateway only
 {{< /badge >}}
 

--- a/tyk-docs/content/tyk-self-managed/install.md
+++ b/tyk-docs/content/tyk-self-managed/install.md
@@ -25,35 +25,35 @@ First, click here to get a trial license
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/docker/" image="/img/docker.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/docker/" image="/img/docker.png" alt="Docker logo">}}
 Install with Docker 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/kubernetes" image="/img/k8s.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/kubernetes" image="/img/k8s.png" alt="Kubernetes logo">}}
 Install on K8s 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/ansible/" image="/img/ansible.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/ansible/" image="/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/redhat-rhel-centos/" image="/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/redhat-rhel-centos/" image="/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on Red Hat 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/debian-ubuntu" image="/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/debian-ubuntu" image="/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Ubuntu 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/installation/on-aws" image="/img/aws.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/installation/on-aws" image="/img/aws.png" alt="AWS logo">}}
 Install on Amazon AWS 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/installation/on-heroku" image="/img/heroku-logo.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/installation/on-heroku" image="/img/heroku-logo.png" alt="Heroku logo">}}
 Install Tyk on Heroku 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/microsoft-azure/" image="/img/azure-2.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/microsoft-azure/" image="/img/azure-2.png" alt="Microsoft Azure logo">}}
 Install on Microsoft Azure 
 {{< /badge >}}
 

--- a/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
@@ -26,7 +26,7 @@
 	{{end}}
 	<p>	
 		{{if .Get "image"}}
-		<img src="{{ $src }}" style="{{.Get "imageStyle"}}"/>
+		<img src="{{ $src }}" alt="{{ .Get "alt" }}" style="{{.Get "imageStyle"}}"/>
 		{{end}}
 		{{if .Get "title"}}
 		<center>


### PR DESCRIPTION
## Summary
- The `badge` shortcode's `<img>` tag never rendered an `alt` attribute at all, even when content authors already passed `alt="..."` to the shortcode call — it was silently dropped by the template. This was flagged by an SEO/accessibility audit.
- Fixed `tyk-docs/themes/tykio/layouts/shortcodes/badge.html` to actually output the `alt` parameter. This alone fixes every badge call across the branch that already had `alt="..."` (no content changes needed for those).
- Added `alt="..."` to the badge calls that were genuinely missing it entirely:
  - `tyk-docs/content/apim/open-source/installation.md` — 6 badges (Docker, Kubernetes, Ansible, Red Hat, Debian, GitHub)
  - `tyk-docs/content/content.md` — 3 logo badges (Tyk Self-Managed, Tyk Cloud, Tyk Open Source). The 6 badges with `image=""` were left untouched (nothing to add alt text for).
  - `tyk-docs/content/tyk-self-managed/install.md` — 8 badges (Docker, Kubernetes, Ansible, Red Hat, Debian, AWS, Heroku, Microsoft Azure)
- Left untouched (already had correct `alt=` on every badge call, now rendered correctly thanks to the template fix):
  - `tyk-docs/content/developer-support/tyk-release-summary/overview.md`
  - `tyk-docs/content/plugins/tutorials/quick-starts/go/quickstart.md`
  - `tyk-docs/content/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/overview.md`
  - `tyk-docs/content/tyk-cloud.md`
- `README.md` (shortcode documentation, not live content) was not touched.

## Test plan
- [ ] Confirm `hugo` builds the branch without errors
- [ ] Spot check rendered pages (`/apim/open-source/`, home page, `/tyk-self-managed/install/`) to confirm badge images now have meaningful `alt` text in the rendered HTML
- [ ] Confirm pages that already had `alt="..."` in the shortcode call (e.g. release-summary overview, EDP install overview, quickstart) now render that alt text correctly