### PR TITLE
Add missing alt text to badge shortcode images (4.3)

### DIFF
--- a/tyk-docs/content/apim/open-source/installation.md
+++ b/tyk-docs/content/apim/open-source/installation.md
@@ -17,27 +17,27 @@ The backbone of all our products is our open source Gateway. You can install our
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-docker/" image="/img/docker.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-docker/" image="/img/docker.png" alt="Docker logo">}}
 Install with Docker. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-kubernetes/" image="/img/k8s.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-kubernetes/" image="/img/k8s.png" alt="Kubernetes logo">}}
 Install with K8s. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-ansible/" image="/img/ansible.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-ansible/" image="/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-redhat-rhel-centos/" image="/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-redhat-rhel-centos/" image="/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on RHEL / CentOS. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-debian-ubuntu/" image="/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-debian-ubuntu/" image="/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Debian / Ubuntu. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/img/GitHub-Mark-64px.png">}}
+{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/img/GitHub-Mark-64px.png" alt="GitHub logo">}}
 Visit our Gateway GitHub Repo. 
 {{< /badge >}}
 

--- a/tyk-docs/content/content.md
+++ b/tyk-docs/content/content.md
@@ -18,13 +18,13 @@ url: /
 
 {{< grid >}}
 
-{{< badge read="7 mins" imageStyle="object-fit:contain" href="/apim/open-source/" image="/img/logos/tyk-logo-opensource.png">}}
+{{< badge read="7 mins" imageStyle="object-fit:contain" href="/apim/open-source/" image="/img/logos/tyk-logo-opensource.png" alt="Tyk Open Source logo">}}
 {{< /badge >}}
 
-{{< badge read="10 mins" imageStyle="object-fit:contain" href="tyk-self-managed/install" image="/img/logos/tyk-logo-selfmanaged.png">}}
+{{< badge read="10 mins" imageStyle="object-fit:contain" href="tyk-self-managed/install" image="/img/logos/tyk-logo-selfmanaged.png" alt="Tyk Self-Managed logo">}}
 {{< /badge >}}
 
-{{< badge read="15 mins" imageStyle="object-fit:contain" href="/tyk-cloud/" image="/img/logos/tyk-logo-cloud.png" >}}
+{{< badge read="15 mins" imageStyle="object-fit:contain" href="/tyk-cloud/" image="/img/logos/tyk-logo-cloud.png" alt="Tyk Cloud logo" >}}
 {{< /badge >}}
 
 

--- a/tyk-docs/content/tyk-cloud.md
+++ b/tyk-docs/content/tyk-cloud.md
@@ -24,7 +24,7 @@ Or click here to [learn more]({{< ref "tyk-cloud/what-is-tyk-cloud" >}})
 
 {{< grid >}}
 
-{{< badge read="15 mins" href="/tyk-cloud/getting-started/" image="/img/tyk-cloud.svg">}}
+{{< badge read="15 mins" href="/tyk-cloud/getting-started/" image="/img/tyk-cloud.svg" alt="Tyk Cloud logo">}}
 Configure Tyk Cloud
 {{< /badge >}}
 

--- a/tyk-docs/content/tyk-self-managed/install.md
+++ b/tyk-docs/content/tyk-self-managed/install.md
@@ -17,35 +17,35 @@ aliases:
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/docker/" image="/img/docker.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/docker/" image="/img/docker.png" alt="Docker logo">}}
 Install with Docker 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/kubernetes" image="/img/k8s.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/kubernetes" image="/img/k8s.png" alt="Kubernetes logo">}}
 Install on K8s 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/ansible/" image="/img/ansible.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/ansible/" image="/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/redhat-rhel-centos/" image="/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/redhat-rhel-centos/" image="/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on Red Hat 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/debian-ubuntu" image="/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/debian-ubuntu" image="/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Ubuntu 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/installation/on-aws" image="/img/aws.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/installation/on-aws" image="/img/aws.png" alt="AWS logo">}}
 Install on Amazon AWS 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/installation/on-heroku" image="/img/heroku-logo.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/installation/on-heroku" image="/img/heroku-logo.png" alt="Heroku logo">}}
 Install Tyk on Heroku 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/microsoft-azure/" image="/img/azure-2.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/microsoft-azure/" image="/img/azure-2.png" alt="Microsoft Azure logo">}}
 Install on Microsoft Azure 
 {{< /badge >}}
 

--- a/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
@@ -26,7 +26,7 @@
 	{{end}}
 	<p>	
 		{{if .Get "image"}}
-		<img src="{{ $src }}" style="{{.Get "imageStyle"}}"/>
+		<img src="{{ $src }}" alt="{{ .Get "alt" }}" style="{{.Get "imageStyle"}}"/>
 		{{end}}
 		{{if .Get "title"}}
 		<center>


### PR DESCRIPTION
## Summary
- The custom `badge` shortcode (`tyk-docs/themes/tykio/layouts/shortcodes/badge.html`) never rendered an `alt` attribute on its `<img>`, even on call sites that already passed `alt="..."` — the value was silently dropped. This was flagged by an SEO/accessibility audit.
- Fixed the shortcode template to output `alt="{{ .Get "alt" }}"` on the `<img>` tag.
- Added `alt="..."` to every `badge` call site missing it across content that renders an image (installation/tech-logo cards). Call sites with `image=""` (no image rendered) were left untouched, as were any that already had `alt="..."` set.

## Files changed
- `tyk-docs/themes/tykio/layouts/shortcodes/badge.html` — shortcode fix
- `tyk-docs/content/apim/open-source/installation.md` — 6 badges (Docker, Kubernetes, Ansible, Red Hat, Debian, GitHub)
- `tyk-docs/content/content.md` — 3 badges (Tyk Open Source, Tyk Self-Managed, Tyk Cloud logos)
- `tyk-docs/content/tyk-cloud.md` — 1 badge (Tyk Cloud)
- `tyk-docs/content/tyk-self-managed/install.md` — 8 badges (Docker, Kubernetes, Ansible, Red Hat, Debian, AWS, Heroku, Microsoft Azure)

## Test plan
- [ ] Build the site locally (`hugo` in `tyk-docs/`) and confirm the affected pages build without errors
- [ ] Inspect rendered HTML on `/apim/open-source/`, the homepage, `/tyk-cloud/`, and `/tyk-self-managed/install/` to confirm each badge `<img>` now has a non-empty, descriptive `alt` attribute
- [ ] Confirm badges with `image=""` still render with no `<img>` tag (unaffected)