### PR TITLE
Add outdated-version banner to v5.7 pages

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -133,6 +133,8 @@
       <article class="page-content {{ if .Params.hideSidebar }}home-mobile-padding{{ end }}">
         <main class="page-content__main">
           <div class="wysiwyg page-content__container">
+            {{ partial "outdated_version_banner.html" . }}
+
             {{ if .Params.diffTitle }}
               {{ if .Params.diffTitleName }}
                 <h1>{{ .Params.diffTitleName }}</h1>

--- a/tyk-docs/themes/tykio/layouts/partials/outdated_version_banner.html
+++ b/tyk-docs/themes/tykio/layouts/partials/outdated_version_banner.html
@@ -1,0 +1,43 @@
+{{/*
+  This branch is a frozen, pre-Mintlify (< 5.8) documentation version - it no
+  longer receives new content, so unlike the Mintlify site there is no single
+  place that tracks "the current latest version" here. Rather than hardcode a
+  version number that would need manual upkeep on every future release, the
+  banner just says "the latest release" and links to it.
+
+  Reuses the same canonical-link resolution as the SEO canonical <link> tag in
+  baseof.html: canonical_map.json gives an exact per-page equivalent URL on the
+  current docs site where one has been mapped, falling back to stripping the
+  version segment from the permalink otherwise.
+*/}}
+{{- $latestLink := replace .Permalink .Site.BaseURL .Site.Params.CanonicalBaseUrl -}}
+{{- with index site.Data.canonical_map (strings.TrimPrefix "/docs/5.7/" .RelPermalink) -}}
+  {{- $latestLink = . -}}
+{{- end -}}
+<div
+  id="tyk-outdated-banner"
+  style="position:relative;background:#d97706;color:#fff;text-align:center;font-size:14px;line-height:1.5;padding:10px 44px;border-radius:8px;margin:0 0 20px 0;">
+  <span>
+    &#9888;&#65039; <strong>Outdated Version</strong> - This page refers to an older version of our
+    documentation. We recommend using the
+    <a href="{{ $latestLink }}" style="color:#fff;font-weight:600;text-decoration:underline;">latest release</a>
+    for the most up-to-date guidance.
+  </span>
+  <button
+    type="button"
+    aria-label="Dismiss banner"
+    onclick="document.getElementById('tyk-outdated-banner').style.display='none'; try { localStorage.setItem('tykOutdatedBannerDismissed', '1'); } catch (e) {}"
+    style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:#fff;font-size:16px;cursor:pointer;padding:4px;">
+    &#10007;
+  </button>
+</div>
+<script>
+  (function () {
+    try {
+      if (localStorage.getItem('tykOutdatedBannerDismissed') === '1') {
+        var el = document.getElementById('tyk-outdated-banner');
+        if (el) el.style.display = 'none';
+      }
+    } catch (e) {}
+  })();
+</script>


### PR DESCRIPTION
## Summary
Companion to the Mintlify outdated-version banner rework (tyk-docs, was #2554) - this branch (v5.7) predates the Mintlify migration and currently has no equivalent notice, so readers landing here have no obvious way back to current docs.

- New partial `themes/tykio/layouts/partials/outdated_version_banner.html`, included in `baseof.html` at the top of the content column (above the page `<h1>`, matching the Mintlify placement).
- Dismissible (persists via `localStorage`, plain button `onclick` + a tiny inline script - no build pipeline for JS on this frozen branch, so no separate `.js` file).
- Link target reuses the **existing** `canonical_map.json` / `CanonicalBaseUrl` resolution already used for the SEO canonical `<link>` tag in `baseof.html`: exact per-page mapping where one exists in `canonical_map.json`, falling back to stripping the version segment otherwise. So the banner links to the actual equivalent page on the current docs site, not just the docs homepage.

## Notes
- No version number in the copy ("the latest release", not "v5.14") - unlike the Mintlify side, this branch has no build-time mechanism to keep a version number current, and hardcoding one would silently go stale.
- Dismissal is permanent (no "reappears on next release" logic) - this branch's content is frozen, so there's no release event to key a reset off of, unlike the Mintlify widget.
- Verified locally with `hugo --minify -D`: banner renders correctly above the title, and the link resolves to the mapped URL (e.g. `/advanced-configuration/` → `https://tyk.io/docs/api-management/traffic-transformation`).

## Testing done
- Local Hugo build (`hugo --minify -D`) - confirmed banner markup renders on content pages with the correct resolved link.
- Not yet checked in a real browser - recommend a quick preview-deploy check before merging.