### PR TITLE
Add missing alt text to badge shortcode images (4.2)

### DIFF
--- a/tyk-docs/content/api-management/oss/tyk-solutions-oss-install.md
+++ b/tyk-docs/content/api-management/oss/tyk-solutions-oss-install.md
@@ -18,27 +18,27 @@ The backbone of all our products is our open source Gateway. You can install our
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-docker/" image="/docs/img/docker.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-docker/" image="/docs/img/docker.png" alt="Docker logo">}}
 Install with Docker. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-kubernetes/" image="/docs/img/k8s.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-kubernetes/" image="/docs/img/k8s.png" alt="Kubernetes logo">}}
 Install with K8s. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-ansible/" image="/docs/img/ansible.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-ansible/" image="/docs/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-redhat-rhel-centos/" image="/docs/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-redhat-rhel-centos/" image="/docs/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on RHEL / CentOS. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-oss/ce-debian-ubuntu/" image="/docs/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="/docs/tyk-oss/ce-debian-ubuntu/" image="/docs/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Debian / Ubuntu. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/docs/img/GitHub-Mark-64px.png">}}
+{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/docs/img/GitHub-Mark-64px.png" alt="GitHub logo">}}
 Visit our Gateway GitHub Repo. 
 {{< /badge >}}
 

--- a/tyk-docs/content/documentation.md
+++ b/tyk-docs/content/documentation.md
@@ -18,13 +18,13 @@ hideSidebar: true
 
 {{< grid >}}
 
-{{< badge read="7 mins" imageStyle="object-fit:contain" href="/docs/apim/open-source/" image="/docs/img/logos/tyk-logo-opensource.png">}}
+{{< badge read="7 mins" imageStyle="object-fit:contain" href="/docs/apim/open-source/" image="/docs/img/logos/tyk-logo-opensource.png" alt="Tyk Open Source logo">}}
 {{< /badge >}}
 
-{{< badge read="10 mins" imageStyle="object-fit:contain" href="/docs/tyk-on-premises/" image="/docs/img/logos/tyk-logo-selfmanaged.png">}}
+{{< badge read="10 mins" imageStyle="object-fit:contain" href="/docs/tyk-on-premises/" image="/docs/img/logos/tyk-logo-selfmanaged.png" alt="Tyk Self-Managed logo">}}
 {{< /badge >}}
 
-{{< badge read="15 mins" imageStyle="object-fit:contain" href="/docs/tyk-cloud/" image="/docs/img/logos/tyk-logo-cloud.png" >}}
+{{< badge read="15 mins" imageStyle="object-fit:contain" href="/docs/tyk-cloud/" image="/docs/img/logos/tyk-logo-cloud.png" alt="Tyk Cloud logo" >}}
 {{< /badge >}}
 
 

--- a/tyk-docs/content/tyk-cloud/tyk-cloud.md
+++ b/tyk-docs/content/tyk-cloud/tyk-cloud.md
@@ -23,7 +23,7 @@ Or click here to [learn more](/docs/tyk-cloud/what-is-tyk-cloud/)
 
 {{< grid >}}
 
-{{< badge read="15 mins" href="/docs/tyk-cloud/getting-started/" image="/docs/img/tyk-cloud.svg">}}
+{{< badge read="15 mins" href="/docs/tyk-cloud/getting-started/" image="/docs/img/tyk-cloud.svg" alt="Tyk Cloud logo">}}
 Configure Tyk Cloud
 {{< /badge >}}
 

--- a/tyk-docs/content/tyk-on-prem/installation/installation.md
+++ b/tyk-docs/content/tyk-on-prem/installation/installation.md
@@ -17,35 +17,35 @@ aliases:
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/docker/" image="/docs/img/docker.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/docker/" image="/docs/img/docker.png" alt="Docker logo">}}
 Install with Docker 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/kubernetes/" image="/docs/img/k8s.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/kubernetes/" image="/docs/img/k8s.png" alt="Kubernetes logo">}}
 Install on K8s 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/ansible/" image="/docs/img/ansible.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/ansible/" image="/docs/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/redhat-rhel-centos/" image="/docs/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/redhat-rhel-centos/" image="/docs/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on Red Hat 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/debian-ubuntu/" image="/docs/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/debian-ubuntu/" image="/docs/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Ubuntu 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/aws/" image="/docs/img/aws.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/aws/" image="/docs/img/aws.png" alt="AWS logo">}}
 Install on Amazon AWS 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/heroku/" image="/docs/img/heroku-logo.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/heroku/" image="/docs/img/heroku-logo.png" alt="Heroku logo">}}
 Install Tyk on Heroku 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/docs/tyk-on-premises/microsoft-azure/" image="/docs/img/azure-2.png">}}
+{{< badge read="10 mins" href="/docs/tyk-on-premises/microsoft-azure/" image="/docs/img/azure-2.png" alt="Microsoft Azure logo">}}
 Install on Microsoft Azure 
 {{< /badge >}}
 

--- a/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
@@ -7,7 +7,7 @@
 	{{end}}
 	<p>	
 		{{if .Get "image"}}
-		<img src="{{strings.TrimPrefix "/docs" (.Get "image") | relURL }}" style="{{.Get "imageStyle"}}"/>
+		<img src="{{strings.TrimPrefix "/docs" (.Get "image") | relURL }}" alt="{{ .Get "alt" }}" style="{{.Get "imageStyle"}}"/>
 		{{end}}
 		{{if .Get "title"}}
 		<center>


### PR DESCRIPTION
## Summary
- The `badge` shortcode (`tyk-docs/themes/tykio/layouts/shortcodes/badge.html`) never output an `alt` attribute on its `<img>`, even on badge calls where content authors had already tried to pass `alt="..."`. This was flagged by an SEO/accessibility audit.
- Fixed the shortcode template to render `alt="{{ .Get "alt" }}"` on the `<img>` tag.
- Added an `alt="..."` parameter to every badge call site in content that was missing one (18 call sites across 4 pages), using descriptive text matched to each logo/icon.
- Badge calls with `image=""` (no image rendered) were left untouched, since there's no image to describe.

## Files changed
- `tyk-docs/themes/tykio/layouts/shortcodes/badge.html` — template fix
- `tyk-docs/content/api-management/oss/tyk-solutions-oss-install.md` — 6 badges (docker, k8s, ansible, redhat, debian, github)
- `tyk-docs/content/documentation.md` — 3 badges (Tyk Open Source, Self-Managed, Cloud logos)
- `tyk-docs/content/tyk-cloud/tyk-cloud.md` — 1 badge (Tyk Cloud logo)
- `tyk-docs/content/tyk-on-prem/installation/installation.md` — 8 badges (docker, k8s, ansible, redhat, debian, aws, heroku, azure)

## Test plan
- [x] Confirmed via `grep -rn 'badge.*image=' tyk-docs/content/` that every badge call with a non-empty `image=` now has an `alt=` attribute (excluding intentionally empty `image=""` calls).
- [x] Confirmed no other files (README.md, baseof.html, etc.) were touched.
- [ ] Run local Hugo build/preview to visually confirm badges render unchanged with the new `alt` attributes present in rendered HTML.