### PR TITLE
Fix outdated-version banner to stay pinned when a page loads at an anchor

### DIFF
--- a/tyk-docs/themes/tykio/layouts/_default/baseof.html
+++ b/tyk-docs/themes/tykio/layouts/_default/baseof.html
@@ -109,6 +109,8 @@
   </head>
 
   <body class="page-documentation {{ if not .Params.hideSidebar }}hasSidebar{{ end }}">
+    {{ partial "outdated_version_banner.html" . }}
+
     <!-- Google Tag Manager (noscript) -->
     <noscript
       ><iframe

--- a/tyk-docs/themes/tykio/layouts/partials/outdated_version_banner.html
+++ b/tyk-docs/themes/tykio/layouts/partials/outdated_version_banner.html
@@ -39,6 +39,11 @@
 <script>
   (function () {
     var DISMISS_KEY = 'tykOutdatedBannerDismissed';
+    // This branch never releases a new version to key dismissal against (see
+    // the comment above), so instead a dismissal simply expires after a
+    // fixed number of days and the banner reappears on its own.
+    var DISMISS_DAYS = 7;
+    var DISMISS_MS = DISMISS_DAYS * 24 * 60 * 60 * 1000;
     var banner = document.getElementById('tyk-outdated-banner');
     if (!banner) return;
 
@@ -53,12 +58,13 @@
       banner.style.display = 'none';
       document.body.style.paddingTop = '';
       try {
-        localStorage.setItem(DISMISS_KEY, '1');
+        localStorage.setItem(DISMISS_KEY, String(Date.now()));
       } catch (e) {}
     };
 
     try {
-      if (localStorage.getItem(DISMISS_KEY) === '1') {
+      var dismissedAt = parseInt(localStorage.getItem(DISMISS_KEY), 10);
+      if (dismissedAt && Date.now() - dismissedAt < DISMISS_MS) {
         banner.style.display = 'none';
         return;
       }

--- a/tyk-docs/themes/tykio/layouts/partials/outdated_version_banner.html
+++ b/tyk-docs/themes/tykio/layouts/partials/outdated_version_banner.html
@@ -1,0 +1,78 @@
+{{/*
+  This branch is a frozen, pre-Mintlify (< 5.8) documentation version - it no
+  longer receives new content, so unlike the Mintlify site there is no single
+  place that tracks "the current latest version" here. Rather than hardcode a
+  version number that would need manual upkeep on every future release, the
+  banner just says "the latest release" and links to it.
+
+  Reuses the same canonical-link resolution as the SEO canonical <link> tag in
+  baseof.html: canonical_map.json gives an exact per-page equivalent URL on the
+  current docs site where one has been mapped, falling back to stripping the
+  version segment from the permalink otherwise.
+
+  The banner is fixed to the viewport top rather than inserted into the page
+  content, so it stays visible regardless of scroll position - including when
+  a page loads scrolled straight to a heading anchor, which would otherwise
+  scroll straight past a banner embedded at the top of the content.
+*/}}
+{{- $latestLink := replace .Permalink .Site.BaseURL .Site.Params.CanonicalBaseUrl -}}
+{{- with index site.Data.canonical_map (strings.TrimPrefix "/docs/5.7/" .RelPermalink) -}}
+  {{- $latestLink = . -}}
+{{- end -}}
+<div
+  id="tyk-outdated-banner"
+  style="position:fixed;top:0;left:0;width:100%;z-index:500;box-sizing:border-box;background:#d97706;color:#fff;text-align:center;font-size:14px;line-height:1.5;padding:10px 44px;">
+  <span>
+    &#9888;&#65039; <strong>Outdated Version</strong> - This page refers to an older version of our
+    documentation. We recommend using the
+    <a href="{{ $latestLink }}" style="color:#fff;font-weight:600;text-decoration:underline;">latest release</a>
+    for the most up-to-date guidance.
+  </span>
+  <button
+    type="button"
+    aria-label="Dismiss banner"
+    onclick="window.tykDismissOutdatedBanner()"
+    style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:#fff;font-size:16px;cursor:pointer;padding:4px;">
+    &#10007;
+  </button>
+</div>
+<script>
+  (function () {
+    var DISMISS_KEY = 'tykOutdatedBannerDismissed';
+    var banner = document.getElementById('tyk-outdated-banner');
+    if (!banner) return;
+
+    // Nothing else on this frozen v5.7 layout is fixed/sticky, so pushing the
+    // whole page down by the banner's own height is enough to keep the
+    // header and sidebar from rendering underneath it.
+    function syncPadding() {
+      document.body.style.paddingTop = banner.offsetHeight + 'px';
+    }
+
+    window.tykDismissOutdatedBanner = function () {
+      banner.style.display = 'none';
+      document.body.style.paddingTop = '';
+      try {
+        localStorage.setItem(DISMISS_KEY, '1');
+      } catch (e) {}
+    };
+
+    try {
+      if (localStorage.getItem(DISMISS_KEY) === '1') {
+        banner.style.display = 'none';
+        return;
+      }
+    } catch (e) {}
+
+    syncPadding();
+
+    // The banner's text wraps onto more lines on narrower viewports, so its
+    // height - and the space reserved for it - needs to be recalculated on
+    // resize, not just once on load.
+    var resizeTimer;
+    window.addEventListener('resize', function () {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(syncPadding, 100);
+    });
+  })();
+</script>


### PR DESCRIPTION
## Summary
Supersedes #7220. Same partial/canonical-link approach, reworked for positioning to match the equivalent fix on the Mintlify side (tyk-docs#2648):

- The previous partial rendered the banner as the first element inside the content container (`page-content__container`), in normal document flow. Landing on a page via a heading anchor, or scrolling at all, would move the banner out of view - readers could easily never see it.
- The banner is now `position:fixed` to the viewport top, rendered at the very top of `<body>` (before the header partial) rather than inside the content container, so it stays visible regardless of scroll position or where the page lands on load.
- Nothing else in this layout is fixed or sticky (unlike the Mintlify site's navbar), so pushing the whole page down by the banner's own measured height via a small inline script is enough to keep the header and sidebar from rendering underneath it - no spacer-element trick needed.
- Height is re-measured on resize, since the banner's text wraps differently at different viewport widths.
- Everything else is unchanged from #7220: dismissal via localStorage, and the `canonical_map.json` based "latest release" link resolution (no version-number substitution needed - see the code comment on why).

## Test plan
- [x] Verified locally via `hugo server`
- [ ] Confirm the banner stays visible when loading a page directly at a heading anchor, e.g. `/docs/5.7/tyk-stack/#closed-source`
- [ ] Confirm the header/sidebar are not covered by the fixed banner
- [ ] Review/merge, then decide whether to close #7220 in favor of this