### PR TITLE
Add missing alt text to badge shortcode images (5.0)

### DIFF
--- a/tyk-docs/content/apim/open-source/installation.md
+++ b/tyk-docs/content/apim/open-source/installation.md
@@ -17,27 +17,27 @@ The backbone of all our products is our open source Gateway. You can install our
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-docker/" image="/img/docker.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-docker/" image="/img/docker.png" alt="Docker logo">}}
 Install with Docker. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-kubernetes/" image="/img/k8s.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-kubernetes/" image="/img/k8s.png" alt="Kubernetes logo">}}
 Install with K8s. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-ansible/" image="/img/ansible.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-ansible/" image="/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-redhat-rhel-centos/" image="/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-redhat-rhel-centos/" image="/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on RHEL / CentOS. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-oss/ce-debian-ubuntu/" image="/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="tyk-oss/ce-debian-ubuntu/" image="/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Debian / Ubuntu. 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/img/GitHub-Mark-64px.png">}}
+{{< badge read="10 mins" href="https://github.com/TykTechnologies/tyk" image="/img/GitHub-Mark-64px.png" alt="GitHub logo">}}
 Visit our Gateway GitHub Repo. 
 {{< /badge >}}
 

--- a/tyk-docs/content/tyk-cloud.md
+++ b/tyk-docs/content/tyk-cloud.md
@@ -32,7 +32,7 @@ Start using Tyk on our servers. Nothing to install:
 
 {{< grid >}}
 
-{{< badge read="5 mins" href="/deployment-and-operations/tyk-cloud-platform/quick-start/" image="/img/tyk-cloud.svg">}}
+{{< badge read="5 mins" href="/deployment-and-operations/tyk-cloud-platform/quick-start/" image="/img/tyk-cloud.svg" alt="Tyk Cloud logo">}}
 Quick Start
 {{< /badge >}}
 

--- a/tyk-docs/content/tyk-self-managed/install.md
+++ b/tyk-docs/content/tyk-self-managed/install.md
@@ -37,35 +37,35 @@ Then navigate to [http://localhost:3000](http://localhost:3000) and input the li
 
 {{< grid >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/docker/" image="/img/docker.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/docker/" image="/img/docker.png" alt="Docker logo">}}
 Install with Docker 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/kubernetes" image="/img/k8s.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/kubernetes" image="/img/k8s.png" alt="Kubernetes logo">}}
 Install on K8s 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/ansible/" image="/img/ansible.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/ansible/" image="/img/ansible.png" alt="Ansible logo">}}
 Install with Ansible 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/redhat-rhel-centos/" image="/img/redhat-logo2.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/redhat-rhel-centos/" image="/img/redhat-logo2.png" alt="Red Hat logo">}}
 Install on Red Hat 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/debian-ubuntu" image="/img/debian-nd-753.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/debian-ubuntu" image="/img/debian-nd-753.png" alt="Debian logo">}}
 Install on Ubuntu 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/installation/on-aws" image="/img/aws.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/installation/on-aws" image="/img/aws.png" alt="AWS logo">}}
 Install on Amazon AWS 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="tyk-on-premises/installation/on-heroku" image="/img/heroku-logo.png">}}
+{{< badge read="10 mins" href="tyk-on-premises/installation/on-heroku" image="/img/heroku-logo.png" alt="Heroku logo">}}
 Install Tyk on Heroku 
 {{< /badge >}}
 
-{{< badge read="10 mins" href="/tyk-on-premises/microsoft-azure/" image="/img/azure-2.png">}}
+{{< badge read="10 mins" href="/tyk-on-premises/microsoft-azure/" image="/img/azure-2.png" alt="Microsoft Azure logo">}}
 Install on Microsoft Azure 
 {{< /badge >}}
 

--- a/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
+++ b/tyk-docs/themes/tykio/layouts/shortcodes/badge.html
@@ -25,7 +25,7 @@
 	{{end}}
 	<p>	
 		{{if .Get "image"}}
-		<img src="{{ $src }}" style="{{.Get "imageStyle"}}"/>
+		<img src="{{ $src }}" alt="{{ .Get "alt" }}" style="{{.Get "imageStyle"}}"/>
 		{{end}}
 		{{if .Get "title"}}
 		<center>


### PR DESCRIPTION
## Summary
- The `badge` shortcode's `<img>` tag never rendered an `alt` attribute, even on badge calls where authors had already tried to pass `alt="..."`. This was silently dropping alt text and was flagged by an SEO/accessibility audit.
- Fixed `tyk-docs/themes/tykio/layouts/shortcodes/badge.html` to output `alt="{{ .Get "alt" }}"` on the `<img>` tag.
- Added `alt="..."` to every badge call site across the branch that was missing it (logo/tech images for install options): `apim/open-source/installation.md`, `tyk-self-managed/install.md`, and `tyk-cloud.md`.
- Badges with `image=""` (no image, e.g. in `content.md`) were left untouched since no `<img>` is rendered for those.

## Test plan
- [ ] `grep -rn 'badge.*image=' tyk-docs/content/` confirms every non-empty `image=` badge call now has a matching `alt=` attribute.
- [ ] Build the Hugo site locally and inspect rendered `<img>` tags on `/apim/open-source/installation/`, `/tyk-self-managed/install/`, and `/tyk-cloud/` to confirm `alt` text is present and correct.
- [ ] Confirm `content.md`'s image-less badges render unchanged (no `alt` attribute needed since no image).