### PR TITLE
Add missing alt text to badge shortcode images (4.1)

### DIFF
--- a/tyk-docs/content/api-management/oss/tyk-solutions-oss-install.md
+++ b/tyk-docs/content/api-management/oss/tyk-solutions-oss-install.md
@@ -18,27 +18,27 @@ The backbone of all our products is our open source Gateway. You can install our
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-docker/" image="/docs/img/docker.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-docker/" image="/docs/img/docker.png" alt="Docker logo">}}
 Install with Docker. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-kubernetes/" image="/docs/img/k8s.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-kubernetes/" image="/docs/img/k8s.png" alt="Kubernetes logo">}}
 Install with K8s. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-ansible/" image="/docs/img/ansible.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-ansible/" image="/docs/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-redhat-rhel-centos/" image="/docs/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-redhat-rhel-centos/" image="/docs/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on RHEL / CentOS. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-debian-ubuntu/" image="/docs/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-debian-ubuntu/" image="/docs/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Debian / Ubuntu. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/docs/img/GitHub-Mark-64px.png">}}
+{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/docs/img/GitHub-Mark-64px.png" alt="GitHub logo">}}
 Visit our Gateway GitHub Repo. 
 {{< /badge >}}
 

--- a/tyk-docs/content/documentation.md
+++ b/tyk-docs/content/documentation.md
@@ -18,13 +18,13 @@ hideSidebar: true
 
 {{< grid >}}
 
-{{< badge read="7 mins" imageStyle="object-fit:contain" href="/docs/apim/open-source/" image="/docs/img/logos/tyk-logo-opensource.png">}}
+{{< badge read="7 mins" imageStyle="object-fit:contain" href="/docs/apim/open-source/" image="/docs/img/logos/tyk-logo-opensource.png" alt="Tyk Open Source logo">}}
 {{< /badge >}}
 
-{{< badge read="10 mins" imageStyle="object-fit:contain" href="/docs/tyk-on-premises/" image="/docs/img/logos/tyk-logo-selfmanaged.png">}}
+{{< badge read="10 mins" imageStyle="object-fit:contain" href="/docs/tyk-on-premises/" image="/docs/img/logos/tyk-logo-selfmanaged.png" alt="Tyk Self-Managed logo">}}
 {{< /badge >}}
 
-{{< badge read="15 mins" imageStyle="object-fit:contain" href="/docs/tyk-cloud/" image="/docs/img/logos/tyk-logo-cloud.png" >}}
+{{< badge read="15 mins" imageStyle="object-fit:contain" href="/docs/tyk-cloud/" image="/docs/img/logos/tyk-logo-cloud.png" alt="Tyk Cloud logo" >}}
 {{< /badge >}}
 
 

--- a/tyk-docs/content/tyk-cloud/tyk-cloud.md
+++ b/tyk-docs/content/tyk-cloud/tyk-cloud.md
@@ -23,7 +23,7 @@ Or click here to [learn more](/docs/tyk-cloud/what-is-tyk-cloud/)
 
 {{< grid >}}
 
-{{< badge read="15 mins" href="/docs/tyk-cloud/getting-started/" image="/docs/img/tyk-cloud.svg">}}
+{{< badge read="15 mins" href="/docs/tyk-cloud/getting-started/" image="/docs/img/tyk-cloud.svg" alt="Tyk Cloud logo">}}
 Configure Tyk Cloud
 {{< /badge >}}
 

--- a/tyk-docs/content/tyk-on-prem/installation/installation.md
+++ b/tyk-docs/content/tyk-on-prem/installation/installation.md
@@ -17,35 +17,35 @@ aliases:
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/docker/" image="/docs/img/docker.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/docker/" image="/docs/img/docker.png" alt="Docker logo">}}
 Install with Docker 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/kubernetes/" image="/docs/img/k8s.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/kubernetes/" image="/docs/img/k8s.png" alt="Kubernetes logo">}}
 Install on K8s 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/ansible/" image="/docs/img/ansible.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/ansible/" image="/docs/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/redhat-rhel-centos/" image="/docs/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/redhat-rhel-centos/" image="/docs/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on Red Hat 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/debian-ubuntu/" image="/docs/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/debian-ubuntu/" image="/docs/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Ubuntu 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/aws/" image="/docs/img/aws.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/aws/" image="/docs/img/aws.png" alt="AWS logo">}}
 Install on Amazon AWS 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/heroku/" image="/docs/img/heroku-logo.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/heroku/" image="/docs/img/heroku-logo.png" alt="Heroku logo">}}
 Install Tyk on Heroku 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/microsoft-azure/" image="/docs/img/azure-2.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/microsoft-azure/" image="/docs/img/azure-2.png" alt="Microsoft Azure logo">}}
 Install on Microsoft Azure 
 {{< /badge >}}
 

--- a/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
@@ -7,7 +7,7 @@
 	{{end}}
 	<p>	
 		{{if .Get "image"}}
-		<img src="{{strings.TrimPrefix "/docs" (.Get "image") | relURL }}" style="{{.Get "imageStyle"}}"/>
+		<img src="{{strings.TrimPrefix "/docs" (.Get "image") | relURL }}" alt="{{ .Get "alt" }}" style="{{.Get "imageStyle"}}"/>
 		{{end}}
 		{{if .Get "title"}}
 		<center>


### PR DESCRIPTION
## Summary
- The `badge` shortcode's `<img>` tag never output an `alt` attribute, even when content authors already passed `alt="..."` — it was silently dropped by the template.
- Fixed `tyk-docs/themes/tykio/layouts/shortcodes/badge.html` to actually render the `alt` parameter.
- Added `alt="..."` to every badge call site that was missing it (none had it before, since it was never rendered):
  - `tyk-docs/content/api-management/oss/tyk-solutions-oss-install.md` — 6 badges (docker, k8s, ansible, redhat, debian, github)
  - `tyk-docs/content/documentation.md` — 3 logo badges (opensource, selfmanaged, cloud); left the 6 `image=""` badges untouched since they render no image
  - `tyk-docs/content/tyk-cloud/tyk-cloud.md` — 1 badge (tyk-cloud.svg)
  - `tyk-docs/content/tyk-on-prem/installation/installation.md` — 8 badges (docker, k8s, ansible, redhat, debian, aws, heroku, azure)
- `README.md` (shortcode documentation, not live content) intentionally left untouched.

Fixes an SEO/accessibility audit finding (missing image alt text) on this branch.

## Test plan
- [ ] Build the Hugo site locally on `release-4.1` and confirm each affected page renders `<img alt="...">` on all badge images
- [ ] Confirm badges with `image=""` still render with no `<img>` tag (unaffected)
- [ ] Visually spot-check the 4 changed pages render unchanged (alt text is non-visual)